### PR TITLE
UI refinements related to creating/viewing recipes

### DIFF
--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -5,48 +5,48 @@ import CreateComposition from '../../components/Modal/CreateComposition';
 class RecipeListView extends React.Component {
   state = { recipe: '' };
 
-  componentDidMount() {
-    this.bindExpand();
-  }
+  // componentDidMount() {
+  //   this.bindExpand();
+  // }
+  //
+  // componentDidUpdate() {
+  //   this.unbind();
+  //   this.bindExpand();
+  // }
+  //
+  // componentWillUnmount() {
+  //   this.unbind();
+  // }
 
-  componentDidUpdate() {
-    this.unbind();
-    this.bindExpand();
-  }
-
-  componentWillUnmount() {
-    this.unbind();
-  }
-
-  bindExpand() {
-    // click the list-view heading then expand a row
-    $('.list-group-item-header').click(function (event) {
-      if (!$(event.target).is('button, a, input, .fa-ellipsis-v')) {
-        $(this).find('.fa-angle-right')
-          .toggleClass('fa-angle-down')
-          .end()
-          .parent()
-          .toggleClass('list-view-pf-expand-active')
-          .find('.list-group-item-container')
-          .toggleClass('hidden');
-      }
-    });
-
-    // click the close button, hide the expand row and remove the active status
-    $('.list-group-item-container .close').on('click', function () {
-      $(this).parent()
-        .addClass('hidden')
-        .parent()
-        .removeClass('list-view-pf-expand-active')
-        .find('.fa-angle-right')
-        .removeClass('fa-angle-down');
-    });
-  }
-
-  unbind() {
-    $('.list-group-item-header').off('click');
-    $('.list-group-item-container .close').off('click');
-  }
+  // bindExpand() {
+  //   // click the list-view heading then expand a row
+  //   $('.list-group-item-header').click(function (event) {
+  //     if (!$(event.target).is('button, a, input, .fa-ellipsis-v')) {
+  //       $(this).find('.fa-angle-right')
+  //         .toggleClass('fa-angle-down')
+  //         .end()
+  //         .parent()
+  //         .toggleClass('list-view-pf-expand-active')
+  //         .find('.list-group-item-container')
+  //         .toggleClass('hidden');
+  //     }
+  //   });
+  //
+  //   // click the close button, hide the expand row and remove the active status
+  //   $('.list-group-item-container .close').on('click', function () {
+  //     $(this).parent()
+  //       .addClass('hidden')
+  //       .parent()
+  //       .removeClass('list-view-pf-expand-active')
+  //       .find('.fa-angle-right')
+  //       .removeClass('fa-angle-down');
+  //   });
+  // }
+  //
+  // unbind() {
+  //   $('.list-group-item-header').off('click');
+  //   $('.list-group-item-container .close').off('click');
+  // }
 
   handleCreateCompos = (recipe) => {
     this.setState({ recipe });
@@ -63,7 +63,7 @@ class RecipeListView extends React.Component {
         {recipes.map((recipe, i) =>
           <div className="list-group-item" key={i}>
             <div className="list-group-item-header">
-              <div className="list-view-pf-expand">
+              <div className="list-view-pf-expand hidden">
                 <span className="fa fa-angle-right"></span>
               </div>
               <div className="list-view-pf-checkbox">
@@ -114,19 +114,19 @@ class RecipeListView extends React.Component {
                     <div
                       className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked"
                     >
-                      Version<strong>1</strong>
+                      Revision<strong>{recipe.version ? recipe.version : '0.0.0'}</strong>
                     </div>
                     <div
-                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked"
+                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
                     >
                       Test<strong>2</strong></div>
                     <div
-                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked"
+                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
                     >
                       Development<strong>0</strong>
                     </div>
                     <div
-                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked"
+                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
                     >
                       Production<strong>1</strong>
                     </div>

--- a/components/Modal/CreateRecipe.js
+++ b/components/Modal/CreateRecipe.js
@@ -4,7 +4,7 @@ import RecipeApi from '../../data/RecipeApi';
 
 class CreateRecipe extends React.Component {
 
-  state = { showErrorName: false, inlineError: false,
+  state = { showErrorName: false, inlineError: false, checkErrors: true,
     recipe: {
       name: '',
       description: '',
@@ -48,32 +48,35 @@ class CreateRecipe extends React.Component {
         this.setState({ showErrorName: true });
         this.showInlineError();
       } else {
+        $('#cmpsr-modal-crt-compos').modal('hide');
         RecipeApi.handleCreateRecipe(event, this.state.recipe);
       }
     }
   }
 
-  handleErrorName(event) {
-    if (this.state.recipe.name === '') {
-      setTimeout(() => {
-        this.setState({ showErrorName: true });
-      }, 200); // don't change state immediately so that user has time to finish clicking Save,
-               // if that's how onBlur is triggered
-    }
+  errorChecking(state) {
+    this.setState({checkErrors: state});
   }
 
-  showNameError() {
-    this.setState({ showErrorName: true });
+  dismissErrors(e) {
+    this.setState({ inlineError: false });
+    this.setState({ showErrorName: false });
+  }
+
+  handleErrorName(event) {
+    if (this.state.recipe.name === '' && this.state.checkErrors) {
+      setTimeout(() => {
+        this.setState({ showErrorName: true });
+      }, 400); // don't change state immediately so that user has time to finish clicking Save,
+               // if that's how onBlur is triggered
+    }
   }
 
   showInlineError() {
     this.setState({ inlineError: true });
   }
 
-  dismissErrors() {
-    this.setState({ inlineError: false });
-    this.setState({ showErrorName: false });
-  }
+
 
   render() {
     return (
@@ -93,6 +96,8 @@ class CreateRecipe extends React.Component {
                 className="close"
                 data-dismiss="modal"
                 aria-hidden="true"
+                onMouseEnter={() => this.errorChecking(false)}
+                onMouseLeave={() => this.errorChecking(true)}
                 onClick={(e) => this.dismissErrors(e)}
               >
                 <span className="pficon pficon-close"></span>
@@ -151,6 +156,8 @@ class CreateRecipe extends React.Component {
                 type="button"
                 className="btn btn-default"
                 data-dismiss="modal"
+                onMouseEnter={() => this.errorChecking(false)}
+                onMouseLeave={() => this.errorChecking(true)}
                 onClick={(e) => this.dismissErrors(e)}
               >Cancel</button>
               {this.state.recipe.name === '' &&
@@ -163,7 +170,6 @@ class CreateRecipe extends React.Component {
                 <button
                   type="button"
                   className="btn btn-primary"
-                  data-dismiss="modal"
                   onClick={(e) => RecipeApi.handleCreateRecipe(e, this.state.recipe)}
                 >Save</button>
               }

--- a/components/Modal/CreateRecipe.js
+++ b/components/Modal/CreateRecipe.js
@@ -48,10 +48,14 @@ class CreateRecipe extends React.Component {
         this.setState({ showErrorName: true });
         this.showInlineError();
       } else {
-        $('#cmpsr-modal-crt-compos').modal('hide');
-        RecipeApi.handleCreateRecipe(event, this.state.recipe);
+        this.handleCreateRecipe(event, this.state.recipe);
       }
     }
+  }
+
+  handleCreateRecipe(event, recipe) {
+    $('#cmpsr-modal-crt-recipe').modal('hide');
+    RecipeApi.handleCreateRecipe(event, recipe);
   }
 
   errorChecking(state) {
@@ -170,7 +174,7 @@ class CreateRecipe extends React.Component {
                 <button
                   type="button"
                   className="btn btn-primary"
-                  onClick={(e) => RecipeApi.handleCreateRecipe(e, this.state.recipe)}
+                  onClick={(e) => this.handleCreateRecipe(e, this.state.recipe)}
                 >Save</button>
               }
             </div>

--- a/data/RecipeApi.js
+++ b/data/RecipeApi.js
@@ -150,6 +150,26 @@ class RecipeApi {
     return p;
   }
 
+  handleEditDescription(description) {
+    const recipe = {
+      name: this.recipe.name,
+      description: description,
+      version: this.recipe.version,
+      modules: this.recipe.modules,
+      packages: this.recipe.packages,
+    };
+    const p = new Promise((resolve, reject) => {
+      this.postRecipe(recipe)
+      .then(() => {
+        resolve();
+      }).catch(e => {
+        console.log(`Error updating recipe description: ${e}`);
+        reject();
+      });
+    });
+    return p;
+  }
+
   postRecipe(recipe) {
     return utils.apiFetch(constants.post_recipes_new, {
       method: 'POST',

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -28,6 +28,8 @@ class RecipePage extends React.Component {
     selectedComponent: '',
     selectedComponentStatus: 'view',
     selectedComponentParent: '',
+    inlineEditDescription: false,
+    inlineEditDescriptionValue: '',
     revisions: [
       {
         number: '3',
@@ -210,6 +212,25 @@ class RecipePage extends React.Component {
     event.stopPropagation();
   };
 
+  handleEditDescription = (action) => {
+    const state = !this.state.inlineEditDescription;
+    this.setState({inlineEditDescription: state});
+    if (state === true) {
+      this.setState({inlineEditDescriptionValue: this.state.recipe.description});
+    } else if (action === 'save') {
+      let recipe = this.state.recipe;
+      recipe.description = this.state.inlineEditDescriptionValue;
+      this.setState({recipe: recipe});
+      RecipeApi.handleEditDescription(recipe.description);
+    } else if (action === 'cancel') {
+
+    }
+  }
+
+  handleChangeDescription(event) {
+    this.setState({inlineEditDescriptionValue: event.target.value});
+  }
+
   render() {
     const activeRevision = this.state.revisions.filter((obj) => obj.active === true)[0];
     const pastRevisions = this.state.revisions.filter((obj) => obj.active === false);
@@ -321,7 +342,28 @@ class RecipePage extends React.Component {
                   <dt>Name</dt>
                   <dd>{this.state.recipe.name}</dd>
                   <dt>Description</dt>
-                  <dd>{this.state.recipe.description}</dd>
+                  {this.state.inlineEditDescription &&
+                    <dd>
+                      <div className="input-group">
+                        <input type="text" className="form-control" value={this.state.inlineEditDescriptionValue} onChange={(e) => this.handleChangeDescription(e)} />
+                        <span className="input-group-btn">
+                          <button className="btn btn-link" type="button" onClick={() => this.handleEditDescription('save')}>
+                            <span className="fa fa-check"></span>
+                          </button>
+                          <button className="btn btn-link" type="button" onClick={() => this.handleEditDescription('cancel')}>
+                            <span className="pficon pficon-close"></span>
+                          </button>
+                        </span>
+                      </div>
+                    </dd>
+                    ||
+                    <dd onClick={() => this.handleEditDescription()}>
+                      {this.state.recipe.description}
+                      <button className="btn btn-link" type="button">
+                        <span className="pficon pficon-edit"></span>
+                      </button>
+                    </dd>
+                  }
                   <dt>Revision</dt>
                   <dd>3</dd>
                   <dt>Install size</dt>


### PR DESCRIPTION
- Recipes page was updated so that expand/collapse ability is removed (previously a hard-coded composition was listed in the expanded section of a recipe list item). For now, the code to expand/collapse is just commented out, since this will probably be added back in.
- Create Recipe dialog has updates related to not showing error messages on Cancel, and removing the background color on Save
- Ability to edit the description was added to the Recipe page. On the recipe page, Details tab, clicking the description or Edit icon next to the description displays an input field. When the description is modified, the change can be saved or canceled. If saved, the recipe is immediately updated in the database.