### PR TITLE
Add e2e sanity test for imorted content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,6 @@ end-to-end-test:
 	sudo docker-compose -f welder-deployment/docker-compose.yml -p welder up -d
 
 	sudo docker run --rm --name welder_end_to_end --network welder_default \
-	    -v test-result-volume:/result weld/end-to-end:latest \
+	    -v test-result-volume:/result -v bdcs-mddb-volume:/mddb -e MDDB='/mddb/metadata.db' \
+	    weld/end-to-end:latest \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test

--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -12,7 +12,8 @@
     "mocha": "^3.2.0",
     "nightmare": "^2.10.0",
     "request": "^2.81.0",
-    "request-promise-native": "^1.0.3"
+    "request-promise-native": "^1.0.3",
+    "sqlite3": "^3.1.8"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/test/end-to-end/pages/editRecipe.js
+++ b/test/end-to-end/pages/editRecipe.js
@@ -23,6 +23,9 @@ module.exports = class EditRecipePage extends MainPage {
 
     // Save button
     this.btnSave = '.cmpsr-edit-actions .btn-primary';
+
+    // component count inside the pagination control
+    this.totalComponentCount = '.cmpsr-recipe-inputs-pagination span';
   }
 
   get url() {

--- a/test/end-to-end/test/test_importSanity.js
+++ b/test/end-to-end/test/test_importSanity.js
@@ -1,0 +1,46 @@
+const Nightmare = require('nightmare');
+const expect = require('chai').expect;
+const EditRecipePage = require('../pages/editRecipe');
+const apiCall = require('../utils/apiCall');
+const pageConfig = require('../config');
+const sqlite3 = require('sqlite3').verbose();
+
+describe('Imported Content Sanity Testing', function () {
+  this.timeout(15000);
+  const db = new sqlite3.Database(process.env.MDDB || 'metadata.db');
+
+  before((done) => {
+    // Check BDCS API and Web service first
+    apiCall.serviceCheck(done);
+  });
+
+  before((done) => {
+    // Create a new recipe before the first test run in this suite
+    apiCall.newRecipe(pageConfig.recipe.simple, done);
+  });
+
+  after((done) => {
+    // Delete added recipe after all tests completed in this sute
+    apiCall.deleteRecipe(pageConfig.recipe.simple.name, done);
+  });
+
+  const editRecipePage = new EditRecipePage(pageConfig.recipe.simple.name);
+
+  it('displayed count should match distinct count from DB', (done) => {
+    db.each('SELECT name, COUNT(DISTINCT name) AS total_count FROM groups', (err, row) => {
+      const expectedText = `1 - 50 of ${row.total_count}`;
+
+      const nightmare = new Nightmare();
+      nightmare
+        .goto(editRecipePage.url)
+        .wait(editRecipePage.totalComponentCount)
+        .then(() => nightmare
+          .evaluate(page => document.querySelector(page.totalComponentCount).innerText
+            , editRecipePage))
+        .then((element) => {
+          expect(element).to.equal(expectedText);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
This is in addition to the import sanity tests on the backend. We can always add more content tests on the frontend if needed.