### PR TITLE
Add wait selector step when switching pages to make case more stable.

### DIFF
--- a/test/end-to-end/test/test_createRecipe.js
+++ b/test/end-to-end/test/test_createRecipe.js
@@ -27,9 +27,11 @@ describe('Create Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(recipesPage.url)
+          .wait(recipesPage.btnCreateRecipe)
           .click(recipesPage.btnCreateRecipe)
-          .wait(createRecipePage.labelCreateRecipe)
+          .wait(createRecipePage.btnSave)
           .click(createRecipePage.btnSave)
+          .wait(createRecipePage.labelAlertInfo)
           .evaluate(page => document.querySelector(page.labelAlertInfo).innerText
             , createRecipePage)
           .end()
@@ -54,8 +56,9 @@ describe('Create Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(recipesPage.url)
+          .wait(recipesPage.btnCreateRecipe)
           .click(recipesPage.btnCreateRecipe)
-          .wait(createRecipePage.labelCreateRecipe)
+          .wait(createRecipePage.inputDescription)
           .wait(1000)
           .insert(createRecipePage.inputName, createRecipePage.varRecName)
           .insert(createRecipePage.inputDescription, createRecipePage.varRecDesc)

--- a/test/end-to-end/test/test_editRecipe.js
+++ b/test/end-to-end/test/test_editRecipe.js
@@ -36,7 +36,7 @@ describe('Edit Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(editRecipePage.url)
-          .wait(editRecipePage.labelEditRecipe)
+          .wait(editRecipePage.linkRecipeName)
           .then(() => nightmare
             .evaluate(page => document.querySelector(page.linkRecipeName).innerText
               , editRecipePage))
@@ -61,7 +61,7 @@ describe('Edit Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(editRecipePage.url)
-          .wait(editRecipePage.labelEditRecipe)
+          .wait(editRecipePage.labelRecipeTitle)
           .evaluate(page => document.querySelector(page.labelRecipeTitle).innerText
             , editRecipePage)
           .end()
@@ -77,7 +77,7 @@ describe('Edit Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(editRecipePage.url)
-          .wait(editRecipePage.labelEditRecipe)
+          .wait(editRecipePage.btnCreateCompos)
           .evaluate(page => document.querySelector(page.btnCreateCompos).innerText
             , editRecipePage)
           .end()
@@ -98,7 +98,9 @@ describe('Edit Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(editRecipePage.url)
+          .wait(editRecipePage.btnCreateCompos)
           .click(editRecipePage.btnCreateCompos)
+          .wait(createComposPage.labelCreateCompos)
           .evaluate(page => document.querySelector(page.labelCreateCompos).innerText
             , createComposPage)
           .end()
@@ -117,11 +119,14 @@ describe('Edit Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(editRecipePage.url)
+          .wait(editRecipePage.btnCreateCompos)
           .click(editRecipePage.btnCreateCompos)
+          .wait(createComposPage.btnCreate)
           .select(createComposPage.selectComposType, createComposPage.composType)
           .select(createComposPage.selectComposArch, createComposPage.composArch)
           .click(createComposPage.btnCreate)
           .wait(toastNotifPage.iconCreating)
+          .wait(toastNotifPage.labelStatus)
           .then(() => nightmare
             .evaluate(page => document.querySelector(page.labelStatus).innerText
             , toastNotifPage))
@@ -130,6 +135,7 @@ describe('Edit Recipe Page', function () {
           })
           .then(() => nightmare
             .wait(toastNotifPage.iconComplete)
+            .wait(toastNotifPage.labelStatus)
             .evaluate(page => document.querySelector(page.labelStatus).innerText
             , toastNotifPage)
             .end())

--- a/test/end-to-end/test/test_recipes.js
+++ b/test/end-to-end/test/test_recipes.js
@@ -43,7 +43,7 @@ describe('Recipes Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(recipesPage.url)
-          // .wait('.container-pf-nav-pf-vertical')
+          .wait(recipesPage.btnCreateRecipe)
           .evaluate(page => document.querySelector(page.btnCreateRecipe).innerText
             , recipesPage)
           .end()
@@ -62,8 +62,9 @@ describe('Recipes Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(recipesPage.url)
+          .wait(recipesPage.btnCreateRecipe)
           .click(recipesPage.btnCreateRecipe)
-          // .wait(createRecipePage.labelCreateRecipe)
+          .wait(createRecipePage.labelCreateRecipe)
           .evaluate(page => document.querySelector(page.labelCreateRecipe).innerText
             , createRecipePage)
           .end()
@@ -97,6 +98,7 @@ describe('Recipes Page', function () {
           const nightmare = new Nightmare();
           nightmare
             .goto(recipesPage.url)
+            .wait(recipeNameSelector)
             .evaluate(selector => document.querySelector(selector).innerText
               , recipeNameSelector)
             .end()
@@ -108,6 +110,7 @@ describe('Recipes Page', function () {
         it('should have correct recipe description on list after new recipe added', (done) => {
           new Nightmare()
           .goto(recipesPage.url)
+          .wait(recipesPage.labelRecipeDescr)
           .evaluate(page => [...document.querySelectorAll(page.labelRecipeDescr)]
             .map(x => x.innerText), recipesPage)
           .end()
@@ -133,7 +136,9 @@ describe('Recipes Page', function () {
           const nightmare = new Nightmare();
           nightmare
             .goto(recipesPage.url)
+            .wait(btnCreateCompos)
             .click(btnCreateCompos)
+            .wait(createComposPage.labelCreateCompos)
             .evaluate(page => document.querySelector(page.labelCreateCompos).innerText
               , createComposPage)
             .end()
@@ -152,11 +157,14 @@ describe('Recipes Page', function () {
           const nightmare = new Nightmare();
           nightmare
             .goto(recipesPage.url)
+            .wait(btnCreateCompos)
             .click(btnCreateCompos)
+            .wait(createComposPage.btnCreate)
             .select(createComposPage.selectComposType, createComposPage.composType)
             .select(createComposPage.selectComposArch, createComposPage.composArch)
             .click(createComposPage.btnCreate)
             .wait(toastNotifPage.iconCreating)
+            .wait(toastNotifPage.labelStatus)
             .then(() => nightmare
               .evaluate(page => document.querySelector(page.labelStatus).innerText
               , toastNotifPage))
@@ -165,6 +173,7 @@ describe('Recipes Page', function () {
             })
             .then(() => nightmare
               .wait(toastNotifPage.iconComplete)
+              .wait(toastNotifPage.labelStatus)
               .evaluate(page => document.querySelector(page.labelStatus).innerText
               , toastNotifPage)
               .end())

--- a/test/end-to-end/test/test_viewRecipe.js
+++ b/test/end-to-end/test/test_viewRecipe.js
@@ -35,6 +35,7 @@ describe('View Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(viewRecipePage.url)
+          .wait(viewRecipePage.labelRecipeName)
           .evaluate(page => document.querySelector(page.labelRecipeName).innerText
             , viewRecipePage)
           .end()
@@ -52,6 +53,7 @@ describe('View Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(viewRecipePage.url)
+          .wait(viewRecipePage.labelRecipeTitle)
           .evaluate(page => document.querySelector(page.labelRecipeTitle).innerText
             , viewRecipePage)
           .end()
@@ -67,6 +69,7 @@ describe('View Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(viewRecipePage.url)
+          .wait(viewRecipePage.btnCreateCompos)
           .evaluate(page => document.querySelector(page.btnCreateCompos).innerText
             , viewRecipePage)
           .end()
@@ -87,6 +90,7 @@ describe('View Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(viewRecipePage.url)
+          .wait(viewRecipePage.btnCreateCompos)
           .click(viewRecipePage.btnCreateCompos)
           .evaluate(page => document.querySelector(page.labelCreateCompos).innerText
             , createComposPage)
@@ -106,11 +110,14 @@ describe('View Recipe Page', function () {
         const nightmare = new Nightmare();
         nightmare
           .goto(viewRecipePage.url)
+          .wait(viewRecipePage.btnCreateCompos)
           .click(viewRecipePage.btnCreateCompos)
+          .wait(createComposPage.btnCreate)
           .select(createComposPage.selectComposType, createComposPage.composType)
           .select(createComposPage.selectComposArch, createComposPage.composArch)
           .click(createComposPage.btnCreate)
           .wait(toastNotifPage.iconCreating)
+          .wait(toastNotifPage.labelStatus)
           .then(() => nightmare
             .evaluate(page => document.querySelector(page.labelStatus).innerText
             , toastNotifPage))
@@ -119,6 +126,7 @@ describe('View Recipe Page', function () {
           })
           .then(() => nightmare
             .wait(toastNotifPage.iconComplete)
+            .wait(toastNotifPage.labelStatus)
             .evaluate(page => document.querySelector(page.labelStatus).innerText
             , toastNotifPage)
             .end())


### PR DESCRIPTION
That will not increase case running by adding wait selector step.
From my debug result, all of wait selector step just cost 0ms.

`nightmare queueing action "wait" +0ms`