### PR TITLE
Ability to see recipe manifest via Export action

### DIFF
--- a/components/ListView/ListItemExpandRevisions.js
+++ b/components/ListView/ListItemExpandRevisions.js
@@ -72,7 +72,7 @@ class ListItemExpandRevisions extends React.Component {
                 aria-labelledby="dropdownKebabRight9"
               >
                 <li><a >View Recipe</a></li>
-                <li><a >Export</a></li>
+                <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e)}>Export</a></li>
                 <li role="separator" className="divider"></li>
                 {listItem.active === true &&
                   <li><a >Clone Revision</a></li>
@@ -228,6 +228,7 @@ ListItemExpandRevisions.propTypes = {
   changelog: React.PropTypes.array,
   compositions: React.PropTypes.array,
   recipe: React.PropTypes.string,
+  handleShowModalExport: React.PropTypes.func,
 };
 
 export default ListItemExpandRevisions;

--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -9,6 +9,7 @@ class RecipeListView extends React.Component {
 
   state = { recipe: '' };
 
+  // The following enables the expand/collapse interaction
   // componentDidMount() {
   //   this.bindExpand();
   // }
@@ -96,7 +97,7 @@ class RecipeListView extends React.Component {
                     className="dropdown-menu dropdown-menu-right"
                     aria-labelledby="dropdownKebabRight9"
                   >
-                    <li><a >Export</a></li>
+                    <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e, recipe.name)}>Export</a></li>
                     <li><a href="#" onClick={(e) => this.props.handleDelete(e, recipe.id)}>Archive</a></li>
                   </ul>
                 </div>
@@ -213,6 +214,7 @@ class RecipeListView extends React.Component {
 RecipeListView.propTypes = {
   recipes: React.PropTypes.array,
   setNotifications: React.PropTypes.func,
+  handleShowModalExport: React.PropTypes.func,
 };
 
 export default RecipeListView;

--- a/components/Modal/ExportRecipe.js
+++ b/components/Modal/ExportRecipe.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 class ExportRecipe extends React.Component {
 
-  componentDidMount(){
+  componentDidMount() {
     $(this.modal).modal('show');
     $(this.modal).on('hidden.bs.modal', this.props.handleHideModalExport);
   }
 
-  handleCopy(){
+  handleCopy() {
     this.recipe_contents_text.select();
     document.execCommand('copy');
   }
@@ -61,7 +61,7 @@ class ExportRecipe extends React.Component {
                     className="col-sm-3 control-label"
                     htmlFor="textInput2-modal-markup"
                   >Contents</label>
-                  { this.props.contents &&
+                  {this.props.contents &&
                     <div className="col-sm-9">
                       <textarea
                         readOnly
@@ -69,9 +69,9 @@ class ExportRecipe extends React.Component {
                         ref={(c) => { this.recipe_contents_text = c; }}
                         className="form-control"
                         rows="10"
-                        value={this.props.contents.map(comp => {
-                            return (comp.name + '-' + comp.version + '-' + comp.release)
-                          }).join('\n')}
+                        value={this.props.contents.map((comp) => (
+                          `${comp.name}-${comp.version}-${comp.release}`
+                        )).join('\n')}
                       />
                       <p>{this.props.contents.length} total components</p>
                     </div>

--- a/components/Modal/ExportRecipe.js
+++ b/components/Modal/ExportRecipe.js
@@ -3,12 +3,12 @@ import React from 'react';
 class ExportRecipe extends React.Component {
 
   componentDidMount(){
-    $(this.refs.modal).modal('show');
-    $(this.refs.modal).on('hidden.bs.modal', this.props.handleHideModalExport);
+    $(this.modal).modal('show');
+    $(this.modal).on('hidden.bs.modal', this.props.handleHideModalExport);
   }
 
   handleCopy(){
-    this.refs.recipe_contents_text.select();
+    this.recipe_contents_text.select();
     document.execCommand('copy');
   }
 
@@ -17,7 +17,7 @@ class ExportRecipe extends React.Component {
       <div
         className="modal fade"
         id="cmpsr-modal-export"
-        ref="modal"
+        ref={(c) => { this.modal = c; }}
         tabIndex="-1"
         role="dialog"
         aria-labelledby="myModalLabel"
@@ -66,7 +66,7 @@ class ExportRecipe extends React.Component {
                       <textarea
                         readOnly
                         id="textInput2-modal-markup"
-                        ref="recipe_contents_text"
+                        ref={(c) => { this.recipe_contents_text = c; }}
                         className="form-control"
                         rows="10"
                         value={this.props.contents.map(comp => {

--- a/components/Modal/ExportRecipe.js
+++ b/components/Modal/ExportRecipe.js
@@ -1,0 +1,107 @@
+import React from 'react';
+
+class ExportRecipe extends React.Component {
+
+  componentDidMount(){
+    $(this.refs.modal).modal('show');
+    $(this.refs.modal).on('hidden.bs.modal', this.props.handleHideModalExport);
+  }
+
+  handleCopy(){
+    this.refs.recipe_contents_text.select();
+    document.execCommand('copy');
+  }
+
+  render() {
+    return (
+      <div
+        className="modal fade"
+        id="cmpsr-modal-export"
+        ref="modal"
+        tabIndex="-1"
+        role="dialog"
+        aria-labelledby="myModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <button
+                type="button"
+                className="close"
+                data-dismiss="modal"
+              >
+                <span className="pficon pficon-close"></span>
+              </button>
+              <h4 className="modal-title" id="myModalLabel">Export Recipe</h4>
+            </div>
+            <div className="modal-body">
+              <form className="form-horizontal" onKeyPress={(e) => this.handleEnterKey(e)}>
+                <div className="form-group">
+                  <label
+                    className="col-sm-3 control-label"
+                  >Recipe</label>
+                  <div className="col-sm-9">
+                    <p className="form-control-static">{this.props.recipe}</p>
+                  </div>
+                </div>
+                <div className="form-group">
+                  <label
+                    className="col-sm-3 control-label"
+                    htmlFor="textInput-modal-markup"
+                  >Export as</label>
+                  <div className="col-sm-9">
+                    <select className="form-control">
+                      <option>Text</option>
+                    </select>
+                  </div>
+                </div>
+                <div className="form-group">
+                  <label
+                    className="col-sm-3 control-label"
+                    htmlFor="textInput2-modal-markup"
+                  >Contents</label>
+                  { this.props.contents &&
+                    <div className="col-sm-9">
+                      <textarea
+                        readOnly
+                        id="textInput2-modal-markup"
+                        ref="recipe_contents_text"
+                        className="form-control"
+                        rows="10"
+                        value={this.props.contents.map(comp => {
+                            return (comp.name + '-' + comp.version + '-' + comp.release)
+                          }).join('\n')}
+                      />
+                      <p>{this.props.contents.length} total components</p>
+                    </div>
+                    ||
+                    <div className="col-sm-1">
+                      <div className="spinner"></div>
+                    </div>
+                  }
+                </div>
+              </form>
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-default"
+                data-dismiss="modal"
+              >Close</button>
+              <button type="button" className="btn btn-primary" onClick={() => this.handleCopy()}>Copy</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ExportRecipe.propTypes = {
+  recipe: React.PropTypes.string,
+  contents: React.PropTypes.array,
+  handleHideModalExport: React.PropTypes.func,
+};
+
+export default ExportRecipe;

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Toolbar = () => (
+const Toolbar = (props) => (
 
   <div className="row toolbar-pf">
     <div className="col-sm-12">
@@ -67,7 +67,7 @@ const Toolbar = () => (
                 aria-expanded="false"
               ><span className="fa fa-ellipsis-v"></span></button>
               <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                <li><a >Export</a></li>
+                <li><a href="#" onClick={(e) => props.handleShowModalExport(e)}>Export</a></li>
                 <li role="separator" className="divider"></li>
                 <li><a >Update Selected Components</a></li>
                 <li><a >Remove Selected Components</a></li>
@@ -128,5 +128,9 @@ const Toolbar = () => (
     </div>
   </div>
 );
+
+Toolbar.propTypes = {
+  handleShowModalExport: React.PropTypes.func,
+};
 
 export default Toolbar;

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -719,8 +719,10 @@ class RecipePage extends React.Component {
                       >Edit Recipe</Link>
                       <button
                         className="btn btn-default"
+                        id="cmpsr-btn-crt-compos"
+                        data-toggle="modal"
+                        data-target="#cmpsr-modal-crt-compos"
                         type="button"
-                        onClick={(e) => this.handleShowModalCreateComp(e)}
                       >Create Composition</button>
                       <div className="dropdown btn-group  dropdown-kebab-pf">
                         <button
@@ -796,8 +798,10 @@ class RecipePage extends React.Component {
               >
                 <button
                   className="btn btn-default"
+                  id="cmpsr-btn-crt-compos"
+                  data-toggle="modal"
+                  data-target="#cmpsr-modal-crt-compos"
                   type="button"
-                  onClick={(e) => this.handleShowModalCreateComp(e)}
                 >Create Composition</button>
               </EmptyState>
             ||
@@ -817,14 +821,10 @@ class RecipePage extends React.Component {
             <p>Errata</p>
           </Tab>
         </Tabs>
-        {this.state.modalCreateComp ?
-          <CreateComposition
-            recipe={this.state.recipe.name}
-            setNotifications={this.setNotifications}
-            handleHideModalCreateComp={this.handleHideModalCreateComp}
-          /> :
-          null
-        }
+        <CreateComposition
+          recipe={this.state.recipe.name}
+          setNotifications={this.setNotifications}
+        />
         {this.state.modalExport ?
           <ExportRecipe
             recipe={this.state.recipe.name}

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -5,6 +5,7 @@ import { Tab, Tabs } from 'react-patternfly-shims';
 import RecipeContents from '../../components/ListView/RecipeContents';
 import ComponentDetailsView from '../../components/ListView/ComponentDetailsView';
 import CreateComposition from '../../components/Modal/CreateComposition';
+import ExportRecipe from '../../components/Modal/ExportRecipe';
 import EmptyState from '../../components/EmptyState/EmptyState';
 import ListView from '../../components/ListView/ListView';
 import ListItemExpandRevisions from '../../components/ListView/ListItemExpandRevisions';
@@ -30,6 +31,7 @@ class RecipePage extends React.Component {
     selectedComponentParent: '',
     inlineEditDescription: false,
     inlineEditDescriptionValue: '',
+    modalExport: false,
     revisions: [
       {
         number: '3',
@@ -231,6 +233,15 @@ class RecipePage extends React.Component {
     this.setState({ inlineEditDescriptionValue: event.target.value });
   }
 
+  // handle show/hide of modal dialogs
+  handleHideModalExport = () => {
+    this.setState({ modalExport: false });
+  }
+  handleShowModalExport = (e) => {
+    this.setState({ modalExport: true });
+    e.preventDefault();
+    e.stopPropagation();
+  }
   render() {
     const activeRevision = this.state.revisions.filter((obj) => obj.active === true)[0];
     const pastRevisions = this.state.revisions.filter((obj) => obj.active === false);
@@ -279,7 +290,7 @@ class RecipePage extends React.Component {
                           aria-expanded="false"
                         ><span className="fa fa-ellipsis-v"></span></button>
                         <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a>Export</a></li>
+                          <li><a href="#" onClick={(e) => this.handleShowModalExport(e)}>Export</a></li>
                         </ul>
                       </div>
                     </div>
@@ -502,7 +513,7 @@ class RecipePage extends React.Component {
                               aria-expanded="false"
                             ><span className="fa fa-ellipsis-v"></span></button>
                             <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                              <li><a >Export</a></li>
+                              <li><a href="#" onClick={(e) => this.handleShowModalExport(e)}>Export</a></li>
                             </ul>
                           </div>
                         </div>
@@ -669,6 +680,7 @@ class RecipePage extends React.Component {
                 changelog={this.state.changelog}
                 compositions={this.state.compositions}
                 listItem={activeRevision}
+                handleShowModalExport={this.handleShowModalExport}
               />
               <div className="list-group-item list-group-item__separator">
                 <div className="list-view-pf-main-info">
@@ -689,6 +701,7 @@ class RecipePage extends React.Component {
                   changelog={this.state.changelog}
                   compositions={this.state.compositions}
                   listItem={revision}
+                  handleShowModalExport={this.handleShowModalExport}
                   key={i}
                 />
               )}
@@ -706,10 +719,8 @@ class RecipePage extends React.Component {
                       >Edit Recipe</Link>
                       <button
                         className="btn btn-default"
-                        id="cmpsr-btn-crt-compos"
-                        data-toggle="modal"
-                        data-target="#cmpsr-modal-crt-compos"
                         type="button"
+                        onClick={(e) => this.handleShowModalCreateComp(e)}
                       >Create Composition</button>
                       <div className="dropdown btn-group  dropdown-kebab-pf">
                         <button
@@ -721,7 +732,7 @@ class RecipePage extends React.Component {
                           aria-expanded="false"
                         ><span className="fa fa-ellipsis-v"></span></button>
                         <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a >Export</a></li>
+                          <li><a href="#" onClick={(e) => this.handleShowModalExport(e)}>Export</a></li>
                         </ul>
                       </div>
                     </div>
@@ -785,13 +796,9 @@ class RecipePage extends React.Component {
               >
                 <button
                   className="btn btn-default"
-                  id="cmpsr-btn-crt-compos"
-                  data-toggle="modal"
-                  data-target="#cmpsr-modal-crt-compos"
                   type="button"
-                >
-                  Create Composition
-                </button>
+                  onClick={(e) => this.handleShowModalCreateComp(e)}
+                >Create Composition</button>
               </EmptyState>
             ||
               <ListView id="cmpsr-recipe-compositions" >
@@ -810,10 +817,22 @@ class RecipePage extends React.Component {
             <p>Errata</p>
           </Tab>
         </Tabs>
-        <CreateComposition
-          recipe={this.state.recipe.name}
-          setNotifications={this.setNotifications}
-        />
+        {this.state.modalCreateComp ?
+          <CreateComposition
+            recipe={this.state.recipe.name}
+            setNotifications={this.setNotifications}
+            handleHideModalCreateComp={this.handleHideModalCreateComp}
+          /> :
+          null
+        }
+        {this.state.modalExport ?
+          <ExportRecipe
+            recipe={this.state.recipe.name}
+            contents={this.state.dependencies}
+            handleHideModalExport={this.handleHideModalExport}
+          /> :
+          null
+        }
       </Layout>
     );
   }

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -5,6 +5,7 @@ import RecipeContents from '../../components/ListView/RecipeContents';
 import ComponentInputs from '../../components/ListView/ComponentInputs';
 import ComponentDetailsView from '../../components/ListView/ComponentDetailsView';
 import CreateComposition from '../../components/Modal/CreateComposition';
+import ExportRecipe from '../../components/Modal/ExportRecipe';
 import EmptyState from '../../components/EmptyState/EmptyState';
 import Pagination from '../../components/Pagination/Pagination';
 import Toolbar from '../../components/Toolbar/Toolbar';
@@ -31,6 +32,7 @@ class EditRecipePage extends React.Component {
     inputComponents: [[]], inputFilters: [], filteredComponents: [[]],
     selectedComponent: '', selectedComponentStatus: '', selectedComponentParent: '',
     selectedInputPage: 0, inputPageSize: 50, totalInputs: 0, totalFilteredInputs: 0,
+    modalExport: false,
   };
 
   componentWillMount() {
@@ -451,6 +453,16 @@ class EditRecipePage extends React.Component {
     return ([page, index]);
   }
 
+  // handle show/hide of modal dialogs
+  handleHideModalExport = () => {
+    this.setState({ modalExport: false });
+  }
+  handleShowModalExport = (e) => {
+    this.setState({ modalExport: true });
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   render() {
     const recipeDisplayName = this.props.route.params.recipe;
 
@@ -485,7 +497,7 @@ class EditRecipePage extends React.Component {
 
           {this.state.selectedComponent === '' &&
             <div className="col-sm-7 col-md-8 col-sm-push-5 col-md-push-4" id="cmpsr-recipe-list-edit">
-              <Toolbar />
+              <Toolbar handleShowModalExport={this.handleShowModalExport} />
             {this.state.recipeComponents.length === 0 &&
               <EmptyState
                 title={'Add Recipe Components'}
@@ -612,6 +624,14 @@ class EditRecipePage extends React.Component {
           recipe={this.state.recipe.name}
           setNotifications={this.setNotifications}
         />
+        {this.state.modalExport ?
+          <ExportRecipe
+            recipe={this.state.recipe.name}
+            contents={this.state.recipeDependencies}
+            handleHideModalExport={this.handleHideModalExport}
+          /> :
+          null
+        }
 
       </Layout>
 

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -78,7 +78,7 @@ class RecipesPage extends React.Component {
   }
   handleShowModalExport = (e, recipe) => {
     // This implementation of the dialog only provides a text option, and it's
-    // automatically selected. Eventually, the following code should move to a 
+    // automatically selected. Eventually, the following code should move to a
     // separate function that is called when the user selects the text option
 
     // display the dialog, a spinner will display while contents are undefined
@@ -89,7 +89,7 @@ class RecipesPage extends React.Component {
     const recipeName = recipe.replace(/\s/g, '-');
     Promise.all([RecipeApi.getRecipe(recipeName)]).then((data) => {
       this.setState({ modalRecipeContents: data[0].dependencies });
-    }).catch(e => console.log(`Error in EditRecipe promise: ${e}`));
+    }).catch(err => console.log(`Error in EditRecipe promise: ${err}`));
     e.preventDefault();
     e.stopPropagation();
   }
@@ -225,9 +225,14 @@ class RecipesPage extends React.Component {
             </div>
           </div>
         </div>
-        <RecipeListView recipes={this.state.recipes} handleDelete={this.handleDelete} setNotifications={this.setNotifications} handleShowModalExport={this.handleShowModalExport} />
+        <RecipeListView
+          recipes={this.state.recipes}
+          handleDelete={this.handleDelete}
+          setNotifications={this.setNotifications}
+          handleShowModalExport={this.handleShowModalExport}
+        />
         <CreateRecipe />
-        { this.state.modalExport ?
+        {this.state.modalExport ?
           <ExportRecipe
             recipe={this.state.modalRecipe}
             contents={this.state.modalRecipeContents}

--- a/public/custom.css
+++ b/public/custom.css
@@ -8,7 +8,12 @@ div.hidden-nav .navbar-pf-vertical { display: none; }
 .toolbar-pf-results-none > div { display: none;}
 [data-toggle] {cursor: pointer;}
 .list-view-pf-additional-info-item .label {margin: .5em 0;}
-/*label {margin-right:5px;} this causes issues in popup dialogs */
+
+/* This is added for the export dialog so that the contents have higher contrast */
+textarea.form-control[readonly] {
+  background-color: inherit;
+  color: inherit;
+}
 
 .tab-container {
   padding: 15px 0;


### PR DESCRIPTION
Includes updates for:
https://trello.com/c/XTe8z9Ef/261-3-manifest-file-include-link-in-ui

Updates include:
- Export action that displays on Recipes, Recipe and Edit
  Recipe pages opens a modal dialog
- dialog includes 'Export as' select menu with only one
  option for now, 'Text'
- For the 'Text' option, a textarea displays listing all
  components as name-version-release, with the total
  number displayed below
- For the 'Text' option, a Copy button displays that will copy
  the contents of the textarea to the clipboard
- When displaying the dialog on the Recipes page, a
  spinner displays in place of the textarea while the contents
  are being retrieved