### PR TITLE
Package end-to-end test into a docker image.

### DIFF
--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -1,0 +1,54 @@
+# A Fedora 25 End-To-End Automation Test Container
+FROM weld/fedora:25
+MAINTAINER Xiaofeng Wang <xiaofwan@redhat.com>
+
+# Install xvfb to simulate framebuffer for nightmare.js
+# Install electorn dependency
+RUN dnf --setopt=deltarpm=0 --verbose install -y xorg-x11-server-Xvfb which libXScrnSaver \
+clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel xorg-x11-server-utils \
+libcap-devel cups-devel libXtst-devel alsa-lib-devel libXrandr-devel GConf2-devel nss-devel
+
+RUN echo 'PATH=/usr/local/bin/:$PATH' >> /etc/bashrc
+
+# Based on official node docker image
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.9.1
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["xvfb-run", "-a", "-s", "-screen 0 1024x768x24", "npm", "run", "test"]
+
+## Do the things more likely to change below here. ##
+
+# Volumes for xUnit result file.
+VOLUME /result
+
+# Update node dependencies only if they have changed
+COPY ./package.json /end2end/package.json
+RUN cd /end2end/ && npm install --only=production
+
+# Copy the rest of the UI files over and compile them
+COPY . /end2end/

--- a/test/end-to-end/README.md
+++ b/test/end-to-end/README.md
@@ -5,20 +5,22 @@ The end-to-end automation test for Welder! It is performed on the application le
 
 ## How To Test
 
+### Running end-to-end test directly on the host
+
 The end-to-end tests are powered by [nightmare](http://nightmarejs.org/), 
 [chai](http://chaijs.com/), [mocha](http://mochajs.org/) and [request-promise-native](https://github.com/request/request-promise-native)
 
-### Requirement
+#### Requirement
 
 1. Have both bdcs-api-rs and welder-web running on localhost.
 
 2. Use "real" API, not mock API.
 
-### Test Case Location
+#### Test Case Location
 
 All test cases are placed in *test/end-to-end/test* directory.
 
-### Test Running Command
+#### Test Running Command
 
 ```shell
 $ cd test/end-to-end
@@ -26,6 +28,26 @@ $ npm install                                   # Install end-to-end dependencie
 $ npm run test                                  # Run end-to-end test
 $ npm run xunittest                             # Run end-to-end test with xunit xml result output
 ```
+
+### Running end-to-end test in Docker
+
+The end-to-end test docker image is an executable image, which starts container, runs test, and exits.
+
+The docker image depends on a base image, named weld/fedora:25, which needs have been previously built. 
+If it is not available it can be built from the welder-deployment repository by running `make weld-f25`.
+
+Build end-to-end test docker image by running:
+
+`sudo docker build -t weld/end-to-end:latest .`
+
+The end-to-end test needs both bdcs-api-rs and welder-web docker running. Build them from welder-deployment 
+repository by running `make build` and `make import-metadata`. Run them by running `sudo docker-compose -p welder up -d`.
+
+Run end-to-end test like this:
+
+`sudo docker run --rm --name welder_end_to_end --network welder_default -v test-result-volume:/result weld/end-to-end:latest xvfb-run -a -s '-screen 0 1024x768x24' npm run citest`
+
+XUnit XML format result will be generated at */var/lib/docker/volumes/test-result-volume/_data/result.xml*
 
 ## Directory Layout
 

--- a/test/end-to-end/entrypoint.sh
+++ b/test/end-to-end/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Rewrite config.json to use service name as hostname of API and Web
+cd /end2end/ || exit 1
+
+sed -i "s,\"root\": \"http://localhost:3000/\",\"root\": \"http://web:3000/\"," config.json
+sed -i "s,\"uri\": \"http://localhost:4000/\",\"uri\": \"http://api:4000/\"," config.json
+
+echo "Running with config.json settings:"
+cat ./config.json
+
+# Execute the CMD
+exec "$@"

--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -4,19 +4,22 @@
   "description": "weldr-web end-to-end automation test",
   "scripts": {
     "xunittest": "mocha -R xunit -O output=result.xml",
-    "test": "mocha"
+    "test": "mocha",
+    "citest": "mocha -R xunit -O output=/result/result.xml"
   },
   "dependencies": {
     "chai": "^3.5.0",
+    "mocha": "^3.2.0",
+    "nightmare": "^2.10.0",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.3"
+  },
+  "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-mocha": "^4.9.0",
-    "eslint-plugin-react": "^6.10.3",
-    "mocha": "^3.2.0",
-    "nightmare": "^2.10.0",
-    "request": "^2.81.0",
-    "request-promise-native": "^1.0.3"
+    "eslint-plugin-react": "^6.10.3"
   }
 }


### PR DESCRIPTION
Run docker image as run end-to-end test.

Move eslint and its plugin from dependencies to devDependencies.

Update README.md with Running end-to-end test in Docker section added.