### PR TITLE
Recipe revisions

### DIFF
--- a/components/ListView/ListItemExpandRevisions.js
+++ b/components/ListView/ListItemExpandRevisions.js
@@ -124,7 +124,7 @@ class ListItemExpandRevisions extends React.Component {
                         </div>
                       )}
                     </div>
-                    <div className="cmpsr-summary-listview">
+                    <div className="cmpsr-summary-listview hidden">
                       <p><strong>Comments</strong></p>
                       <div className="input-group">
                         <input type="text" className="form-control" />

--- a/components/ListView/ListItemExpandRevisions.js
+++ b/components/ListView/ListItemExpandRevisions.js
@@ -2,6 +2,8 @@ import React, { PropTypes } from 'react';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';
 import ComponentSummaryList from '../../components/ListView/ComponentSummaryList';
 import ListItemLabel from '../../components/ListView/ListItemLabel';
+import Link from '../../components/Link';
+
 
 class ListItemExpandRevisions extends React.Component {
 
@@ -33,10 +35,11 @@ class ListItemExpandRevisions extends React.Component {
 
   render() {
     const { listItem } = this.props;
-    let dependencyCount = 0;
-    if (listItem.projects !== undefined) {
-      dependencyCount = listItem.projects.length;
-    }
+    const comments = this.props.comments.filter(obj => obj.revision == listItem.number);
+    const changelog = this.props.changelog.filter(obj => obj.revision == listItem.number);
+    const compositions = this.props.compositions.filter(obj => obj.revision == listItem.number);
+    console.log(comments);
+
     return (
 
             <div className={"list-group-item " + (this.state.expanded ? 'list-view-pf-expand-active' : '')}>
@@ -46,17 +49,18 @@ class ListItemExpandRevisions extends React.Component {
                 </div>
 
                 <div className="list-view-pf-actions">
+                  { listItem.active === true &&
+                  <Link to={"/edit/" + this.props.recipe } className="btn btn-default">Edit Recipe</Link>
+                  ||
+                  <button className="btn btn-default" type="button">Restore and Edit</button>
+                  }
+                  <button className="btn btn-default" id="cmpsr-btn-crt-compos" data-toggle="modal" data-target="#cmpsr-modal-crt-compos" type="button">Create Composition</button>
                   <div className="dropdown pull-right dropdown-kebab-pf">
                     <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight9" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true"><span className="fa fa-ellipsis-v"></span></button>
                     <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight9">
                       <li><a href="#">View Recipe</a></li>
-                      { listItem.active === "true" &&
-                      <li><a href="#">Edit Recipe</a></li>
-                      ||
-                      <li><a href="#">Restore and Edit</a></li>
-                      }
-                      { listItem.active === "true" &&
-                      <li><a href="#">Preserve Revision</a></li>
+                      { listItem.active === true &&
+                      <li><a href="#">Clone Revision</a></li>
                       ||
                       <li><a href="#">Restore Revision</a></li>
                       }
@@ -73,7 +77,7 @@ class ListItemExpandRevisions extends React.Component {
                   <div className="list-view-pf-body">
                     <div className="list-view-pf-description">
                       <div className="list-group-item-heading">
-                        <a href="#" data-item="name">Revision { listItem.number }{ listItem.active === "true" && <span>, Current Revision</span>}</a>
+                        <a href="#" data-item="name">Revision { listItem.number }</a>
                       </div>
                       <div className="list-group-item-text">
                         Based on { listItem.basedOn }
@@ -103,89 +107,69 @@ class ListItemExpandRevisions extends React.Component {
                   <div className="col-md-6">
                     <div className="cmpsr-summary-listview">
                       <p><strong>Compositions</strong> ({listItem.compositions})</p>
-                      { listItem.compositions !== "0" &&
-                      <div className="list-group list-view-pf list-view-pf-view cmpsr-list-view-viewskinny">
-                        <div className="list-group-item">
-                          <div className="list-view-pf-main-info">
-                            <div className="list-view-pf-left" data-item="type">
-                              <span className="pf pficon-image list-view-pf-icon-sm" aria-hidden="true"></span>
-                            </div>
-                            <div className="list-view-pf-body">
-                              <div className="list-view-pf-description">
-                                <a href="#">Composition 1 (iso)</a> <span className="text-muted">created 1/15/17, last exported 2/15/17</span>
+                      { compositions.map((composition, i) =>
+                        <div className="list-group list-view-pf list-view-pf-view cmpsr-list-view-viewskinny">
+                          <div className="list-group-item">
+                            <div className="list-view-pf-main-info">
+                              <div className="list-view-pf-left" data-item="type">
+                                <span className="pf pficon-image list-view-pf-icon-sm" aria-hidden="true"></span>
+                              </div>
+                              <div className="list-view-pf-body">
+                                <div className="list-view-pf-description">
+                                  <a href="#">Composition {composition.number} ({composition.type})</a> <span className="text-muted">created {composition.date_created}, last exported {composition.date_exported}</span>
+                                </div>
                               </div>
                             </div>
                           </div>
                         </div>
-
+                      )}
+                    </div>
+                    <div className="cmpsr-summary-listview">
+                      <p><strong>Comments</strong></p>
+                      <div className="input-group">
+                        <input type="text" className="form-control" />
+                        <span className="input-group-btn">
+                          <button className="btn btn-default" type="button">Post Comment</button>
+                        </span>
                       </div>
-                      }
+                      { comments.map((comment, i) =>
+                        <div className="list-group list-view-pf list-view-pf-view cmpsr-list-view-viewskinny">
+                          <div className="list-group-item">
+                            <div className="list-view-pf-main-info">
+                              <div className="list-view-pf-left" data-item="type">
+                                <span className="fa fa-comment-o list-view-pf-icon-sm" aria-hidden="true"></span>
+                              </div>
+                              <div className="list-view-pf-body">
+                                <div className="list-view-pf-description">
+                                  <p className="text-muted pull-right">{comment.user}, {comment.date}</p>
+                                  <p>{comment.comment}</p>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+
+                        </div>
+                      )}
                     </div>
                   </div>
 
                   <div className="col-md-6">
                     <div className="cmpsr-summary-listview">
                       <p><strong>Change Log</strong></p>
-                      <div className="list-group list-view-pf list-view-pf-view cmpsr-list-view-viewskinny">
-                        { listItem.compositions !== "0" &&
-                        <div className="list-group-item">
-                          <div className="list-view-pf-main-info">
+                      { changelog.map((change, i) =>
+                        <div className="list-group list-view-pf list-view-pf-view cmpsr-list-view-viewskinny">
+                          <div className="list-group-item">
+                            <div className="list-view-pf-main-info">
                             <div className="list-view-pf-body">
                               <div className="list-view-pf-description">
-                                <a href="#">Composition exported</a> <span className="text-muted">2/15/17 by Brian Johnson</span>
+                                <a href="#">{change.action}</a> <span className="text-muted">{change.date} by {change.user}</span>
                               </div>
                             </div>
-                          </div>
-                        </div>
-                        }
-                        { listItem.compositions !== "0" &&
-                        <div className="list-group-item">
-                          <div className="list-view-pf-main-info">
-                            <div className="list-view-pf-body">
-                              <div className="list-view-pf-description">
-                                <a href="#">Composition created</a> <span className="text-muted">1/15/17 by Brian Johnson</span>
-                              </div>
                             </div>
                           </div>
+
                         </div>
-                        }
-                        <div className="list-group-item">
-                          <div className="list-view-pf-main-info">
-                            <div className="list-view-pf-body">
-                              <div className="list-view-pf-description">
-                                <a href="#">Recipe modified</a> <span className="text-muted">12/15/16 by Brian Johnson</span>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="list-group-item">
-                          <div className="list-view-pf-main-info">
-                            <div className="list-view-pf-body">
-                              <div className="list-view-pf-description">
-                                <a href="#">Revision created</a> <span className="text-muted">12/15/16 by Brian Johnson</span>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="list-group-item hidden">
-                          <div className="list-view-pf-main-info">
-                            <div className="list-view-pf-body">
-                              <div className="list-view-pf-description">
-                                <a href="#" data-item="name">1 component added, 2 components removed by Brian Johnson</a>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="list-group-item hidden">
-                          <div className="list-view-pf-main-info">
-                            <div className="list-view-pf-body">
-                              <div className="list-view-pf-description">
-                                <a href="#" data-item="name">4 components added by swilliams</a>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
+                      )}
                     </div>
                   </div>
 

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -209,16 +209,6 @@ class RecipePage extends React.Component {
             <div className="row toolbar-pf">
               <div className="col-sm-12">
                 <form className="toolbar-pf-actions">
-                  <div className="form-group">
-                    <div className="dropdown btn-group">
-                      <button type="button" className="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Revision 3<span className="caret"></span></button>
-                      <ul className="dropdown-menu">
-                        <li><a href="#">Revision 3</a></li>
-                        <li><a href="#">Revision 2</a></li>
-                        <li><a href="#">Revision 1</a></li>
-                      </ul>
-                    </div>
-                  </div>
                   <div className="toolbar-pf-action-right">
                     <div className="form-group">
                     <Link to={"/edit/" + this.props.route.params.recipe } className="btn btn-default">Edit Recipe</Link>

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -18,20 +18,140 @@ class RecipePage extends React.Component {
   state = { recipe: {}, components: [], dependencies: [], activeTab: "Components", selectedComponent: "", selectedComponentStatus: "view", selectedComponentParent: "",
     revisions: [
       {
+        "number" : "3",
+        "basedOn" : "Revision 2",
+        "components" : "8",
+        "compositions" : "1",
+        "size" : "2,678 KB",
+        "active": true
+      },
+      {
         "number" : "2",
         "basedOn" : "Revision 1",
-        "components" : "3",
+        "components" : "5",
         "compositions" : "1",
         "size" : "2,345 KB",
-        "active": "true"
+        "active": false
       },
       {
         "number" : "1",
         "basedOn" : "New recipe",
-        "components" : "2",
+        "components" : "3",
         "compositions" : "0",
-        "size" : "2,345 KB",
-        "active": "false"
+        "size" : "1,234 KB",
+        "active": false
+      }
+    ],
+    comments: [
+      {
+        "date" : "2/04/17",
+        "user" : "Brian Johnson",
+        "revision" : "3",
+        "comment" : "Including components to support php."
+      },
+      {
+        "date" : "1/17/17",
+        "user" : "Brian Johnson",
+        "revision" : "2",
+        "comment" : "Early test results are good, but new requirements include php support."
+      },
+      {
+        "date" : "1/17/17",
+        "user" : "Brian Johnson",
+        "revision" : "2",
+        "comment" : "NOT PRODUCTION READY - only creating a composition to do early testing."
+      },
+      {
+        "date" : "1/06/17",
+        "user" : "Brian Johnson",
+        "revision" : "1",
+        "comment" : "Saving this first revision just to capture minimal requirements for comparison against future revisions"
+      }
+    ],
+    compositions: [
+      {
+        "date_created" : "2/06/17",
+        "date_exported" : "2/06/17",
+        "user" : "Brian Johnson",
+        "number" : "2",
+        "type" : "iso",
+        "revision" : "3"
+      },
+      {
+        "date_created" : "1/17/17",
+        "date_exported" : "1/17/17",
+        "user" : "Brian Johnson",
+        "number" : "1",
+        "type" : "iso",
+        "revision" : "2"
+      }
+    ],
+    changelog: [
+      {
+        "revision" : "3",
+        "action" : "Composition exported",
+        "date" : "2/06/07",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "3",
+        "action" : "Composition created",
+        "date" : "2/06/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "3",
+        "action" : "Recipe modified",
+        "date" : "2/06/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "3",
+        "action" : "Recipe modified",
+        "date" : "2/04/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "3",
+        "action" : "Revision created",
+        "date" : "2/04/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "2",
+        "action" : "Composition exported",
+        "date" : "1/17/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "2",
+        "action" : "Composition created",
+        "date" : "1/17/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "2",
+        "action" : "Recipe modified",
+        "date" : "1/12/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "2",
+        "action" : "Revision created",
+        "date" : "1/06/17",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "1",
+        "action" : "Recipe modified",
+        "date" : "12/15/16",
+        "user" : "Brian Johnson"
+      },
+      {
+        "revision" : "1",
+        "action" : "Revision created",
+        "date" : "12/15/16",
+        "user" : "Brian Johnson"
       }
     ]
   };
@@ -71,13 +191,19 @@ class RecipePage extends React.Component {
   };
 
   render() {
+    const activeRevision = this.state.revisions.filter(function(obj) {
+      return obj.active == true;
+    })[0];
+    const pastRevisions = this.state.revisions.filter(function(obj) {
+      return obj.active == false;
+    });
     return (
       <Layout className="container-fluid container-pf-nav-pf-vertical">
 
 				<ol className="breadcrumb"><li><Link to="/recipes">Back to Recipes</Link></li><li className="active"><strong>{ this.props.route.params.recipe }</strong></li></ol>
-
-				<h1>{ this.props.route.params.recipe }</h1>
-
+        <div className="cmpsr-title-summary">
+          <h1 className="cmpsr-title-summary__item">{ this.props.route.params.recipe }</h1><p className="cmpsr-title-summary__item">Current Revision: 3<span className="text-muted">, {this.state.recipe.description}</span></p>
+        </div>
         <Tabs key="pf-tabs" ref="pfTabs" tabChanged={this.handleTabChanged.bind(this)}>
           <Tab tabTitle="Details" active={this.state.activeTab == 'Details'}>
             <div className="row toolbar-pf">
@@ -85,8 +211,9 @@ class RecipePage extends React.Component {
                 <form className="toolbar-pf-actions">
                   <div className="form-group">
                     <div className="dropdown btn-group">
-                      <button type="button" className="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Revision 2<span className="caret"></span></button>
+                      <button type="button" className="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Revision 3<span className="caret"></span></button>
                       <ul className="dropdown-menu">
+                        <li><a href="#">Revision 3</a></li>
                         <li><a href="#">Revision 2</a></li>
                         <li><a href="#">Revision 1</a></li>
                       </ul>
@@ -130,19 +257,52 @@ class RecipePage extends React.Component {
                 </div>
               </div>
             </div>
-            <div className="tab-container">
-              <dl className="dl-horizontal mt-">
-                <dt>Name</dt>
-                <dd>{this.state.recipe.name}</dd>
-                <dt>Description</dt>
-                <dd>{this.state.recipe.description}</dd>
-                <dt>Revision</dt>
-                <dd>3</dd>
-                <dt>Last modified by</dt>
-                <dd>Brian Johnson</dd>
-                <dt>Last modified date</dt>
-                <dd>01/12/17</dd>
-              </dl>
+            <div className="tab-container row">
+              <div className="col-md-6">
+                <dl className="dl-horizontal mt-">
+                  <dt>Name</dt>
+                  <dd>{this.state.recipe.name}</dd>
+                  <dt>Description</dt>
+                  <dd>{this.state.recipe.description}</dd>
+                  <dt>Revision</dt>
+                  <dd>3</dd>
+                  <dt>Install size</dt>
+                  <dd>2,678 KB</dd>
+                  <dt>Last modified by</dt>
+                  <dd>Brian Johnson</dd>
+                  <dt>Last modified date</dt>
+                  <dd>01/12/17</dd>
+                </dl>
+              </div>
+              <div className="col-md-6">
+                <div className="cmpsr-summary-listview">
+                  <p><strong>Comments</strong></p>
+                  <div className="input-group">
+                    <input type="text" className="form-control" />
+                    <span className="input-group-btn">
+                      <button className="btn btn-default" type="button">Post Comment</button>
+                    </span>
+                  </div>
+                  { this.state.comments.map((comment, i) =>
+                    <div className="list-group list-view-pf list-view-pf-view cmpsr-list-view-viewskinny">
+                      <div className="list-group-item">
+                        <div className="list-view-pf-main-info">
+                          <div className="list-view-pf-left" data-item="type">
+                            <span className="fa fa-comment-o list-view-pf-icon-sm" aria-hidden="true"></span>
+                          </div>
+                          <div className="list-view-pf-body">
+                            <div className="list-view-pf-description">
+                              <p className="text-muted pull-right">&nbsp;&nbsp;{comment.user}, Revision {comment.revision}, {comment.date}</p>
+                              <p>{comment.comment}</p>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           </Tab>
           <Tab tabTitle="Components" active={this.state.activeTab == 'Components'}>
@@ -154,8 +314,9 @@ class RecipePage extends React.Component {
                   <form className="toolbar-pf-actions">
                     <div className="form-group">
                       <div className="dropdown btn-group">
-                        <button type="button" className="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Revision 2<span className="caret"></span></button>
+                        <button type="button" className="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Revision 3<span className="caret"></span></button>
                         <ul className="dropdown-menu">
+                          <li><a href="#">Revision 3</a></li>
                           <li><a href="#">Revision 2</a></li>
                           <li><a href="#">Revision 1</a></li>
                         </ul>
@@ -251,8 +412,6 @@ class RecipePage extends React.Component {
                 <form className="toolbar-pf-actions">
                   <div className="toolbar-pf-action-right">
                     <div className="form-group">
-                    <Link to={"/edit/" + this.props.route.params.recipe } className="btn btn-default">Edit Recipe</Link>
-                      <button className="btn btn-default" id="cmpsr-btn-crt-compos" data-toggle="modal" data-target="#cmpsr-modal-crt-compos" type="button">Create Composition</button>
                       <div className="dropdown btn-group  dropdown-kebab-pf">
                         <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span className="fa fa-ellipsis-v"></span></button>
                         <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
@@ -288,8 +447,31 @@ class RecipePage extends React.Component {
               </div>
             </div>
             <ListViewExpand id="cmpsr-recipe-revisions" >
-              {this.state.revisions .map((revision, i) =>
-                <ListItemExpandRevisions listItemParent="cmpsr-recipe-revisions" listItem={revision} key={i} />
+              <div className="list-group-item list-group-item__separator">
+                <div className="list-view-pf-main-info">
+                  <div className="list-view-pf-body">
+                    <div className="list-view-pf-description">
+                      <div className="list-group-item-heading">
+                        Current Revision
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <ListItemExpandRevisions listItemParent="cmpsr-recipe-revisions" recipe={ this.props.route.params.recipe } comments={this.state.comments} changelog={this.state.changelog} compositions={this.state.compositions} listItem={activeRevision}/>
+              <div className="list-group-item list-group-item__separator">
+                <div className="list-view-pf-main-info">
+                  <div className="list-view-pf-body">
+                    <div className="list-view-pf-description">
+                      <div className="list-group-item-heading">
+                        Past Revisions
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              {pastRevisions.map((revision, i) =>
+                <ListItemExpandRevisions listItemParent="cmpsr-recipe-revisions" recipe={ this.props.route.params.recipe } comments={this.state.comments} changelog={this.state.changelog} compositions={this.state.compositions} listItem={revision} key={i} />
               )}
             </ListViewExpand>
 

--- a/public/custom.css
+++ b/public/custom.css
@@ -210,3 +210,14 @@
 #cmpsr-recipe-details {
   padding: 10px 35px;
 }
+
+
+/* Recipe details page */
+
+.list-view-pf .list-group-item__separator, .list-view-pf .list-group-item__separator:hover {
+  background-color: #f7f7f7;
+}
+.list-view-pf .list-group-item__separator .list-view-pf-main-info {
+  padding-top: 0;
+  padding-bottom: 0;
+}


### PR DESCRIPTION
https://trello.com/c/ELJLX8Fg/183-3-comments-and-revisions-rough-draft-ui-design

Updates include draft UI for the following:
- ability to capture comments about the recipe. I should be able to see these comments on the Details tab only
	- showing comments per Revision on the Revisions tab is deferred until it becomes a known requirement
	- this update also includes removing the ability to toggle to a different revision on the Details tab. This feature will only be available on the Components tab. And information for different revisions will be available on the Revisions tab
- visual differentiation between current revision and past revisions
- visible actions per revision for editing the recipe and creating the composition