### PR TITLE
fixing a bug related to pagination

### DIFF
--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -147,15 +147,15 @@ class EditRecipePage extends React.Component {
     // the event target can either be the paging buttons on the page input
     let page;
 
-    event.preventDefault();
-    event.stopPropagation();
-
     if (event.currentTarget.localName === "a") {
       page = parseFloat(event.currentTarget.getAttribute("data-page"));
+      event.preventDefault();
+      event.stopPropagation();
     } else {
       if (event.which === 13 || event.keyCode === 13) {
         page = parseFloat(event.currentTarget.value) - 1;
         event.preventDefault();
+        event.stopPropagation();
       } else {
         return; // don't continue if keypress was not the Enter key
       }


### PR DESCRIPTION
When preventDefault and stopPropagation were
added to the pagination, they prevented the default
behavior of entering a new value in the input field.
I moved these to only the cases where the user is
hitting the enter key when the input has focus or
using the pagination buttons, but not when hitting
any other key (e.g. like "9" to navigate to page 9).