### PR TITLE
Optimize environment setup script to speed up test time.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+test
+metadata.db
+.travis.yml
+Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,39 @@ services:
 language: node_js
 node_js:
   - "6"
+env:
+  global:
+    - secure: NaGi05Fc5Wb/k34kaevbG42/4dGSO/KZas+CZTypeU9BdwCC5DX32nr+vxpDzLUwXjJe1eOItn+cusgeXJmVPSTSfP++mkj+gs6Q3WzN0GBxTuBVKsd2AisWtJWCeiOKBOUpeDeaqGtay7yA4jOhvGhqwU1tp3Gnwq7RotJJtwmFTwarLGGSfHgPoJn6Pd3upAgjSq7+cb8dzZkyI2iEdIIqUWjohzlAXvVkq+UabuHvt6xN+9R0xZB7hdjYDAEp2lgOi48p1wY+tCJyLM9Nj6T2V/sqNmyuWMepYVU5MQM9puoyVUsO2blHn7WHIzwhHACm9R70B7tLzlur1V2PtzbvY6rct34T+SZ0UBeJPlgjh5rM4yKXUXchKAL75mgf+ndi4GI/RqWo7m0bz29kinL7cg7+/8on4SPxOLYy9aXIKyFqSSwqeNQqT5L4RRRNcxSlI8i/7l8WH4KfVg3JKC45fv5sFYao1qwRHCb1uFAAHwedS5BlkazyHVEjPb8XTtXne8WkeIfMSaj1aF6IuMrZqPC+oQ3qNheQ6iNF2twCsIgUXq393r4DvrCDhuD/oFoU5VnsTbW/GUhTsJ/NVPXmlv1rvzhamdv0CiY/ct6qmzJTi3o70gT5n9mFZ8CmD939OJ3TrL5sN+q1janwdnN8skZhRRhMyMLcND8lZ2Q=
+  matrix:
+    - COMMAND=eslint
+    - COMMAND=stylelint
+    - COMMAND=build-test
+    - COMMAND=unit-test
+    - COMMAND=end-to-end-test
 cache:
   directories:
   - node_modules # NPM packages
 before_install:
-  - npm install
-  - node run build
-env:
-  - COMMAND=eslint
-  - COMMAND=stylelint
-  - COMMAND=unit-test
-  - COMMAND=end-to-end-test
+  - if [ "$COMMAND" == "end-to-end-test" ]; then make e2e-before-install; fi
+install:
+  - |
+      if [ "$COMMAND" != "end-to-end-test" ]; then
+        npm install
+      else
+        make e2e-install
+      fi
 script:
   - make "$COMMAND"
 after_success:
   - if [ "$COMMAND" == "unit-test" ]; then npm install coveralls && cat ./coverage/lcov.info | coveralls; fi
+  - |
+      if [ "$COMMAND" == "end-to-end-test" ]; then
+        # if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+          docker login -u atodorov -p $DOCKER_PASSWORD
+          docker push welder/welder-web
+          docker push welder/end-to-end
+        # fi
+      fi
 notifications:
   email:
     on_failure: change

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # A Fedora 25 BDCS API Container
-FROM weld/fedora:25
+FROM welder/fedora:latest
 MAINTAINER Brian C. Lane <bcl@redhat.com>
 RUN dnf install -y nginx
 

--- a/Makefile
+++ b/Makefile
@@ -4,26 +4,28 @@ eslint:
 stylelint:
 	npm run stylelint
 
+build-test:
+	npm run build
+
 unit-test:
 	npm run test:cov
 
 end-to-end-test:
-	git clone https://github.com/weldr/welder-deployment
-	make -C welder-deployment/ weld-f25
-
-	sudo docker build -f ./test/end-to-end/Dockerfile -t weld/end-to-end:latest ./test/end-to-end/
-
-	git clone ../welder-web welder-deployment/welder-web
-	make -C welder-deployment/ repos
-	
-	if [ ! -d ./welder-deployment/mddb ]; then \
-		mkdir ./welder-deployment/mddb; \
-	fi; \
-	sudo docker-compose -f welder-deployment/docker-compose.yml build
-	wget https://s3.amazonaws.com/weldr/metadata.db -O welder-deployment/mddb/metadata.db
-	sudo docker-compose -f welder-deployment/docker-compose.yml -p welder up -d
-
-	sudo docker run --rm --name welder_end_to_end --network welder_default \
-	    -v test-result-volume:/result -v `pwd`/welder-deployment/mddb:/mddb -e MDDB='/mddb/metadata.db' \
-	    weld/end-to-end:latest \
+	sudo docker run --rm --name end_to_end --network welder \
+	    -v test-result-volume:/result -v `pwd`:/mddb -e MDDB='/mddb/metadata.db' \
+	    welder/end-to-end:${TRAVIS_BUILD_NUMBER} \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test
+
+e2e-before-install:
+	sudo docker pull welder/fedora:latest
+	sudo docker pull welder/bdcs-api-rs:latest
+	wget https://s3.amazonaws.com/weldr/metadata.db
+	sudo docker network create welder
+	sudo docker build --cache-from welder/welder-web:latest -t welder/welder-web:latest .
+	sudo docker build --cache-from welder/end-to-end:latest -t welder/end-to-end:latest test/end-to-end/
+	sudo docker tag welder/welder-web:latest welder/welder-web:${TRAVIS_BUILD_NUMBER}
+	sudo docker tag welder/end-to-end:latest welder/end-to-end:${TRAVIS_BUILD_NUMBER}
+
+e2e-install:
+	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest
+	sudo docker run -d --name web --restart=always -p 80:3000 --network welder welder/welder-web:${TRAVIS_BUILD_NUMBER}

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -1,5 +1,5 @@
 # A Fedora 25 End-To-End Automation Test Container
-FROM weld/fedora:25
+FROM welder/fedora:latest
 MAINTAINER Xiaofeng Wang <xiaofwan@redhat.com>
 
 # Install xvfb to simulate framebuffer for nightmare.js


### PR DESCRIPTION
1. Enable docker cache to speed up container build time.