### PR TITLE
Recipe delete

### DIFF
--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -93,7 +93,7 @@ class RecipeListView extends React.Component {
                     aria-labelledby="dropdownKebabRight9"
                   >
                     <li><a href="#">Export</a></li>
-                    <li><a href="#">Delete</a></li>
+                    <li><a href="#" onClick={(e) => this.props.handleDelete(e, recipe.id)}>Archive</a></li>
                   </ul>
                 </div>
               </div>

--- a/core/constants.js
+++ b/core/constants.js
@@ -16,6 +16,7 @@ const constants = {
   get_modules_info: '/api/v0/modules/info/',
   get_compose_types: '/api/v0/compose/types',
   post_recipes_new: '/api/v0/recipes/new',
+  delete_recipe: '/api/v0/recipes/delete/',
 
 };
 

--- a/data/RecipeApi.js
+++ b/data/RecipeApi.js
@@ -204,6 +204,13 @@ class RecipeApi {
     return p;
   }
 
+  deleteRecipe(recipes) {
+    ///api/v0/recipes/delete/<recipe>
+    return utils.apiFetch(constants.delete_recipe + recipes, {
+      method: 'DELETE',
+    }, true);
+  }
+
 }
 
 export default new RecipeApi();

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -51,10 +51,22 @@ class RecipesPage extends React.Component {
   handleDelete = (event, recipe) => {
     event.preventDefault();
     event.stopPropagation();
-    // delete the recipe
-    RecipeApi.deleteRecipe(recipe);
-    // get recipes again
-    this.getRecipes();
+    const p = new Promise((resolve, reject) => {
+      RecipeApi.deleteRecipe(recipe)
+      .then(() => {
+        // find the recipe in recipes and remove it
+        let recipes = this.state.recipes;
+        recipes = recipes.filter(
+          (obj) => (obj.id !== recipe)
+        );
+        this.setState({recipes: recipes});
+        resolve();
+      }).catch(e => {
+        console.log(`Error deleting recipe: ${e}`);
+        reject();
+      });
+    });
+    return p;
   }
 
 
@@ -132,7 +144,7 @@ class RecipesPage extends React.Component {
                       <li role="separator" className="divider"></li>
                       <li><a href="#">Create Compositions</a></li>
                       <li><a href="#">Export Selected Recipes</a></li>
-                      <li><a href="#">Archive Selected Recipes</a></li>
+                      <li className="hidden"><a href="#">Archive Selected Recipes</a></li>
                     </ul>
                   </div>
                 </div>

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Layout from '../../components/Layout';
 import RecipeListView from '../../components/ListView/RecipeListView';
 import CreateRecipe from '../../components/Modal/CreateRecipe';
+import RecipeApi from '../../data/RecipeApi';
 import constants from '../../core/constants';
 import utils from '../../core/utils';
 
@@ -38,11 +39,22 @@ class RecipesPage extends React.Component {
             // ,"packages":[{"name":"tmux","version":"2.2"}]}],"offset":0,"limit":20}
           utils.apiFetch(constants.get_recipes_info + recipeName)
               .then(recipedata => {
-                this.setState({ recipes: this.state.recipes.concat(recipedata.recipes[0]) });
+                let recipe = recipedata.recipes[0];
+                recipe.id = recipeName;
+                this.setState({ recipes: this.state.recipes.concat(recipe) });
               });
         }
       })
       .catch(e => console.log(`Error getting recipes: ${e}`));
+  }
+
+  handleDelete = (event, recipe) => {
+    event.preventDefault();
+    event.stopPropagation();
+    // delete the recipe
+    RecipeApi.deleteRecipe(recipe);
+    // get recipes again
+    this.getRecipes();
   }
 
 
@@ -115,12 +127,12 @@ class RecipesPage extends React.Component {
                       aria-haspopup="true"
                       aria-expanded="false"
                     ><span className="fa fa-ellipsis-v"></span></button>
-                    <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
+                    <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
                       <li><a href="#">Import Recipe</a></li>
                       <li role="separator" className="divider"></li>
                       <li><a href="#">Create Compositions</a></li>
                       <li><a href="#">Export Selected Recipes</a></li>
-                      <li><a href="#">Delete Selected Recipes</a></li>
+                      <li><a href="#">Archive Selected Recipes</a></li>
                     </ul>
                   </div>
                 </div>
@@ -177,7 +189,7 @@ class RecipesPage extends React.Component {
             </div>
           </div>
         </div>
-        <RecipeListView recipes={this.state.recipes} setNotifications={this.setNotifications} />
+        <RecipeListView recipes={this.state.recipes} handleDelete={this.handleDelete} setNotifications={this.setNotifications} />
         <CreateRecipe />
       </Layout>
     );


### PR DESCRIPTION
For the purposes of usability testing, this PR includes an action "Archive" that deletes a recipe. The "Archive" action is needed for getting feedback. The delete action is used to remove the recipe. This is not intended to be a final implementation.

The action "Archive" displays in the kebab on a recipe list item. 

NOTE: these updates were implemented using the updates included in this PR: https://github.com/weldr/bdcs-api-rs/pull/58