### PR TITLE
Try to optimize e2e tests by re-using images from Docker hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+test
+metadata.db
+.travis.yml
+Makefile
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,45 @@ cache:
   directories:
   - node_modules # NPM packages
 before_install:
-  - npm install
-  - node run build
+  - |
+        if [ "$COMMAND" == "end-to-end-test" ]; then
+            sudo docker pull welder/web-nodejs:latest
+            sudo docker pull welder/web:latest
+            sudo docker pull welder/web-e2e-tests:latest
+        else
+            npm install
+        fi
+
 env:
-  - COMMAND=eslint
-  - COMMAND=stylelint
-  - COMMAND=unit-test
-  - COMMAND=end-to-end-test
+  global:
+    secure: "Q9X11ehcl4YE0ylxDGk8NgVeO7nIpqWiI9am2GA6JVXcxeYYcLf3NHGe1JiLwFQ/xSq4KJrY0IgpivkVrPwTOojpR/tRG5QNDR/IJzN/6PV0IAWkHjPDKZexCQmy4IoPFib/cWqxo46V/JZ+gzs/TJugkl5/QpTcGlCr+d7VkuA80Bj0nlQO5GevYVgYMCrN6u6cKNOWtNQ0gppxHrpsLo36MpHqHbNbv236GPGsV4K2qpiqvvO5ogD+LCv5xoKEZK0ext4FNrrZFq6XEYdy9uUaUbSFfoG+HXESXbIt0L7krQDT/PkKI0X4nM91eYl5mS63+HVue7vLiijS5h9+YCa8HblMIiAiyrR3lPPH0Hx4FVSrQfkvtoXMBs3nRt7keu2FG370a7WoaQ71Q2jHrI9cfYzRwa/Mok73eF/oeN32hPlPDD679hWOZYqbSksSTikCLIgwJpEgIfaHgEYXFmL2JFXk0HbgIciA+C9fE0rfaUbmARtWYq8c+b52aIxAHEV9zYy3JeARrYxk7s3jQgS/LZIw4rfso+bQIvEMUDWt8MnvKaecY1E7XjOpW1kuk8gVjZbHm6oHKl2IndZA9KNpXjT2ew8d3SB69l2lswUYu4mTdywNEUt6nIaQtROiiftUKYThAbibIEIrq7GxQSOYMUPbvUYsZO5rkVssJps="
+  matrix:
+    - COMMAND=eslint
+    - COMMAND=stylelint
+    - COMMAND=unit-test
+    - COMMAND=end-to-end-test
 script:
   - make "$COMMAND"
 after_success:
   - if [ "$COMMAND" == "unit-test" ]; then npm install coveralls && cat ./coverage/lcov.info | coveralls; fi
+  - |
+        if [ "$COMMAND" == "end-to-end-test" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+            # tag the current builds with the build number
+            # if nothing has been changed the push will detect that
+            # and the new tag will appear on Docker Hub without anything being
+            # actually uploaded
+            sudo docker tag welder/web-nodejs:latest welder/web-nodejs:$TRAVIS_BUILD_NUMBER
+            sudo docker tag welder/web:latest welder/web:$TRAVIS_BUILD_NUMBER
+            sudo docker tag welder/web-e2e-tests:latest welder/web-e2e-tests:$TRAVIS_BUILD_NUMBER
+
+            docker login -u atodorov -p $DOCKER_PASSWORD
+
+            docker push welder/web-nodejs
+            docker push welder/web
+            docker push welder/web-e2e-tests
+        fi
+
 notifications:
   email:
     on_failure: change
-    on_success: change
+    on_success: never

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,7 @@
 # A Fedora 25 BDCS API Container
-FROM welder/fedora:latest
+FROM welder/web-nodejs:latest
 MAINTAINER Brian C. Lane <bcl@redhat.com>
 RUN dnf install -y nginx
-
-RUN echo 'PATH=/usr/local/bin/:$PATH' >> /etc/bashrc
-
-# Based on official node docker image
-# gpg keys listed at https://github.com/nodejs/node
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.9.1
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM welder/web-nodejs:latest
 MAINTAINER Brian C. Lane <bcl@redhat.com>
 RUN dnf install -y nginx
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD nginx -g "daemon off;"
 EXPOSE 3000
 
@@ -19,3 +17,6 @@ RUN cd /welder/ && npm install
 # Copy the rest of the UI files over and compile them
 COPY . /welder/
 RUN cd /welder/ && node run build
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.nodejs
+++ b/Dockerfile.nodejs
@@ -1,0 +1,32 @@
+# A base image with Node.js environment
+FROM welder/fedora:latest
+MAINTAINER Alexander Todorov <atodorov@redhat.com>
+
+RUN echo 'PATH=/usr/local/bin/:$PATH' >> /etc/bashrc
+
+# Based on official node docker image
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.9.1
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ end-to-end-test:
 	sudo docker build -f Dockerfile.nodejs --cache-from welder/web-nodejs:latest -t welder/web-nodejs:latest .
 
 	sudo docker network create welder
-	sudo docker build -t weld/web:latest .
-	sudo docker build -f ./test/end-to-end/Dockerfile -t weld/end-to-end:latest ./test/end-to-end/
+	sudo docker build --cache-from welder/web:latest -t welder/web:latest .
+	sudo docker build -f ./test/end-to-end/Dockerfile --cache-from welder/web-e2e-tests:latest -t welder/web-e2e-tests:latest ./test/end-to-end/
 
 	wget https://s3.amazonaws.com/weldr/metadata.db
 	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest
-	sudo docker run -d --name web --restart=always -p 80:3000 --network welder weld/web:latest
+	sudo docker run -d --name web --restart=always -p 80:3000 --network welder welder/web:latest
 
 	sudo docker run --rm --name welder_end_to_end --network welder \
 	    -v test-result-volume:/result -v `pwd`:/mddb -e MDDB='/mddb/metadata.db' \
-	    weld/end-to-end:latest \
+	    welder/web-e2e-tests:latest \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ unit-test:
 	npm run test:cov
 
 end-to-end-test:
+	sudo docker build -f Dockerfile.nodejs --cache-from welder/web-nodejs:latest -t welder/web-nodejs:latest .
+
 	sudo docker network create welder
 	sudo docker build -t weld/web:latest .
 	sudo docker build -f ./test/end-to-end/Dockerfile -t weld/end-to-end:latest ./test/end-to-end/

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -1,5 +1,5 @@
 # A Fedora 25 End-To-End Automation Test Container
-FROM welder/fedora:latest
+FROM welder/web-nodejs:latest
 MAINTAINER Xiaofeng Wang <xiaofwan@redhat.com>
 
 # Install xvfb to simulate framebuffer for nightmare.js
@@ -7,35 +7,6 @@ MAINTAINER Xiaofeng Wang <xiaofwan@redhat.com>
 RUN dnf --setopt=deltarpm=0 --verbose install -y xorg-x11-server-Xvfb which libXScrnSaver \
 clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel xorg-x11-server-utils \
 libcap-devel cups-devel libXtst-devel alsa-lib-devel libXrandr-devel GConf2-devel nss-devel
-
-RUN echo 'PATH=/usr/local/bin/:$PATH' >> /etc/bashrc
-
-# Based on official node docker image
-# gpg keys listed at https://github.com/nodejs/node
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.9.1
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -8,8 +8,6 @@ RUN dnf --setopt=deltarpm=0 --verbose install -y xorg-x11-server-Xvfb which libX
 clang dbus-devel gtk2-devel libnotify-devel libgnome-keyring-devel xorg-x11-server-utils \
 libcap-devel cups-devel libXtst-devel alsa-lib-devel libXrandr-devel GConf2-devel nss-devel
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["xvfb-run", "-a", "-s", "-screen 0 1024x768x24", "npm", "run", "test"]
 
 ## Do the things more likely to change below here. ##
@@ -23,3 +21,6 @@ RUN cd /end2end/ && npm install --only=production
 
 # Copy the rest of the UI files over and compile them
 COPY . /end2end/
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
This is an updated version of #125 which pulls the latest images from Docker hub and tries to reuse them as cache. 

NOTE: as in my PR for bdcs-api-rs here we see the npm install happening again inside the image although there's no need for that. I'm not quite certain what causes this but I think it will be resolved once the changes get merged to master and we start pushing to Hub from CI.