### PR TITLE
Pagination

### DIFF
--- a/components/Pagination/Pagination.js
+++ b/components/Pagination/Pagination.js
@@ -76,6 +76,50 @@ class Pagination extends React.Component {
         />
       );
     }
+    let previousPage = null;
+    if (currentPage === 0) {
+      previousPage = (
+        <li className="disabled">
+          <a>
+            <span className="i fa fa-angle-left"></span>
+          </a>
+        </li>
+      );
+    } else {
+      previousPage = (
+        <li>
+          <a
+            href="#"
+            data-page={currentPage - 1}
+            onClick={(e) => this.props.handlePagination(e)}
+          >
+            <span className="i fa fa-angle-left"></span>
+          </a>
+        </li>
+      );
+    }
+    let nextPage = null;
+    if (currentPage === totalPages) {
+      nextPage = (
+        <li className="disabled">
+          <a>
+            <span className="i fa fa-angle-right"></span>
+          </a>
+        </li>
+      );
+    } else {
+      nextPage = (
+        <li>
+          <a
+            href="#"
+            data-page={currentPage + 1}
+            onClick={(e) => this.props.handlePagination(e)}
+          >
+            <span className="i fa fa-angle-right"></span>
+          </a>
+        </li>
+      );
+    }
 
     return (
       <div className={`${cssClass}  content-view-pf-pagination`}>
@@ -86,30 +130,13 @@ class Pagination extends React.Component {
             {currentPage === totalPages && totalItems || (currentPage + 1) * pageSize}
           </span> of {totalItems}
         </span>
-
         <ul className="pagination pagination-pf-back">
-          <li className={currentPage === 0 && 'disabled'}>
-            <a
-              href="#"
-              data-page={currentPage === 0 && '0' || currentPage - 1}
-              onClick={(e) => this.props.handlePagination(e)}
-            >
-              <span className="i fa fa-angle-left"></span>
-            </a>
-          </li>
+          {previousPage}
         </ul>
         {pageInput}
         <span>of <span className="pagination-pf-pages">{totalPages + 1}</span></span>
         <ul className="pagination pagination-pf-forward">
-          <li className={currentPage === totalPages && 'disabled'}>
-            <a
-              href="#"
-              data-page={currentPage === totalPages && totalPages || currentPage + 1}
-              onClick={(e) => this.props.handlePagination(e)}
-            >
-              <span className="i fa fa-angle-right"></span>
-            </a>
-          </li>
+          {nextPage}
         </ul>
       </div>
     );

--- a/components/Pagination/Pagination.js
+++ b/components/Pagination/Pagination.js
@@ -1,0 +1,127 @@
+import React from 'react';
+
+class Pagination extends React.Component {
+
+  state = { pageValue: '' }
+
+  componentWillMount() {
+    this.setState({ pageValue: this.props.currentPage });
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.setState({ pageValue: newProps.currentPage });
+    // If the input has focus when the page value is updated, then select the
+    // text
+    if (this.refs.paginationPage === document.activeElement) {
+      this.refs.paginationPage.select();
+    }
+  }
+
+  handleBlur = (event) => {
+    // if the user exits the field when the value != the current page
+    // then reset the page value
+    // if (this.state.pageValue !== this.props.currentPage) {
+      this.setState({ pageValue: this.props.currentPage });
+    // }
+  }
+
+  handleChange = (event) => {
+    // check if value is a number, if not or if <= 0, then set to ''
+    let page;
+    if (!isNaN(event.target.value) && event.target.value > 0) {
+      page = event.target.value - 1;
+    } else {
+      page = '';
+    }
+    // only update the value if the value is within the range or is '' (in case
+    // the user is clearing the value to type a new one)
+    if (!(page > Math.ceil((this.props.totalItems / this.props.pageSize) - 1)) || page === '') {
+      this.setState({ pageValue: page });
+    } else {
+      event.target.select();
+    }
+  }
+  // current page and total pages start count at 0. Anywhere these values
+  // display in the UI, then + 1 must be included.
+
+  render() {
+    const { cssClass, currentPage, totalItems, pageSize } = this.props;
+    const totalPages = Math.ceil((totalItems / pageSize) - 1);
+    let pageInput = null;
+    if (this.state.pageValue !== '') {
+      pageInput = (
+        <input
+          className="pagination-pf-page"
+          ref="paginationPage"
+          type="text" value={this.state.pageValue + 1}
+          id="cmpsr-recipe-inputs-page"
+          aria-label="Current Page"
+          onClick={() => { this.refs.paginationPage.select(); }}
+          onChange={this.handleChange}
+          onKeyPress={(e) => this.props.handlePagination(e)}
+          onBlur={this.handleBlur}
+        />
+      );
+    } else {
+      pageInput = (
+        <input
+          className="pagination-pf-page"
+          ref="paginationPage"
+          type="text" value=""
+          id="cmpsr-recipe-inputs-page"
+          aria-label="Current Page"
+          onClick={() => { this.refs.paginationPage.select(); }}
+          onChange={this.handleChange}
+          onBlur={this.handleBlur}
+        />
+      );
+    }
+
+    return (
+      <div className={`${cssClass}  content-view-pf-pagination`}>
+        <span>
+          <span className="pagination-pf-items-current">
+            {(currentPage + 1) * pageSize - pageSize + 1}
+            <span> - </span>
+            {currentPage === totalPages && totalItems || (currentPage + 1) * pageSize}
+          </span> of {totalItems}
+        </span>
+
+        <ul className="pagination pagination-pf-back">
+          <li className={currentPage === 0 && 'disabled'}>
+            <a
+              href="#"
+              data-page={currentPage === 0 && '0' || currentPage - 1}
+              onClick={(e) => this.props.handlePagination(e)}
+            >
+              <span className="i fa fa-angle-left"></span>
+            </a>
+          </li>
+        </ul>
+        {pageInput}
+        <span>of <span className="pagination-pf-pages">{totalPages + 1}</span></span>
+        <ul className="pagination pagination-pf-forward">
+          <li className={currentPage === totalPages && 'disabled'}>
+            <a
+              href="#"
+              data-page={currentPage === totalPages && totalPages || currentPage + 1}
+              onClick={(e) => this.props.handlePagination(e)}
+            >
+              <span className="i fa fa-angle-right"></span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    );
+  }
+}
+
+Pagination.propTypes = {
+  currentPage: React.PropTypes.number,
+  cssClass: React.PropTypes.string,
+  totalItems: React.PropTypes.number,
+  pageSize: React.PropTypes.number,
+  handlePagination: React.PropTypes.func,
+};
+
+export default Pagination;

--- a/components/Pagination/Pagination.js
+++ b/components/Pagination/Pagination.js
@@ -17,12 +17,10 @@ class Pagination extends React.Component {
     }
   }
 
-  handleBlur = (event) => {
+  handleBlur = () => {
     // if the user exits the field when the value != the current page
     // then reset the page value
-    // if (this.state.pageValue !== this.props.currentPage) {
-      this.setState({ pageValue: this.props.currentPage });
-    // }
+    this.setState({ pageValue: this.props.currentPage });
   }
 
   handleChange = (event) => {

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -114,10 +114,10 @@ class EditRecipePage extends React.Component {
         for (let i = 1; i <= totalPages; i++) {
           inputs.push([]);
         }
-        this.setState({filteredComponents : inputs});
-        this.setState({inputFilters : filter});
-        this.setState({selectedInputPage : 0});
+        this.setState({selectedInputPage: 0});
         this.setState({totalFilteredInputs: data[0][1]});
+        this.setState({filteredComponents: inputs});
+        this.setState({inputFilters: filter});
       }).catch(e => console.log('Failed to filter inputs during recipe edit: ' + e));
       // TODO handle the case where no results are returned
       $('#cmpsr-recipe-input-filter').blur();
@@ -126,10 +126,10 @@ class EditRecipePage extends React.Component {
   }
 
   handleClearFilters() {
-    this.setState({selectedInputPage : 0});
-    this.setState({lastFilteredPage: ''});
-    this.setState({filteredComponents : []});
-    this.setState({inputFilters : []});
+    this.setState({selectedInputPage: 0});
+    this.setState({totalFilteredInputs: 0});
+    this.setState({filteredComponents: []});
+    this.setState({inputFilters: []});
     $('#cmpsr-recipe-input-filter').val('');
   }
 
@@ -137,6 +137,7 @@ class EditRecipePage extends React.Component {
     // the event target knows what page to get
     // the event target can either be the paging buttons on the page input
     let page;
+
     if (event.currentTarget.localName === "a") {
       page = parseFloat(event.currentTarget.getAttribute("data-page"));
     } else {
@@ -149,7 +150,7 @@ class EditRecipePage extends React.Component {
     }
     // if the data already exists, just update the selected page number and
     // the DOM will automatically reload
-    this.setState({selectedInputPage : page});
+    this.setState({selectedInputPage: page});
     let currentInputs = []
     let filter = ''
     // check if filters are set to determine current input set
@@ -166,10 +167,10 @@ class EditRecipePage extends React.Component {
         currentInputs[0][page] = inputs;
         switch (currentInputs[1]) {
           case 'inputComponents':
-            this.setState({inputComponents : currentInputs[0]});
+            this.setState({inputComponents: currentInputs[0]});
             break;
           case 'filteredComponents':
-            this.setState({filteredComponents : currentInputs[0]});
+            this.setState({filteredComponents: currentInputs[0]});
             break;
         }
       }).catch(e => console.log('Failed to load requested page of available components: ' + e));

--- a/public/custom.css
+++ b/public/custom.css
@@ -33,6 +33,25 @@
   padding-left: 0;
 }
 
+/* pagination */
+
+.toolbar-pf-results .content-view-pf-pagination {
+  margin-bottom: 5px;
+  margin-top: 5px;
+  background-color: transparent;
+  border: none;
+  justify-content: flex-end;
+  align-items: baseline;
+}
+.toolbar-pf-results .pagination {
+  align-self: center;
+}
+
+.toolbar-pf-results .pagination-pf-page,
+.toolbar-pf-results .pagination.pagination-pf-forward {
+  margin-left: 5px;
+}
+
 /* sidebar toolbar */
 .toolbar-pf-actions {min-height: 28px;}
 .sidebar-pf .toolbar-pf-actions .toolbar-pf-filter {width:auto;}
@@ -99,17 +118,6 @@
 #cmpsr-recipe-inputs .toolbar-pf-results p,
 #cmpsr-recipe-inputs .toolbar-pf-results ul {
   line-height:26.67px;
-}
-
-
-.cmpsr-recipe-inputs-pagination {
-  margin-bottom: 5px;
-  margin-top: 5px;
-}
-.cmpsr-recipe-inputs-pagination .pagination {
-  float: right;
-  margin-bottom: 5px;
-  vertical-align: bottom;
 }
 
 .toolbar-pf-results .list-inline {


### PR DESCRIPTION
This update includes a pagination control above the list of available inputs.

The three main elements of this control are:

- previous page button - Disabled if the current page is the first page. Allows the user to navigate to the previous page.
- next page button - Disabled if the current page is the first page. Allows the user to navigate to the previous page.
- page input - Allows the user to specify a page to navigate to. Does not accept a value other than empty or a number within the page range. If the user changes the value then exits the field without submitting, the value resets to match the current visible page.

These controls make updates to how inputs are set in state. The state is now an array of arrays, with each array being the set of items in that page.

These controls also work with filters. The list of all available inputs is maintained, whereas filtered inputs are cleared when the filter is cleared. This might be something we want to review later to see if it affects performance.