### PR TITLE
fixes issue with updating cached description

### DIFF
--- a/data/RecipeApi.js
+++ b/data/RecipeApi.js
@@ -173,6 +173,9 @@ class RecipeApi {
   }
 
   handleEditDescription(description) {
+    // update cached recipe data
+    this.recipe.description = description;
+    // create recipe variable to post updates
     const recipe = {
       name: this.recipe.name,
       description: description,


### PR DESCRIPTION
@henrywang, this fixes the issue you had noted before about Edit Description and navigating to the Edit Recipe page.

Steps to reproduce the issue being fixed:
1) edit the description on the Recipe page, Details tab
2) navigate to the Edit Recipe page
3) navigate back to the Recipe page

Results:  the previous description before the edit
is visible. But clicking reload on the page will show the
description that was saved.

This issue occurred because the recipe data gets cached,
but the cached description wasn't getting updated upon
editing the description.