### PR TITLE
Fix for GPG key timeout error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -ex \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -23,7 +23,7 @@ RUN set -ex \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info


### PR DESCRIPTION
Currently I'm seeing the following error lcoally and in Travis:
gpg: requesting key 7E37093B from hkp server ha.pool.sks-keyservers.net

gpg: keyserver timed out

gpg: keyserver receive failed: keyserver error

with this patch I'm able to import the offending key:

gpg: requesting key 7D83545D from hkp server pool.sks-keyservers.net
gpg: key 7D83545D: public key "Rod Vagg <rod@vagg.org>" imported
gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
gpg: depth: 0  valid:   2  signed:   2  trust: 0-, 0q, 0n, 0m, 0f, 2u
gpg: depth: 1  valid:   2  signed:   0  trust: 0-, 1q, 0n, 1m, 0f, 0u
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)

The hostname pool.sks-keyservers.net is also the official one listed
in Node's README!