### PR TITLE
When running the API behind a proxy it needs to use relative URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD nginx -g "daemon off;"
 EXPOSE 3000
 
 ## Do the things more likely to change below here. ##

--- a/core/utils.js
+++ b/core/utils.js
@@ -38,6 +38,11 @@ function cockpitFetch(url, options, skipDecode) {
 }
 
 function createUrl(url) {
+  // API is hosted on the same URL as the UI
+  if (welderApiRelative == true) {
+      return url;
+  }
+
   const parser = document.createElement('a');
   parser.href = url;
   parser.scheme = welderApiScheme;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,29 @@
 
 export API_URL=${API_URL:-}
 
-# Rewrite config.json to point to the API URL
-cd /welder/
-sed -i "s,var welderApiHost=.*,var welderApiHost=\"$API_URL\";," ./public/js/config.js
+# Rewrite config.json to use relative URLs for the API requests
+cd /welder/ || exit 1
+if [ -z "$API_URL" ]; then
+    sed -i "s,var welderApiRelative=.*,var welderApiRelative=true;," ./public/js/config.js
+else
+    # Split the API url into scheme host port (ALL MUST BE PRESENT)
+    SCHEME=${API_URL%%://*}
+    NO_SCHEME=${API_URL##$SCHEME://}
+    HOST=${NO_SCHEME%%:*}
+    P1=${NO_SCHEME##*:}
+    PORT=${P1%%/}
 
-# Launch welder-web using nginx
-nginx -g "daemon off;"
+    if [ -z "$SCHEME" ] || [ -z "$HOST" ] || [ -z "$PORT" ]; then
+        echo "ERROR PARSING API_URL=$API_URL";
+        exit 1;
+    fi
+
+    sed -i "s,var welderApiScheme=.*,var welderApiScheme=$SCHEME;," ./public/js/config.js
+    sed -i "s,var welderApiHost=.*,var welderApiHost=\"$HOST\";," ./public/js/config.js
+    sed -i "s,var welderApiPort=.*,var welderApiPort=$PORT;," ./public/js/config.js
+fi
+echo "Running with config.js settings:"
+cat ./public/js/config.js
+
+# Execute the CMD
+exec "$@"

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,3 +1,4 @@
 var welderApiHost="localhost";
 var welderApiPort=4000;
 var welderApiScheme="http";
+var welderApiRelative=false;


### PR DESCRIPTION
Add a switch to make createUrl just return the url, not add the scheme,
host or port.

Split the API_URL into component pieces for new config.js, ALL parts
must be present when setting it.

This also displays the modified config.js when starting.

Startup of nginx has been moved to CMD in the Dockerfile so that you can
start up the container without overriding entrypoint. Just pass
/usr/bin/bash to run bash instead of nginx