### PR TITLE
removing href from nonfunctional links

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -36,8 +36,8 @@ function Header() {
               <span className="caret"></span>
             </a>
             <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
-              <li><a href="#">Help</a></li>
-              <li><a href="#">About</a></li>
+              <li><a >Help</a></li>
+              <li><a >About</a></li>
             </ul>
           </li>
           <li className="dropdown">
@@ -52,8 +52,8 @@ function Header() {
               <span className="caret"></span>
             </a>
             <ul className="dropdown-menu" aria-labelledby="dropdownMenu2">
-              <li><a href="#">Preferences</a></li>
-              <li><a href="#">Logout</a></li>
+              <li><a >Preferences</a></li>
+              <li><a >Logout</a></li>
             </ul>
           </li>
         </ul>

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -83,7 +83,9 @@ class ComponentDetailsView extends React.Component {
   }
 
   handleEdit = (event) => {
-    event.preventDefault();
+    if (event) {
+      event.preventDefault();
+    }
     // user clicked Edit for the selected component
     const component = this.state.componentData;
     // get available builds and set default value
@@ -201,7 +203,7 @@ class ComponentDetailsView extends React.Component {
                   <button
                     className="btn btn-primary"
                     type="button"
-                    onClick={() => this.handleEdit()}
+                    onClick={(e) => this.handleEdit(e)}
                   >Edit</button>
                 </li>
               }
@@ -215,7 +217,7 @@ class ComponentDetailsView extends React.Component {
                   >Save Updates</button>
                 </li>
               }
-              {this.props.status === 'selected' &&
+              {(this.props.status === 'selected' || this.props.status === 'editSelected') &&
                 <li>
                   <button
                     className="btn btn-default"

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -82,7 +82,8 @@ class ComponentDetailsView extends React.Component {
     $('[data-toggle="tooltip"]').tooltip();
   }
 
-  handleEdit = () => {
+  handleEdit = (event) => {
+    event.preventDefault();
     // user clicked Edit for the selected component
     const component = this.state.componentData;
     // get available builds and set default value
@@ -292,8 +293,7 @@ class ComponentDetailsView extends React.Component {
               <dd>{component.ui_type}</dd>
               <dt>Version</dt>
               <dd>
-                {this.state.componentData.version}
-                {(this.props.status === 'selected' &&
+                {this.state.componentData.version} {(this.props.status === 'selected' &&
                   this.state.editSelected === false) &&
                   <a href="#" onClick={(e) => this.handleEdit(e)}>Update</a>
                 }

--- a/components/ListView/ComponentSummaryList.js
+++ b/components/ListView/ComponentSummaryList.js
@@ -33,7 +33,7 @@ class ComponentSummaryList extends React.Component {
                 </div>
                 <div className="list-view-pf-body">
                   <div className="list-view-pf-description">
-                    <a href="#" data-item="name">{listItem.name}</a>
+                    <a data-item="name">{listItem.name}</a>
                   </div>
                 </div>
               </div>

--- a/components/ListView/ListItemComponents.js
+++ b/components/ListView/ListItemComponents.js
@@ -223,7 +223,7 @@ class ListItemComponents extends React.Component {
                       </div>
                       <div className="list-view-pf-body">
                         <div className="list-view-pf-description">
-                          <a href="#" data-item="name">---</a>
+                          <a data-item="name">---</a>
                         </div>
                       </div>
                     </div>

--- a/components/ListView/ListItemCompositions.js
+++ b/components/ListView/ListItemCompositions.js
@@ -23,11 +23,11 @@ class ListItemCompositions extends React.PureComponent {
                 className="dropdown-menu dropdown-menu-right"
                 aria-labelledby="dropdownKebabRight9"
               >
-                <li><a href="#">View Recipe Components</a></li>
-                <li><a href="#">View Recipe Manifest</a></li>
-                <li><a href="#">Export Recipe</a></li>
+                <li><a >View Recipe Components</a></li>
+                <li><a >View Recipe Manifest</a></li>
+                <li><a >Export Recipe</a></li>
                 <li role="separator" className="divider"></li>
-                <li><a href="#">Archive</a></li>
+                <li><a >Archive</a></li>
               </ul>
             </div>
           </div>
@@ -36,7 +36,7 @@ class ListItemCompositions extends React.PureComponent {
             <div className="list-view-pf-body">
               <div className="list-view-pf-description">
                 <div className="list-group-item-heading">
-                  <a href="#" data-item="name">
+                  <a  data-item="name">
                     {this.props.recipe}-rev{listItem.revision}-{listItem.type}
                   </a>
                 </div>

--- a/components/ListView/ListItemExpandRevisions.js
+++ b/components/ListView/ListItemExpandRevisions.js
@@ -71,17 +71,17 @@ class ListItemExpandRevisions extends React.Component {
                 className="dropdown-menu dropdown-menu-right"
                 aria-labelledby="dropdownKebabRight9"
               >
-                <li><a href="#">View Recipe</a></li>
+                <li><a >View Recipe</a></li>
                 {listItem.active === true &&
-                  <li><a href="#">Clone Revision</a></li>
+                  <li><a >Clone Revision</a></li>
                   ||
-                  <li><a href="#">Restore Revision</a></li>
+                  <li><a >Restore Revision</a></li>
                 }
-                <li><a href="#">Save Revision as New Recipe</a></li>
+                <li><a >Save Revision as New Recipe</a></li>
                 <li role="separator" className="divider"></li>
-                <li><a href="#">Create Composition</a></li>
+                <li><a >Create Composition</a></li>
                 <li role="separator" className="divider"></li>
-                <li><a href="#">Archive</a></li>
+                <li><a >Archive</a></li>
               </ul>
             </div>
           </div>
@@ -90,7 +90,7 @@ class ListItemExpandRevisions extends React.Component {
             <div className="list-view-pf-body">
               <div className="list-view-pf-description">
                 <div className="list-group-item-heading">
-                  <a href="#" data-item="name">Revision {listItem.number}</a>
+                  <a  data-item="name">Revision {listItem.number}</a>
                 </div>
                 <div className="list-group-item-text">
                   Based on {listItem.basedOn}
@@ -146,7 +146,7 @@ class ListItemExpandRevisions extends React.Component {
                         </div>
                         <div className="list-view-pf-body">
                           <div className="list-view-pf-description">
-                            <a href="#">
+                            <a >
                               {this.props.recipe}-rev{composition.revision}-{composition.type}
                             </a>
                             <span className="text-muted pull-right">
@@ -202,7 +202,7 @@ class ListItemExpandRevisions extends React.Component {
                       <div className="list-view-pf-main-info">
                         <div className="list-view-pf-body">
                           <div className="list-view-pf-description">
-                            <a href="#">{change.action}</a>
+                            <a >{change.action}</a>
                             <span
                               className="text-muted pull-right"
                             >{change.date} by {change.user}</span>

--- a/components/ListView/ListItemExpandRevisions.js
+++ b/components/ListView/ListItemExpandRevisions.js
@@ -41,7 +41,7 @@ class ListItemExpandRevisions extends React.Component {
         <div className="list-group-item-header" onClick={(e) => this.handleExpandComponent(e)}>
           <div className="list-view-pf-expand">
             <span
-              className={`fa ${this.state.expanded ? 'fa-angle-down' : 'fa-angle-right'}`}
+              className={`fa ${this.state.expanded ? 'fa-angle-right fa-angle-down' : 'fa-angle-right'}`}
             ></span>
           </div>
 

--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -94,8 +94,6 @@ class RecipeListView extends React.Component {
                   >
                     <li><a >Export</a></li>
                     <li><a href="#" onClick={(e) => this.props.handleDelete(e, recipe.id)}>Archive</a></li>
-                    <li><a >Export</a></li>
-                    <li><a >Delete</a></li>
                   </ul>
                 </div>
               </div>

--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -92,8 +92,10 @@ class RecipeListView extends React.Component {
                     className="dropdown-menu dropdown-menu-right"
                     aria-labelledby="dropdownKebabRight9"
                   >
-                    <li><a href="#">Export</a></li>
+                    <li><a >Export</a></li>
                     <li><a href="#" onClick={(e) => this.props.handleDelete(e, recipe.id)}>Archive</a></li>
+                    <li><a >Export</a></li>
+                    <li><a >Delete</a></li>
                   </ul>
                 </div>
               </div>
@@ -165,11 +167,11 @@ class RecipeListView extends React.Component {
                             className="dropdown-menu dropdown-menu-right"
                             aria-labelledby="dropdownKebabRight12"
                           >
-                            <li><a href="#">Action</a></li>
-                            <li><a href="#">Another action</a></li>
-                            <li><a href="#">Something else here</a></li>
+                            <li><a >Action</a></li>
+                            <li><a >Another action</a></li>
+                            <li><a >Something else here</a></li>
                             <li role="separator" className="divider"></li>
-                            <li><a href="#">Separated link</a></li>
+                            <li><a >Separated link</a></li>
                           </ul>
                         </div>
                       </div>

--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -116,7 +116,7 @@ class RecipeListView extends React.Component {
                     <div
                       className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked"
                     >
-                      Revision<strong>{recipe.version ? recipe.version : '0.0.0'}</strong>
+                      Revision<strong>3</strong>
                     </div>
                     <div
                       className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -20,8 +20,8 @@ class Toolbar extends React.Component {
                     aria-expanded="false"
                   >Name<span className="caret"></span></button>
                   <ul className="dropdown-menu">
-                    <li><a href="#">Name</a></li>
-                    <li><a href="#">Version</a></li>
+                    <li><a >Name</a></li>
+                    <li><a >Version</a></li>
                   </ul>
                 </div>
                 <input
@@ -42,8 +42,8 @@ class Toolbar extends React.Component {
                   aria-expanded="false"
                 >Name<span className="caret"></span></button>
                 <ul className="dropdown-menu">
-                  <li><a href="#">Name</a></li>
-                  <li><a href="#">Version</a></li>
+                  <li><a >Name</a></li>
+                  <li><a >Version</a></li>
                 </ul>
               </div>
               <button className="btn btn-link" type="button">
@@ -70,10 +70,10 @@ class Toolbar extends React.Component {
                     aria-expanded="false"
                   ><span className="fa fa-ellipsis-v"></span></button>
                   <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
-                    <li><a href="#">Export Recipe</a></li>
+                    <li><a >Export Recipe</a></li>
                     <li role="separator" className="divider"></li>
-                    <li><a href="#">Update Selected Components</a></li>
-                    <li><a href="#">Remove Selected Components</a></li>
+                    <li><a >Update Selected Components</a></li>
+                    <li><a >Remove Selected Components</a></li>
                   </ul>
                 </div>
               </div>
@@ -111,21 +111,21 @@ class Toolbar extends React.Component {
               <ul className="list-inline">
                 <li>
                   <span className="label label-info">Name: nameofthething
-                    <a href="#"><span className="pficon pficon-close"></span></a>
+                    <a ><span className="pficon pficon-close"></span></a>
                   </span>
                 </li>
                 <li>
                   <span className="label label-info">Version: 3
-                    <a href="#"><span className="pficon pficon-close"></span></a>
+                    <a ><span className="pficon pficon-close"></span></a>
                   </span>
                 </li>
                 <li>
                   <span className="label label-info">Lifecycle: 5
-                    <a href="#"><span className="pficon pficon-close"></span></a>
+                    <a ><span className="pficon pficon-close"></span></a>
                   </span>
                 </li>
               </ul>
-              <p><a href="#">Clear All Filters</a></p>
+              <p><a >Clear All Filters</a></p>
             </div>
           </div>
         </div>

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -278,8 +278,8 @@ class RecipePage extends React.Component {
                           aria-haspopup="true"
                           aria-expanded="false"
                         ><span className="fa fa-ellipsis-v"></span></button>
-                        <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
-                          <li><a href="#">Export Recipe</a></li>
+                        <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
+                          <li><a>Export Recipe</a></li>
                         </ul>
                       </div>
                     </div>
@@ -317,21 +317,21 @@ class RecipePage extends React.Component {
                     <ul className="list-inline">
                       <li>
                         <span className="label label-info">Name: nameofthething
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                       <li>
                         <span className="label label-info">Version: 3
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                       <li>
                         <span className="label label-info">Lifecycle: 5
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                     </ul>
-                    <p><a href="#">Clear All Filters</a></p>
+                    <p><a >Clear All Filters</a></p>
                   </div>
                 </div>
               </div>
@@ -427,9 +427,9 @@ class RecipePage extends React.Component {
                             aria-expanded="false"
                           >Revision 3<span className="caret"></span></button>
                           <ul className="dropdown-menu">
-                            <li><a href="#">Revision 3</a></li>
-                            <li><a href="#">Revision 2</a></li>
-                            <li><a href="#">Revision 1</a></li>
+                            <li><a >Revision 3</a></li>
+                            <li><a >Revision 2</a></li>
+                            <li><a >Revision 1</a></li>
                           </ul>
                         </div>
                       </div>
@@ -445,8 +445,8 @@ class RecipePage extends React.Component {
                               aria-expanded="false"
                             >Name<span className="caret"></span></button>
                             <ul className="dropdown-menu">
-                              <li><a href="#">Name</a></li>
-                              <li><a href="#">Version</a></li>
+                              <li><a >Name</a></li>
+                              <li><a >Version</a></li>
                             </ul>
                           </div>
                           <input
@@ -467,8 +467,8 @@ class RecipePage extends React.Component {
                             aria-expanded="false"
                           >Name<span className="caret"></span></button>
                           <ul className="dropdown-menu">
-                            <li><a href="#">Name</a></li>
-                            <li><a href="#">Version</a></li>
+                            <li><a >Name</a></li>
+                            <li><a >Version</a></li>
                           </ul>
                         </div>
                         <button className="btn btn-link" type="button">
@@ -497,8 +497,8 @@ class RecipePage extends React.Component {
                               aria-haspopup="true"
                               aria-expanded="false"
                             ><span className="fa fa-ellipsis-v"></span></button>
-                            <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
-                              <li><a href="#">Export Recipe</a></li>
+                            <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
+                              <li><a >Export Recipe</a></li>
                             </ul>
                           </div>
                         </div>
@@ -536,21 +536,21 @@ class RecipePage extends React.Component {
                         <ul className="list-inline">
                           <li>
                             <span className="label label-info">Name: nameofthething
-                              <a href="#"><span className="pficon pficon-close"></span></a>
+                              <a ><span className="pficon pficon-close"></span></a>
                             </span>
                           </li>
                           <li>
                             <span className="label label-info">Version: 3
-                              <a href="#"><span className="pficon pficon-close"></span></a>
+                              <a ><span className="pficon pficon-close"></span></a>
                             </span>
                           </li>
                           <li>
                             <span className="label label-info">Lifecycle: 5
-                              <a href="#"><span className="pficon pficon-close"></span></a>
+                              <a ><span className="pficon pficon-close"></span></a>
                             </span>
                           </li>
                         </ul>
-                        <p><a href="#">Clear All Filters</a></p>
+                        <p><a >Clear All Filters</a></p>
                       </div>
                     </div>
                   </div>
@@ -603,9 +603,9 @@ class RecipePage extends React.Component {
                           aria-haspopup="true"
                           aria-expanded="false"
                         ><span className="fa fa-ellipsis-v"></span></button>
-                        <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
+                        <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
 
-                          <li><a href="#">Export Recipe</a></li>
+                          <li><a >Export Recipe</a></li>
                         </ul>
                       </div>
                     </div>
@@ -643,21 +643,21 @@ class RecipePage extends React.Component {
                     <ul className="list-inline">
                       <li>
                         <span className="label label-info">Name: nameofthething
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                       <li>
                         <span className="label label-info">Version: 3
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                       <li>
                         <span className="label label-info">Lifecycle: 5
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                     </ul>
-                    <p><a href="#">Clear All Filters</a></p>
+                    <p><a >Clear All Filters</a></p>
                   </div>
                 </div>
               </div>
@@ -732,8 +732,8 @@ class RecipePage extends React.Component {
                           aria-haspopup="true"
                           aria-expanded="false"
                         ><span className="fa fa-ellipsis-v"></span></button>
-                        <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
-                          <li><a href="#">Export Recipe</a></li>
+                        <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
+                          <li><a >Export Recipe</a></li>
                         </ul>
                       </div>
                     </div>
@@ -771,21 +771,21 @@ class RecipePage extends React.Component {
                     <ul className="list-inline">
                       <li>
                         <span className="label label-info">Name: nameofthething
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                       <li>
                         <span className="label label-info">Version: 3
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                       <li>
                         <span className="label label-info">Lifecycle: 5
-                          <a href="#"><span className="pficon pficon-close"></span></a>
+                          <a ><span className="pficon pficon-close"></span></a>
                         </span>
                       </li>
                     </ul>
-                    <p><a href="#">Clear All Filters</a></p>
+                    <p><a >Clear All Filters</a></p>
                   </div>
                 </div>
               </div>

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -461,7 +461,7 @@ class EditRecipePage extends React.Component {
         <div className="cmpsr-title-summary">
           <h1 className="cmpsr-title-summary__item">{recipeDisplayName}</h1>
           <p className="cmpsr-title-summary__item">
-            Revision {this.state.recipe.version}
+            Revision 3 <span className="hidden">{this.state.recipe.version}</span>
             <span className="text-muted">, Total Disk Space: 1,234 KB</span>
           </p>
         </div>

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -91,8 +91,8 @@ class RecipesPage extends React.Component {
                       aria-expanded="false"
                     >Name<span className="caret"></span></button>
                     <ul className="dropdown-menu">
-                      <li><a href="#">Name</a></li>
-                      <li><a href="#">Version</a></li>
+                      <li><a >Name</a></li>
+                      <li><a >Version</a></li>
                     </ul>
                   </div>
                   <input
@@ -113,8 +113,8 @@ class RecipesPage extends React.Component {
                     aria-expanded="false"
                   >Name<span className="caret"></span></button>
                   <ul className="dropdown-menu">
-                    <li><a href="#">Name</a></li>
-                    <li><a href="#">Version</a></li>
+                    <li><a >Name</a></li>
+                    <li><a >Version</a></li>
                   </ul>
                 </div>
                 <button className="btn btn-link" type="button">
@@ -140,11 +140,11 @@ class RecipesPage extends React.Component {
                       aria-expanded="false"
                     ><span className="fa fa-ellipsis-v"></span></button>
                     <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                      <li><a href="#">Import Recipe</a></li>
+                      <li><a >Import Recipe</a></li>
                       <li role="separator" className="divider"></li>
-                      <li><a href="#">Create Compositions</a></li>
-                      <li><a href="#">Export Selected Recipes</a></li>
-                      <li className="hidden"><a href="#">Archive Selected Recipes</a></li>
+                      <li><a >Create Compositions</a></li>
+                      <li><a >Export Selected Recipes</a></li>
+                      <li className="hidden"><a >Archive Selected Recipes</a></li>
                     </ul>
                   </div>
                 </div>
@@ -182,21 +182,21 @@ class RecipesPage extends React.Component {
                 <ul className="list-inline">
                   <li>
                     <span className="label label-info">Name: nameofthething
-                      <a href="#"><span className="pficon pficon-close"></span></a>
+                      <a ><span className="pficon pficon-close"></span></a>
                     </span>
                   </li>
                   <li>
                     <span className="label label-info">Version: 3
-                      <a href="#"><span className="pficon pficon-close"></span></a>
+                      <a ><span className="pficon pficon-close"></span></a>
                     </span>
                   </li>
                   <li>
                     <span className="label label-info">Lifecycle: 5
-                      <a href="#"><span className="pficon pficon-close"></span></a>
+                      <a ><span className="pficon pficon-close"></span></a>
                     </span>
                   </li>
                 </ul>
-                <p><a href="#">Clear All Filters</a></p>
+                <p><a >Clear All Filters</a></p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
These are updates related to general UI clean up for user testing:

There are non-functional links that are included in the UI for the purposes of user review. But when the user clicks on one of these links, the user is redirected to the home page (i.e. "Overview") due to the `href="#"`. For any link that is not implemented yet, these href attributes have been removed, to avoid any unnecessary confusion during user testing.

Values for "Revision" are replaced with a hard-coded value of "3" so that it matches the mock data. This is to avoid any confusion during user testing.

On the Recipe page, Revisions tab, classes for the expand/collapse arrow are updated to fix a sizing issue. When the down arrow became visible after expanding a list item, the arrow was not the correct size.