### PR TITLE
html/css updates for independent scrolling

### DIFF
--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -149,33 +149,28 @@ class ComponentDetailsView extends React.Component {
     const { component } = this.props;
 
     return (
-      <div className="cmpsr-compon-details">
-        {(this.state.parents.length > 0 &&
-          <ol className="breadcrumb">
-            <li>
-              <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>Back to {this.props.parent}</a>
-            </li>
-            {this.state.parents.map((parent, i) => (
-              <li key={i}>
-                <a href="#" onClick={e => this.props.handleComponentDetails(e, parent, this.state.parents[i - 1])}>
-                  {parent.name}
-                </a>
+      <div className="cmpsr-panel__body cmpsr-panel__body--main">
+        <div className="cmpsr-header">
+          {(this.state.parents.length > 0 &&
+            <ol className="breadcrumb">
+              <li>
+                <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>Back to {this.props.parent}</a>
               </li>
-            ))}
-            <li />
-          </ol>) ||
-          <ol className="breadcrumb">
-            <li>
-              <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>Back to {this.props.parent}</a>
-            </li>
-          </ol>}
-        <h3>
-          <span data-item="name">
-            <ComponentTypeIcons componentType={component.ui_type} compDetails componentInRecipe={component.inRecipe} />
-            {' '}
-            {component.name}
-          </span>
-          <div className="pull-right">
+              {this.state.parents.map((parent, i) => (
+                <li key={i}>
+                  <a href="#" onClick={e => this.props.handleComponentDetails(e, parent, this.state.parents[i - 1])}>
+                    {parent.name}
+                  </a>
+                </li>
+              ))}
+              <li />
+            </ol>) ||
+            <ol className="breadcrumb">
+              <li>
+                <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>Back to {this.props.parent}</a>
+              </li>
+            </ol>}
+          <div className="cmpsr-header__actions">
             <ul className="list-inline">
               {this.props.status === 'available' &&
                 <li>
@@ -208,7 +203,7 @@ class ComponentDetailsView extends React.Component {
                     className="btn btn-default"
                     type="button"
                     data-toggle="tooltip"
-                    data-placement="top"
+                    data-placement="bottom"
                     title=""
                     data-original-title="Remove from Recipe"
                     onClick={e => this.props.handleRemoveComponent(e, component)}
@@ -221,7 +216,7 @@ class ComponentDetailsView extends React.Component {
                   type="button"
                   className="close"
                   data-toggle="tooltip"
-                  data-placement="top"
+                  data-placement="bottom"
                   title=""
                   data-original-title="Hide Details"
                   onClick={e => this.props.handleComponentDetails(e, '')}
@@ -231,18 +226,25 @@ class ComponentDetailsView extends React.Component {
               </li>
             </ul>
           </div>
-        </h3>
-
+          <h3 className="cmpsr-title">
+            <span>
+              <ComponentTypeIcons componentType={component.ui_type} compDetails componentInRecipe={component.inRecipe} />
+              {' '}
+              {component.name}
+            </span>
+          </h3>
+        </div>
         {(this.props.status === 'available' || this.state.editSelected === true || this.props.status === 'editSelected') &&
-          <div className="blank-slate-pf">
+          <div className="cmpsr-component-details__form">
+            <h4>Component Options</h4>
             <form className="form-horizontal">
               <div className="form-group">
-                <label className="col-sm-3 col-md-2 control-label" htmlFor="cmpsr-compon-details-version-select">
+                <label className="col-sm-3 col-md-2 control-label" htmlFor="cmpsr-compon__version-select">
                   Version Release
                 </label>
                 <div className="col-sm-8 col-md-9">
                   <select
-                    id="cmpsr-compon-details-version-select"
+                    id="cmpsr-compon__version-select"
                     className="form-control"
                     value={this.state.selectedBuildIndex}
                     onChange={e => this.handleVersionSelect(e)}
@@ -254,11 +256,11 @@ class ComponentDetailsView extends React.Component {
                 </div>
               </div>
               <div className="form-group hidden">
-                <label className="col-sm-3 col-md-2 control-label" htmlFor="cmpsr-compon-details-instprof-select">
+                <label className="col-sm-3 col-md-2 control-label" htmlFor="cmpsr-compon__instprof-select">
                   Install Profile
                 </label>
                 <div className="col-sm-8 col-md-9">
-                  <select id="cmpsr-compon-details-instprof-select" className="form-control">
+                  <select id="cmpsr-compon__instprof-select" className="form-control">
                     <option>Default</option>
                     <option>Debug</option>
                   </select>
@@ -269,7 +271,7 @@ class ComponentDetailsView extends React.Component {
         <div className="nav-tabs-pf">
           <Tabs key="pf-tabs" ref="pfTabs" tabChanged={e => this.handleTabChanged(e)}>
             <Tab tabTitle="Details" active={this.state.activeTab === 'Details'}>
-              <h3 data-item="summary">{this.state.componentData.summary}</h3>
+              <h4 className="cmpsr-title">{this.state.componentData.summary}</h4>
               <p>{this.state.componentData.description}</p>
               <dl className="dl-horizontal">
                 <dt>Type</dt>

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -90,7 +90,7 @@ class ComponentInputs extends React.Component {
               tabIndex="0"
               data-toggle="tooltip"
               data-trigger="manual"
-              data-placement="right"
+              data-placement="top"
               title=""
               data-original-title={component.active ? 'Hide Details' : 'Show Details and More Options'}
               onClick={e => this.props.handleComponentDetails(e, component)}
@@ -109,10 +109,11 @@ class ComponentInputs extends React.Component {
                   {(component.inRecipe === true &&
                     <a
                       href="#"
+                      className="btn btn-link"
                       data-toggle="tooltip"
                       data-trigger="manual"
                       data-html="true"
-                      data-placement="right"
+                      data-placement="top"
                       title=""
                       data-original-title="Remove Component from Recipe"
                       onClick={e => this.props.handleRemoveComponent(e, component)}
@@ -121,10 +122,11 @@ class ComponentInputs extends React.Component {
                     </a>) ||
                     <a
                       href="#"
+                      className="btn btn-link"
                       data-toggle="tooltip"
                       data-trigger="manual"
                       data-html="true"
-                      data-placement="right"
+                      data-placement="top"
                       title=""
                       data-original-title={`Add Component<br />
                             Version&nbsp;<strong>${component.version}</strong>

--- a/components/ListView/ComponentSummaryList.js
+++ b/components/ListView/ComponentSummaryList.js
@@ -19,7 +19,7 @@ class ComponentSummaryList extends React.Component {
       <div className="cmpsr-summary-listview">
         <p>
           <strong>Dependencies</strong>
-          <span> ({this.props.listItems.length} First Level, --- Total) </span>
+          <span className="badge">{this.props.listItems.length}</span>
           <a href="#" className="pull-right" onClick={e => this.handleShowAll(e)}>
             {`${this.state.showAll ? 'Show Less' : 'Show All'}`}
           </a>

--- a/components/ListView/RecipeContents.js
+++ b/components/ListView/RecipeContents.js
@@ -13,18 +13,7 @@ class RecipeContents extends React.Component {
 
   state = {
     activeTab: 'Components',
-    depsTabTitle: 'Dependencies',
   };
-
-  componentWillReceiveProps(newProps) {
-    if (newProps.dependencies.length > 0) {
-      this.setState({ depsTabTitle: `Dependencies <span class="badge">${newProps.dependencies.length}</span>` });
-    } else {
-      this.setState({ depsTabTitle: 'Dependencies' });
-    }
-  }
-  // Not sure why this doesn't work. The Virtual DOM seems to be updated but the actual DOM is not
-  // Maybe this is due to using a web component instead of react component for tabs
 
   handleTabChanged(e) {
     if (this.state.activeTab !== e.detail) {
@@ -46,10 +35,7 @@ class RecipeContents extends React.Component {
           }}
           tabChanged={this.handleTabChanged}
         >
-          <Tab
-            tabTitle={`Selected Components <span class="badge">${components.length}</span>`}
-            active={this.state.activeTab === 'Selected'}
-          >
+          <Tab tabTitle="Selected Components" active={this.state.activeTab === 'Selected'}>
             <ListView className="cmpsr-recipe__components" stacked>
               {components.map((listItem, i) => (
                 <ListItemComponents
@@ -63,7 +49,7 @@ class RecipeContents extends React.Component {
               ))}
             </ListView>
           </Tab>
-          <Tab tabTitle={this.state.depsTabTitle} active={this.state.activeTab === 'Dependencies'}>
+          <Tab tabTitle="Dependencies" active={this.state.activeTab === 'Dependencies'}>
             <DependencyListView
               className="cmpsr-recipe__dependencies"
               listItems={dependencies}

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -2,32 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Toolbar = props => (
-  <div className="row toolbar-pf">
-    <div className="col-sm-12">
-      <form className="toolbar-pf-actions">
-        <div className="form-group toolbar-pf-filter">
-          <label className="sr-only" htmlFor="filter">Name</label>
-          <div className="input-group">
-            <div className="input-group-btn">
-              <button
-                type="button"
-                className="btn btn-default dropdown-toggle"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-              >
-                Name<span className="caret" />
-              </button>
-              <ul className="dropdown-menu">
-                <li><a>Name</a></li>
-                <li><a>Version</a></li>
-              </ul>
-            </div>
-            <input type="text" className="form-control" id="filter" placeholder="Filter By Name..." />
-          </div>
-        </div>
-        <div className="form-group">
-          <div className="dropdown btn-group">
+  <div className="toolbar-pf">
+    <form className="toolbar-pf-actions">
+      <div className="form-group toolbar-pf-filter">
+        <label className="sr-only" htmlFor="filter">Name</label>
+        <div className="input-group">
+          <div className="input-group-btn">
             <button
               type="button"
               className="btn btn-default dropdown-toggle"
@@ -42,65 +22,82 @@ const Toolbar = props => (
               <li><a>Version</a></li>
             </ul>
           </div>
-          <button className="btn btn-link" type="button">
-            <span className="fa fa-sort-alpha-asc" />
+          <input type="text" className="form-control" id="filter" placeholder="Filter By Name..." />
+        </div>
+      </div>
+      <div className="form-group">
+        <div className="dropdown btn-group">
+          <button
+            type="button"
+            className="btn btn-default dropdown-toggle"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
+          >
+            Name<span className="caret" />
           </button>
+          <ul className="dropdown-menu">
+            <li><a>Name</a></li>
+            <li><a>Version</a></li>
+          </ul>
         </div>
+        <button className="btn btn-link" type="button">
+          <span className="fa fa-sort-alpha-asc" />
+        </button>
+      </div>
 
-        <div className="toolbar-pf-action-right">
-          <div className="form-group">
+      <div className="toolbar-pf-action-right">
+        <div className="form-group">
+          <button
+            className="btn btn-default"
+            id="cmpsr-btn-crt-compos"
+            data-toggle="modal"
+            data-target="#cmpsr-modal-crt-compos"
+            type="button"
+          >
+            Create Composition
+          </button>
+          <div className="dropdown btn-group  dropdown-kebab-pf">
             <button
-              className="btn btn-default"
-              id="cmpsr-btn-crt-compos"
-              data-toggle="modal"
-              data-target="#cmpsr-modal-crt-compos"
+              className="btn btn-link dropdown-toggle"
               type="button"
+              id="dropdownKebab"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false"
             >
-              Create Composition
+              <span className="fa fa-ellipsis-v" />
             </button>
-            <div className="dropdown btn-group  dropdown-kebab-pf">
-              <button
-                className="btn btn-link dropdown-toggle"
-                type="button"
-                id="dropdownKebab"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-              >
-                <span className="fa fa-ellipsis-v" />
-              </button>
-              <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                <li><a href="#" onClick={e => props.handleShowModal(e, 'modalExport')}>Export</a></li>
-                <li role="separator" className="divider" />
-                <li><a>Update Selected Components</a></li>
-                <li><a>Remove Selected Components</a></li>
-              </ul>
-            </div>
+            <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
+              <li><a href="#" onClick={e => props.handleShowModal(e, 'modalExport')}>Export</a></li>
+              <li role="separator" className="divider" />
+              <li><a>Update Selected Components</a></li>
+              <li><a>Remove Selected Components</a></li>
+            </ul>
           </div>
-          <div className="form-group toolbar-pf-find">
-            <button className="btn btn-link btn-find" type="button">
-              <span className="fa fa-search" />
-            </button>
-            <div className="find-pf-dropdown-container">
-              <input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
-              <div className="find-pf-buttons">
-                <span className="find-pf-nums">1 of 3</span>
-                <button className="btn btn-link" type="button">
-                  <span className="fa fa-angle-up" />
-                </button>
-                <button className="btn btn-link" type="button">
-                  <span className="fa fa-angle-down" />
-                </button>
-                <button className="btn btn-link btn-find-close" type="button">
-                  <span className="pficon pficon-close" />
-                </button>
-              </div>
+        </div>
+        <div className="form-group toolbar-pf-find">
+          <button className="btn btn-link btn-find" type="button">
+            <span className="fa fa-search" />
+          </button>
+          <div className="find-pf-dropdown-container">
+            <input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
+            <div className="find-pf-buttons">
+              <span className="find-pf-nums">1 of 3</span>
+              <button className="btn btn-link" type="button">
+                <span className="fa fa-angle-up" />
+              </button>
+              <button className="btn btn-link" type="button">
+                <span className="fa fa-angle-down" />
+              </button>
+              <button className="btn btn-link btn-find-close" type="button">
+                <span className="pficon pficon-close" />
+              </button>
             </div>
           </div>
         </div>
-      </form>
-
-    </div>
+      </div>
+    </form>
   </div>
 );
 

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -249,17 +249,19 @@ class RecipePage extends React.Component {
     const pastRevisions = this.state.revisions.filter(obj => obj.active === false);
     return (
       <Layout className="container-fluid container-pf-nav-pf-vertical" ref="layout">
-        <ol className="breadcrumb">
-          <li><Link to="/recipes">Back to Recipes</Link></li>
-          <li className="active"><strong>{this.props.route.params.recipe}</strong></li>
-        </ol>
-        <div className="cmpsr-header__title">
-          <h1 className="cmpsr-header__title__item">{this.props.route.params.recipe}</h1>
-          <p className="cmpsr-header__title__item">
-            Current Revision: 3
-            {this.state.recipe.description && <span className="text-muted">, {this.state.recipe.description}</span>}
-          </p>
-        </div>
+        <header className="cmpsr-header">
+          <ol className="breadcrumb">
+            <li><Link to="/recipes">Back to Recipes</Link></li>
+            <li className="active"><strong>{this.props.route.params.recipe}</strong></li>
+          </ol>
+          <div className="cmpsr-title">
+            <h1 className="cmpsr-title__item">{this.props.route.params.recipe}</h1>
+            <p className="cmpsr-title__item">
+              Current Revision: 3
+              {this.state.recipe.description && <span className="text-muted">, {this.state.recipe.description}</span>}
+            </p>
+          </div>
+        </header>
         <Tabs key="pf-tabs" ref="pfTabs" tabChanged={this.handleTabChanged}>
           <Tab tabTitle="Details" active={this.state.activeTab === 'Details'}>
             <div className="row toolbar-pf">
@@ -373,14 +375,14 @@ class RecipePage extends React.Component {
                         <div className="list-pf-container">
                           <div className="list-pf-content list-pf-content-flex ">
                             <div className="list-pf-left">
-                              <span className="pf-icon pficon-user list-pf-icon-small text-muted" aria-hidden="true" />
+                              <span className="fa fa-comment-o list-pf-icon-small text-muted" aria-hidden="true" />
                             </div>
                             <div className="list-pf-content-wrapper">
                               <div className="list-pf-main-content">
                                 <div className="list-pf-title ">
-                                  {comment.user}
+                                  Revision {comment.revision}, {comment.date}
                                   <span className="text-muted pull-right">
-                                    Revision {comment.revision}, {comment.date}
+                                    {comment.user}
                                   </span>
                                 </div>
                                 <div className="list-pf-description ">
@@ -533,7 +535,8 @@ class RecipePage extends React.Component {
                       handleComponentDetails={this.handleComponentDetails}
                     />}
                 </div>) ||
-                <div className="col-sm-12">
+                <div className="col-sm-12 cmpsr-component-details--view">
+                  <h3 className="cmpsr-panel__title cmpsr-panel__title--main">Component Details</h3>
                   <ComponentDetailsView
                     parent={this.props.route.params.recipe}
                     component={this.state.selectedComponent}

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -501,180 +501,160 @@ class EditRecipePage extends React.Component {
 
     return (
       <Layout
-        className="container-fluid container-pf-nav-pf-vertical"
+        className="container-pf-nav-pf-vertical cmpsr-grid__wrapper"
         ref={c => {
           this.layout = c;
         }}
       >
-        <div className="cmpsr-header__actions pull-right">
-          <ul className="list-inline">
-            <li className="text-muted">
-              3 changes
-            </li>
-            <li>
-              <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>View and Comment</a>
-            </li>
-            <li>
-              <button className="btn btn-primary" type="button" onClick={e => this.handleSave(e)}>Save</button>
-            </li>
-            <li>
-              <button className="btn btn-default" type="button">Discard Changes</button>
-            </li>
-          </ul>
-        </div>
-        <ol className="breadcrumb">
-          <li><Link to="/recipes">Back to Recipes</Link></li>
-          <li><Link to={`/recipe/${recipeDisplayName}`}>{recipeDisplayName}</Link></li>
-          <li className="active"><strong>Edit Recipe</strong></li>
-        </ol>
-        <div className="cmpsr-header__title">
-          <h1 className="cmpsr-header__title__item">{recipeDisplayName}</h1>
-          <p className="cmpsr-header__title__item">
-            Revision 3<span className="hidden">{this.state.recipe.version}</span>
-            <span className="text-muted">, Total Disk Space: 1,234 KB</span>
-          </p>
-        </div>
-        <div className="row">
-
-          {(this.state.selectedComponent === '' &&
-            <div className="col-sm-7 col-md-8 col-sm-push-5 col-md-push-4 cmpsr-recipe--edit">
-              <div className="panel panel-default">
-                <div className="panel-heading">
-                  <h3 className="panel-title">Recipe Components</h3>
-                </div>
-                <div className="panel-body">
-                  <Toolbar handleShowModal={this.handleShowModal} />
-                  {(this.state.recipeComponents.length === 0 &&
-                    <EmptyState
-                      title={'Add Recipe Components'}
-                      message={'Browse or search for components, then add them to the recipe.'}
-                    />) ||
-                    <RecipeContents
-                      components={this.state.recipeComponents}
-                      dependencies={this.state.recipeDependencies}
-                      handleRemoveComponent={this.handleRemoveComponent}
-                      handleComponentDetails={this.handleComponentDetails}
-                    />}
-                </div>
-              </div>
-            </div>) ||
-            <div className="col-sm-7 col-md-8 col-sm-push-5 col-md-push-4 cmpsr-recipe__details cmpsr-recipe__details--edit">
-              <ComponentDetailsView
-                parent={recipeDisplayName}
-                component={this.state.selectedComponent}
-                componentParent={this.state.selectedComponentParent}
-                status={this.state.selectedComponentStatus}
-                handleComponentDetails={this.handleComponentDetails}
-                handleAddComponent={this.handleAddComponent}
-                handleUpdateComponent={this.handleUpdateComponent}
+        <header className="cmpsr-header">
+          <ol className="breadcrumb">
+            <li><Link to="/recipes">Back to Recipes</Link></li>
+            <li><Link to={`/recipe/${recipeDisplayName}`}>{recipeDisplayName}</Link></li>
+            <li className="active"><strong>Edit Recipe</strong></li>
+          </ol>
+          <div className="cmpsr-header__actions">
+            <ul className="list-inline">
+              <li className="text-muted">
+                3 changes
+              </li>
+              <li>
+                <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>View and Comment</a>
+              </li>
+              <li>
+                <button className="btn btn-primary" type="button" onClick={e => this.handleSave(e)}>Save</button>
+              </li>
+              <li>
+                <button className="btn btn-default" type="button">Discard Changes</button>
+              </li>
+            </ul>
+          </div>
+          <div className="cmpsr-title">
+            <h1 className="cmpsr-title__item">{recipeDisplayName}</h1>
+            <p className="cmpsr-title__item">
+              Revision 3<span className="hidden">{this.state.recipe.version}</span>
+              <span className="text-muted">, Total Disk Space: 1,234 KB</span>
+            </p>
+          </div>
+        </header>
+        {(this.state.selectedComponent === '' &&
+          <h3 className="cmpsr-panel__title cmpsr-panel__title--main">Recipe Components</h3>) ||
+          <h3 className="cmpsr-panel__title cmpsr-panel__title--main">Component Details</h3>}
+        {(this.state.selectedComponent === '' &&
+          <div className="cmpsr-panel__body cmpsr-panel__body--main">
+            <Toolbar handleShowModal={this.handleShowModal} />
+            {(this.state.recipeComponents.length === 0 &&
+              <EmptyState
+                title={'Add Recipe Components'}
+                message={'Browse or search for components, then add them to the recipe.'}
+              />) ||
+              <RecipeContents
+                components={this.state.recipeComponents}
+                dependencies={this.state.recipeDependencies}
                 handleRemoveComponent={this.handleRemoveComponent}
-              />
-            </div>}
+                handleComponentDetails={this.handleComponentDetails}
+              />}
+          </div>) ||
+          <ComponentDetailsView
+            parent={recipeDisplayName}
+            component={this.state.selectedComponent}
+            componentParent={this.state.selectedComponentParent}
+            status={this.state.selectedComponentStatus}
+            handleComponentDetails={this.handleComponentDetails}
+            handleAddComponent={this.handleAddComponent}
+            handleUpdateComponent={this.handleUpdateComponent}
+            handleRemoveComponent={this.handleRemoveComponent}
+          />}
 
-          <div className="col-sm-5 col-md-4 col-sm-pull-7 col-md-pull-8 sidebar-pf cmpsr-recipe__inputs">
+        <h3 className="cmpsr-panel__title cmpsr-panel__title--sidebar">Available Components</h3>
+        <div className="cmpsr-panel__body cmpsr-panel__body--sidebar">
 
-            <div className="panel panel-default">
-              <div className="panel-heading">
-                <h3 className="panel-title">Available Components</h3>
-              </div>
-              <div className="panel-body">
-
-                <div className="row toolbar-pf">
-                  <div className="col-sm-12">
-                    <form className="toolbar-pf-actions">
-                      <div className="form-group toolbar-pf-filter">
-                        <label className="sr-only" htmlFor="cmpsr-recipe-input-filter">Name</label>
-                        <div className="input-group">
-                          <div className="input-group-btn">
-                            <button
-                              type="button"
-                              className="btn btn-default dropdown-toggle"
-                              data-toggle="dropdown"
-                              aria-haspopup="true"
-                              aria-expanded="false"
-                            >
-                              Name <span className="caret" />
-                            </button>
-                            <ul className="dropdown-menu">
-                              <li><a href="#">Type</a></li>
-                              <li><a href="#">Name</a></li>
-                              <li><a href="#">Version</a></li>
-                              <li><a href="#">Release</a></li>
-                              <li><a href="#">Lifecycle</a></li>
-                              <li><a href="#">Support Level</a></li>
-                            </ul>
-                          </div>
-                          <input
-                            type="text"
-                            className="form-control"
-                            id="cmpsr-recipe-input-filter"
-                            placeholder="Filter By Name..."
-                            onKeyPress={e => this.getFilteredInputs(e)}
-                          />
-                        </div>
-                      </div>
-                      <div className="toolbar-pf-action-right">
-                        <div className="form-group toolbar-pf-settings">
-                          <button
-                            className="btn btn-link btn-settings"
-                            type="button"
-                            data-toggle="modal"
-                            data-target="#cmpsr-recipe-inputs-settings"
-                          >
-                            <span className="pf-icon pficon-settings" />
-                          </button>
-                        </div>
-                      </div>
-                    </form>
-                    <div className="row toolbar-pf-results">
-                      <div className="col-sm-12">
-                        {this.state.inputFilters.length > 0 &&
-                          <ul className="list-inline">
-                            <li>
-                              <span className="label label-info">
-                                Name: {this.state.inputFilters[0].value}
-                                <a href="#" onClick={e => this.handleClearFilters(e)}>
-                                  <span className="pficon pficon-close" />
-                                </a>
-                              </span>
-                            </li>
-                            <li>
-                              <a href="#" onClick={e => this.handleClearFilters(e)}>Clear All Filters</a>
-                            </li>
-                          </ul>}
-                        <Pagination
-                          cssClass="cmpsr-recipe__inputs__pagination"
-                          currentPage={this.state.selectedInputPage}
-                          totalItems={
-                            (this.state.inputFilters.length === 0 && this.state.totalInputs) || this.state.totalFilteredInputs
-                          }
-                          pageSize={this.state.inputPageSize}
-                          handlePagination={this.handlePagination}
-                        />
-                      </div>
-                    </div>
+          <div className="toolbar-pf">
+            <form className="toolbar-pf-actions">
+              <div className="form-group toolbar-pf-filter">
+                <label className="sr-only" htmlFor="cmpsr-recipe-input-filter">Name</label>
+                <div className="input-group">
+                  <div className="input-group-btn">
+                    <button
+                      type="button"
+                      className="btn btn-default dropdown-toggle"
+                      data-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      Name <span className="caret" />
+                    </button>
+                    <ul className="dropdown-menu">
+                      <li><a href="#">Type</a></li>
+                      <li><a href="#">Name</a></li>
+                      <li><a href="#">Version</a></li>
+                      <li><a href="#">Release</a></li>
+                      <li><a href="#">Lifecycle</a></li>
+                      <li><a href="#">Support Level</a></li>
+                    </ul>
                   </div>
+                  <input
+                    type="text"
+                    className="form-control"
+                    id="cmpsr-recipe-input-filter"
+                    placeholder="Filter By Name..."
+                    onKeyPress={e => this.getFilteredInputs(e)}
+                  />
                 </div>
-
-                <div className="alert alert-info alert-dismissable">
-                  <button type="button" className="close" data-dismiss="alert" aria-hidden="true">
-                    <span className="pficon pficon-close" />
-                  </button>
-                  <span className="pficon pficon-info" />
-                  <strong>Select components</strong> in this list to add to the recipe.
-                </div>
-                <ComponentInputs
-                  components={
-                    (this.state.inputFilters.length === 0 && this.state.inputComponents[this.state.selectedInputPage]) ||
-                      this.state.filteredComponents[this.state.selectedInputPage]
-                  }
-                  handleComponentDetails={this.handleComponentDetails}
-                  handleAddComponent={this.handleAddComponent}
-                  handleRemoveComponent={this.handleRemoveComponent}
-                />
               </div>
+              <div className="toolbar-pf-action-right">
+                <div className="form-group toolbar-pf-settings">
+                  <button
+                    className="btn btn-link btn-settings"
+                    type="button"
+                    data-toggle="modal"
+                    data-target="#cmpsr-recipe-inputs-settings"
+                  >
+                    <span className="pf-icon pficon-settings" />
+                  </button>
+                </div>
+              </div>
+            </form>
+            <div className="toolbar-pf-results">
+              {this.state.inputFilters.length > 0 &&
+                <ul className="list-inline">
+                  <li>
+                    <span className="label label-info">
+                      Name: {this.state.inputFilters[0].value}
+                      <a href="#" onClick={e => this.handleClearFilters(e)}>
+                        <span className="pficon pficon-close" />
+                      </a>
+                    </span>
+                  </li>
+                  <li>
+                    <a href="#" onClick={e => this.handleClearFilters(e)}>Clear All Filters</a>
+                  </li>
+                </ul>}
+              <Pagination
+                cssClass="cmpsr-recipe__inputs__pagination"
+                currentPage={this.state.selectedInputPage}
+                totalItems={(this.state.inputFilters.length === 0 && this.state.totalInputs) || this.state.totalFilteredInputs}
+                pageSize={this.state.inputPageSize}
+                handlePagination={this.handlePagination}
+              />
             </div>
           </div>
+
+          <div className="alert alert-info alert-dismissable">
+            <button type="button" className="close" data-dismiss="alert" aria-hidden="true">
+              <span className="pficon pficon-close" />
+            </button>
+            <span className="pficon pficon-info" />
+            <strong>Select components</strong> in this list to add to the recipe.
+          </div>
+          <ComponentInputs
+            components={
+              (this.state.inputFilters.length === 0 && this.state.inputComponents[this.state.selectedInputPage]) ||
+                this.state.filteredComponents[this.state.selectedInputPage]
+            }
+            handleComponentDetails={this.handleComponentDetails}
+            handleAddComponent={this.handleAddComponent}
+            handleRemoveComponent={this.handleRemoveComponent}
+          />
         </div>
         <CreateComposition recipe={this.state.recipe.name} setNotifications={this.setNotifications} />
         {this.state.modal === 'modalExport'

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,4 +1,3 @@
-
 [data-toggle] {
   cursor: pointer;
 }
@@ -7,19 +6,202 @@ textarea.form-control[readonly] {
   background-color: inherit;
   color: inherit;
 }
-
+/* Recipe Edit layout */
+.cmpsr-grid__wrapper {
+  display: grid;
+  display: -ms-grid;
+  grid-template-columns: 1fr 2fr;
+  -ms-grid-columns: 1fr 2fr;
+  grid-template-rows: auto auto 1fr;
+  -ms-grid-rows: auto auto 1fr;
+  grid-template-areas:
+    "header header"
+    "inputsTitle editTitle"
+    "inputs edit";
+  overflow: auto;
+  position: absolute;
+  top: 60px;
+  bottom: 0;
+}
 /* Recipe Edit page header */
-.cmpsr-header__actions {
-  padding: 8px 0 8px 15px;
+.cmpsr-grid__wrapper .cmpsr-header {
+  grid-area: header;
+  -ms-grid-column: 1;
+  -ms-span-columns: 2;
+  -ms-grid-row: 1;
+  margin: 0 20px;
 }
-.cmpsr-header__title {
+/* Recipe Edit panels */
+.cmpsr-panel__title {
+  border: 1px solid #d1d1d1;
+  background: #f2f2f2;
+  padding: 10px 20px;
+  font-size: 14px;
+  color: inherit;
+  font-weight: bold;
+  margin: 0;
+}
+.cmpsr-panel__title--sidebar {
+  grid-area: inputsTitle;
+  -ms-grid-column: 1;
+  -ms-grid-row: 2;
+  margin-right: -1px;
+}
+.cmpsr-panel__title--main {
+  grid-area: editTitle;
+  -ms-grid-column: 2;
+  -ms-grid-row: 2;
+}
+.cmpsr-panel__body {
+  border-width: 0 1px 1px;
+  border-style: solid;
+  border-color: #d1d1d1;
+}
+.cmpsr-panel__body--sidebar {
+  grid-area: inputs;
+  -ms-grid-column: 1;
+  -ms-grid-row: 3;
+  margin-right: -1px;
+}
+.cmpsr-panel__body--main {
+  grid-area: edit;
+  -ms-grid-column: 2;
+  -ms-grid-row: 3;
+}
+/* Recipe Edit panel contents */
+.cmpsr-grid__wrapper .cmpsr-panel__body {
+  overflow: auto;
+  min-height: -webkit-min-content;
+  min-height: -moz-min-content;
+  min-height: min-content;
+  position: relative;
+}
+.cmpsr-panel__body .toolbar-pf {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  padding: 0;
+}
+.cmpsr-panel__body .toolbar-pf .btn-link {
+  border: none;
+}
+.cmpsr-panel__body > * {
+  margin: 0 20px;
+}
+.cmpsr-panel__body .toolbar-pf {
+  margin: 0;
+}
+.cmpsr-panel__body .toolbar-pf > * {
+  padding: 0 20px;
+}
+.cmpsr-panel__body  .toolbar-pf .toolbar-pf-actions {
+  padding: 10px 20px 0 20px;
+  margin: 0 0 10px 0;
+}
+.cmpsr-panel__body--view {
+  margin-left: -20px;
+  margin-right: -20px;
+}
+.cmpsr-panel__body .list-pf {
+  border-bottom: none;
+}
+ /* Recipe view */
+ .cmpsr-pg__recipe-view {
+   padding: 0 20px;
+ }
+
+ /* page header */
+.cmpsr-header {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: baseline;
-  margin-top: 20px;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
 }
-.cmpsr-header__title__item {
-  margin-right: 10px;
-  margin-top: 0;
+.cmpsr-header > * {
+  margin: 8px 0 0 0;
+  padding: 0
+}
+.cmpsr-header__actions .list-inline {
+  margin: 0;
+}
+.cmpsr-header__actions .list-inline > li {
+  vertical-align: middle;
+}
+.cmpsr-header__actions .list-inline > li:last-child {
+  padding-right: 0;
+}
+.cmpsr-header__actions .list-inline > li:first-child {
+  padding-left: 0;
+}
+.cmpsr-title {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline;
+  -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+.cmpsr-title__item {
+  margin: 0 10px 0 0;
+}
+
+/* List view */
+/*.cmpsr-list-pf*/
+.cmpsr-list-pf .list-pf-expansion .list-pf-container {
+  display: block;
+} /* TODO: remove and switch to flexbox for expanded contents */
+.cmpsr-list-pf .list-pf-main-content {
+  -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+}
+.cmpsr-list-pf .list-pf-additional-content {
+  -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
+  -webkit-box-pack: start;
+      -ms-flex-pack: start;
+          justify-content: flex-start;
+  -ms-flex-wrap: nowrap;
+      flex-wrap: nowrap;
+}
+.cmpsr-list-pf .list-view-pf-additional-info-item {
+  -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+  -webkit-box-align: left;
+      -ms-flex-align: left;
+          align-items: left;
+}
+@media (min-width: 992px) {
+  .cmpsr-list-pf .list-pf-main-content {
+    -ms-flex-preferred-size: 50%;
+        flex-basis: 50%;
+  }
+  .cmpsr-list-pf .list-pf-additional-content {
+    -ms-flex-preferred-size: 50%;
+        flex-basis: 50%;
+    -ms-flex-pack: distribute;
+        justify-content: space-around;
+  }
+  .cmpsr-list-pf .list-view-pf-additional-info-item {
+    -ms-flex-preferred-size: 50%;
+        flex-basis: 50%;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+  }
 }
 
 /* pagination */
@@ -28,99 +210,36 @@ textarea.form-control[readonly] {
   margin-top: 5px;
   background-color: transparent;
   border: none;
-  justify-content: flex-end;
-  align-items: baseline;
+  -webkit-box-pack: end;
+      -ms-flex-pack: end;
+          justify-content: flex-end;
+  -webkit-box-align: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline;
 }
 .toolbar-pf-results .pagination {
-  align-self: center;
+  -ms-flex-item-align: center;
+      align-self: center;
 }
 .toolbar-pf-results .pagination-pf-page,
 .toolbar-pf-results .pagination.pagination-pf-forward {
   margin-left: 5px;
 }
-
-/* toolbar */
-.toolbar-pf {
-  background-color: transparent;
-}
-.sidebar-pf .toolbar-pf {
-  background-color: #fff;
-}
-.toolbar-pf-actions .toolbar-pf-filter.form-group {
-  padding-left: 20px;
-}
-.toolbar-pf-actions .form-group:first-child {
-  padding-left: 0;
-}
 /* sidebar */
-.sidebar-pf .toolbar-pf-actions .toolbar-pf-filter {
+.cmpsr-panel__body--sidebar .toolbar-pf-actions .toolbar-pf-filter {
   width: auto;
 }
-.sidebar-pf {
-  padding: 0;
+.cmpsr-panel__body--sidebar {
+  background-color: #fafafa;
 }
-.sidebar-pf .toolbar-pf {
-  margin: 0 -20px;
-  padding-top: 14px;
-}
-.sidebar-pf .panel {
-  margin: 0;
-}
-.sidebar-pf .panel-heading {
-  padding: 10px 15px;
-}
-.sidebar-pf .panel-title {
-  font-size: 14px;
-}
-.sidebar-pf .panel-body {
-  padding: 0 20px;
-}
-/*sidebar list view*/
-.cmpsr-recipe__inputs .list-pf {
+.cmpsr-panel__body--sidebar .list-pf {
   margin-top: 20px;
 }
-.cmpsr-recipe__inputs .alert {
+.cmpsr-panel__body--sidebar .alert {
   position: relative;
   top: 10px;
+  margin: 0 20px;
 }
-
-/* Recipe contents Tabs */
-.cmpsr-recipe--edit {
-  padding: 0;
-}
-.cmpsr-recipe--edit .panel-default {
-  border-left: none;
-}
-.cmpsr-recipe--edit .panel-heading {
-  margin-bottom: -10px;
-}
-
-/*.cmpsr-list-pf*/
-.cmpsr-list-pf .list-pf-expansion .list-pf-container {
-  display: block;
-} /* remove and switch to flexbox for expanded contents */
-.cmpsr-list-pf .list-pf-main-content {
-  flex-basis: 100%;
-}
-.cmpsr-list-pf .list-pf-additional-content {
-  flex-basis: 100%;
-  flex-shrink: 0;
-  justify-content: flex-start;
-  flex-wrap: nowrap;
-}
-.cmpsr-list-pf .list-view-pf-additional-info-item {
-  flex-basis: 50%;
-}
-@media (min-width: 992px) {
-  .cmpsr-list-pf .list-pf-main-content {
-    flex-basis: 50%;
-  }
-  .cmpsr-list-pf .list-pf-additional-content {
-    flex-basis: 50%;
-    justify-content: space-around;
-  }
-}
-
 /* Expanded list item contents (i.e. component summary) */
 .list-pf-container .list-pf {
   max-height: 300px;
@@ -128,7 +247,8 @@ textarea.form-control[readonly] {
 }
 .list-pf-container dd {
   overflow: hidden;
-  text-overflow: ellipsis;
+  -o-text-overflow: ellipsis;
+     text-overflow: ellipsis;
 }
 
 /*Component details*/
@@ -137,26 +257,30 @@ textarea.form-control[readonly] {
     height: 30px;
     line-height: 30px;
     width: 30px;
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
     display: inline-flex;
-    justify-content: center;
-    align-items: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
 }
-.cmpsr-recipe__details .close {
-  float: none;
+.cmpsr-component-details--view {
+  margin-top: 20px;
 }
-.cmpsr-recipe__details .form-horizontal {
+.cmpsr-component-details__form {
+  background-color: #ededed;
+  border: 1px solid #24a4e1;
+  border-radius: 1px;
+  margin-bottom: 20px;
+  padding: 5px 10px;
+}
+.cmpsr-component-details__form .form-horizontal {
   margin: 15px 0;
 }
-.cmpsr-recipe__details .blank-slate-pf {
-  margin-top: 0;
-  padding: 0;
-}
-.cmpsr-recipe__details--edit {
-  border-top: 1px solid #d1d1d1;
-}
-.cmpsr-recipe__details--view {
-  padding: 10px 35px;
-}
+
 /* Recipe details page */
 .list-pf .list-group-item__separator,
 .list-pf .list-group-item__separator:hover {
@@ -166,7 +290,6 @@ textarea.form-control[readonly] {
   padding-top: 0;
   padding-bottom: 0;
 }
-
 /* compacted list view */
 /* used in sidebar and expanded list items */
 .cmpsr-list-pf__compacted {
@@ -179,7 +302,7 @@ textarea.form-control[readonly] {
   background: #f5f5f5;
 }
 .cmpsr-list-pf__compacted .list-pf-container {
-  padding: 7px 10px;
+  padding: 5px 10px;
 }
 .list-pf-container .cmpsr-list-pf__compacted .list-pf-container {
   border-top-width: 0;
@@ -191,6 +314,14 @@ textarea.form-control[readonly] {
 /* tab contents */
 .tab-container {
     padding: 20px 0;
+}
+
+/* toolbar */
+.toolbar-pf-actions .toolbar-pf-filter.form-group {
+  padding-left: 20px;
+}
+.toolbar-pf-actions .form-group:first-child {
+  padding-left: 0;
 }
 
 /* ------------------------------- */
@@ -292,4 +423,10 @@ textarea.form-control[readonly] {
 
  .nav-tabs .badge {
    display: inline;
+ }
+
+ /* bs tooltip fixed positioning */
+ .cmpsr-list-inputs .list-pf-actions .tooltip {
+   /*left: auto !important;*/
+   /*right: 0px;*/
  }

--- a/public/custom.css
+++ b/public/custom.css
@@ -424,9 +424,3 @@ textarea.form-control[readonly] {
  .nav-tabs .badge {
    display: inline;
  }
-
- /* bs tooltip fixed positioning */
- .cmpsr-list-inputs .list-pf-actions .tooltip {
-   /*left: auto !important;*/
-   /*right: 0px;*/
- }


### PR DESCRIPTION
These updates include the following: 

- ability to separately scroll the the list of inputs and the list of recipe components
  - additionally, this required changing the position of the tooltips that display in the inputs panel, since contents in one panel cannot overlap another panel
- consistent html/css for headers that display in the Recipe page, Recipe Edit page, and the component details
- component details display as a panel with a panel title on both the Recipe page and Recipe Edit page
- updated styles for the form that displays when viewing component details