### PR TITLE
Manually build all docker containers using the images from Docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,15 @@ unit-test:
 	npm run test:cov
 
 end-to-end-test:
-	git clone https://github.com/weldr/welder-deployment
-	make -C welder-deployment/ weld-f25
-
+	sudo docker network create welder
+	sudo docker build -t weld/web:latest .
 	sudo docker build -f ./test/end-to-end/Dockerfile -t weld/end-to-end:latest ./test/end-to-end/
 
-	git clone ../welder-web welder-deployment/welder-web
-	make -C welder-deployment/ repos
-	
-	if [ ! -d ./welder-deployment/mddb ]; then \
-		mkdir ./welder-deployment/mddb; \
-	fi; \
-	sudo docker-compose -f welder-deployment/docker-compose.yml build
-	wget https://s3.amazonaws.com/weldr/metadata.db -O welder-deployment/mddb/metadata.db
-	sudo docker-compose -f welder-deployment/docker-compose.yml -p welder up -d
+	wget https://s3.amazonaws.com/weldr/metadata.db
+	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest
+	sudo docker run -d --name web --restart=always -p 80:3000 --network welder weld/web:latest
 
-	sudo docker run --rm --name welder_end_to_end --network welder_default \
-	    -v test-result-volume:/result -v `pwd`/welder-deployment/mddb:/mddb -e MDDB='/mddb/metadata.db' \
+	sudo docker run --rm --name welder_end_to_end --network welder \
+	    -v test-result-volume:/result -v `pwd`:/mddb -e MDDB='/mddb/metadata.db' \
 	    weld/end-to-end:latest \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test


### PR DESCRIPTION
This is a pre-requirement for #125. It modifies the build sequence so that web and end-to-end images don't build the welder/fedora:25 and welder/bdcs-api-rs:latest images locally and instead pull them from Docker Hub. This saves us about 5 minutes in execution time.