### PR TITLE
Includes scrollbars for nested lists

### DIFF
--- a/public/custom.css
+++ b/public/custom.css
@@ -215,6 +215,11 @@ div.hidden-nav .navbar-pf-vertical { display: none; }
   padding: 0;
 }
 
+.list-group-item-container .cmpsr-list-view-viewskinny {
+   max-height: 300px;
+   overflow: auto;
+ }
+
 /*Component details*/
 #cmpsr-recipe-details-edit {
   border-top: 1px solid #d1d1d1;


### PR DESCRIPTION
In a list view there list items can be expanded, if the content are
includes a nested list, this sets a max height so that the parent list
item doesn't get too tall.

An example of this is any component list item (Selected Component or Dependency) on either the Recipe page or Edit Recipe page. The nested list is the list of Dependencies that displays in the expanded content area of a component list item.