### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "6"
+cache:
+  directories:
+  - node_modules # NPM packages
+before_install:
+  - npm install
+  - node run build
+env:
+  - COMMAND=lint
+  - COMMAND=test
+script:
+  - npm run "$COMMAND"
+notifications:
+  email:
+    on_failure: change
+    on_success: change

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Patternfly React Starter
 
+[![Build Status](https://travis-ci.org/weldr/welder-web.svg?branch=master)](https://travis-ci.org/weldr/welder-web)
+
 A Patternfly + React starter kit based on [**React Static Boilerplate**](https://github.com/kriasoft/react-static-boilerplate).
 
 **Demo**: https://patternfly-react-starter.firebaseapp.com/ &nbsp;|&nbsp; **View** [docs](./docs) &nbsp;|&nbsp; **Follow us** on


### PR DESCRIPTION
This PR adds Travis CI configuration and uses caching to speed up the build process.

It splits the tests into 2 commands, one for lint and another for tests b/c lint currently fails. An example of how this looks can be seen here:
https://travis-ci.org/atodorov/welder-web/builds/211315919

NOTE: somebody with the appropriate ORG permissions needs to enable building for this repo in Travis CI web interface.