### PR TITLE
Export recipe

### DIFF
--- a/components/ListView/ListItemCompositions.js
+++ b/components/ListView/ListItemCompositions.js
@@ -25,7 +25,7 @@ class ListItemCompositions extends React.PureComponent {
               >
                 <li><a >View Recipe Components</a></li>
                 <li><a >View Recipe Manifest</a></li>
-                <li><a >Export Recipe</a></li>
+                <li><a >Export</a></li>
                 <li role="separator" className="divider"></li>
                 <li><a >Archive</a></li>
               </ul>

--- a/components/ListView/ListItemExpandRevisions.js
+++ b/components/ListView/ListItemExpandRevisions.js
@@ -72,7 +72,7 @@ class ListItemExpandRevisions extends React.Component {
                 aria-labelledby="dropdownKebabRight9"
               >
                 <li><a >View Recipe</a></li>
-                <li><a >Export Recipe</a></li>
+                <li><a >Export</a></li>
                 <li role="separator" className="divider"></li>
                 {listItem.active === true &&
                   <li><a >Clone Revision</a></li>

--- a/components/ListView/ListItemExpandRevisions.js
+++ b/components/ListView/ListItemExpandRevisions.js
@@ -72,14 +72,14 @@ class ListItemExpandRevisions extends React.Component {
                 aria-labelledby="dropdownKebabRight9"
               >
                 <li><a >View Recipe</a></li>
+                <li><a >Export Recipe</a></li>
+                <li role="separator" className="divider"></li>
                 {listItem.active === true &&
                   <li><a >Clone Revision</a></li>
                   ||
                   <li><a >Restore Revision</a></li>
                 }
                 <li><a >Save Revision as New Recipe</a></li>
-                <li role="separator" className="divider"></li>
-                <li><a >Create Composition</a></li>
                 <li role="separator" className="divider"></li>
                 <li><a >Archive</a></li>
               </ul>

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -70,7 +70,7 @@ class Toolbar extends React.Component {
                     aria-expanded="false"
                   ><span className="fa fa-ellipsis-v"></span></button>
                   <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                    <li><a >Export Recipe</a></li>
+                    <li><a >Export</a></li>
                     <li role="separator" className="divider"></li>
                     <li><a >Update Selected Components</a></li>
                     <li><a >Remove Selected Components</a></li>

--- a/data/NotificationsApi.js
+++ b/data/NotificationsApi.js
@@ -57,9 +57,10 @@ class NotificationsApi {
           // this link will need to be implemented when the build process
           // is implemented; this function will need to be extended to handle
           // defining this link
-          kebab: [
-            <a href="#" id="cmpsr-bom-link">Export Recipe (.bom)</a>,
-          ],
+          // kebab: [
+          //   <a href="#" >Export Recipe (.bom)</a>,
+          // ],
+          // this kebab may be needed when the build process is implemented
           fade: true,
         };
         break;

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -279,7 +279,7 @@ class RecipePage extends React.Component {
                           aria-expanded="false"
                         ><span className="fa fa-ellipsis-v"></span></button>
                         <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a>Export Recipe</a></li>
+                          <li><a>Export</a></li>
                         </ul>
                       </div>
                     </div>
@@ -498,7 +498,7 @@ class RecipePage extends React.Component {
                               aria-expanded="false"
                             ><span className="fa fa-ellipsis-v"></span></button>
                             <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                              <li><a >Export Recipe</a></li>
+                              <li><a >Export</a></li>
                             </ul>
                           </div>
                         </div>
@@ -593,22 +593,6 @@ class RecipePage extends React.Component {
               <div className="col-sm-12">
                 <form className="toolbar-pf-actions">
                   <div className="toolbar-pf-action-right">
-                    <div className="form-group">
-                      <div className="dropdown btn-group  dropdown-kebab-pf">
-                        <button
-                          className="btn btn-link dropdown-toggle"
-                          type="button"
-                          id="dropdownKebab"
-                          data-toggle="dropdown"
-                          aria-haspopup="true"
-                          aria-expanded="false"
-                        ><span className="fa fa-ellipsis-v"></span></button>
-                        <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-
-                          <li><a >Export Recipe</a></li>
-                        </ul>
-                      </div>
-                    </div>
                     <div className="form-group toolbar-pf-find">
                       <button className="btn btn-link btn-find" type="button">
                         <span className="fa fa-search"></span>
@@ -733,7 +717,7 @@ class RecipePage extends React.Component {
                           aria-expanded="false"
                         ><span className="fa fa-ellipsis-v"></span></button>
                         <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a >Export Recipe</a></li>
+                          <li><a >Export</a></li>
                         </ul>
                       </div>
                     </div>


### PR DESCRIPTION
This work is in preparation for ability to export a manifest file, but for now, just updates the action label and where the action is included.

Updates include:
- Remove Export action and kebab from Composition
  Created notification
- Replace all instances of 'Export Recipe' with just
  'Export'. This action might later be used for different
  export options, but for now will just export a manifest
  file when the backend work for the manifest file is
  completed
- On Revisions tab, moved 'Export' and kebab from toolbar
  and added to each individual Revision list item