### PR TITLE
Enable end-to-end test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,13 @@ cache:
   - node_modules # NPM packages
 before_install:
   - |
+        npm install coveralls
+        npm install nyc
+
         if [ "$COMMAND" == "end-to-end-test" ]; then
             sudo docker pull welder/web-nodejs:latest
             sudo docker pull welder/web:latest
+            sudo docker pull welder/web-with-coverage:latest
             sudo docker pull welder/web-e2e-tests:latest
         else
             npm install
@@ -29,8 +33,14 @@ env:
 script:
   - make "$COMMAND"
 after_success:
-  - if [ "$COMMAND" == "unit-test" ]; then npm install coveralls && cat ./coverage/lcov.info | coveralls; fi
+  - if [ "$COMMAND" == "unit-test" ]; then cat ./coverage/lcov.info | coveralls; fi
   - |
+        if [ "$COMMAND" == "end-to-end-test" ]; then
+            nyc report
+            nyc report --reporter=lcov
+            cat ./coverage/lcov.info | coveralls
+        fi
+
         if [ "$COMMAND" == "end-to-end-test" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
             # tag the current builds with the build number
             # if nothing has been changed the push will detect that
@@ -38,12 +48,14 @@ after_success:
             # actually uploaded
             sudo docker tag welder/web-nodejs:latest welder/web-nodejs:$TRAVIS_BUILD_NUMBER
             sudo docker tag welder/web:latest welder/web:$TRAVIS_BUILD_NUMBER
+            sudo docker tag welder/web-with-coverage:latest welder/web-with-coverage:$TRAVIS_BUILD_NUMBER
             sudo docker tag welder/web-e2e-tests:latest welder/web-e2e-tests:$TRAVIS_BUILD_NUMBER
 
             docker login -u atodorov -p $DOCKER_PASSWORD
 
             docker push welder/web-nodejs
             docker push welder/web
+            docker push welder/web-with-coverage
             docker push welder/web-e2e-tests
         fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   - node_modules # NPM packages
 before_install:
   - |
-        npm install coveralls
+        npm install codecov
         npm install nyc
 
         if [ "$COMMAND" == "end-to-end-test" ]; then
@@ -33,12 +33,11 @@ env:
 script:
   - make "$COMMAND"
 after_success:
-  - if [ "$COMMAND" == "unit-test" ]; then cat ./coverage/lcov.info | coveralls; fi
+  - if [ "$COMMAND" == "unit-test" ]; then cat ./coverage/lcov.info | codecov; fi
   - |
         if [ "$COMMAND" == "end-to-end-test" ]; then
             nyc report
-            nyc report --reporter=lcov
-            cat ./coverage/lcov.info | coveralls
+            nyc report --reporter=lcov | codecov
         fi
 
         if [ "$COMMAND" == "end-to-end-test" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ EXPOSE 3000
 
 COPY ./docker/nginx.conf /etc/nginx/
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 # Update node dependencies only if they have changed
 COPY ./package.json /welder/package.json
 RUN cd /welder/ && npm install
@@ -17,6 +20,3 @@ RUN cd /welder/ && npm install
 # Copy the rest of the UI files over and compile them
 COPY . /welder/
 RUN cd /welder/ && node run build
-
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.with-coverage
+++ b/Dockerfile.with-coverage
@@ -1,0 +1,5 @@
+FROM welder/web:latest
+MAINTAINER Alexander Todorov <atodorov@redhat.com>
+
+# just build the web container with coverage instrumentation
+RUN cd /welder/ && node run build --with-coverage

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,14 @@ end-to-end-test:
 
 	sudo docker network create welder
 	sudo docker build --cache-from welder/web:latest -t welder/web:latest .
+	sudo docker build -f Dockerfile.with-coverage --cache-from welder/web-with-coverage:latest -t welder/web-with-coverage:latest .
 	sudo docker build -f ./test/end-to-end/Dockerfile --cache-from welder/web-e2e-tests:latest -t welder/web-e2e-tests:latest ./test/end-to-end/
 
 	wget --progress=dot:giga https://s3.amazonaws.com/weldr/metadata.db
 	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest
-	sudo docker run -d --name web --restart=always -p 80:3000 --network welder welder/web:latest
+	sudo docker run -d --name web --restart=always -p 80:3000 --network welder welder/web-with-coverage:latest
 
 	sudo docker run --rm --name welder_end_to_end --network welder \
-	    -v test-result-volume:/result -v `pwd`:/mddb -e MDDB='/mddb/metadata.db' \
+	    -v `pwd`/.nyc_output/:/tmp -v `pwd`:/mddb -e MDDB='/mddb/metadata.db' \
 	    welder/web-e2e-tests:latest \
-	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test
+	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test -- --verbose

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ You can also test your app in release (production) mode by running `node run sta
 with HMR and React Hot Loader disabled by running `node run start --no-hmr`. The app should become
 available at [http://localhost:3000/](http://localhost:3000/).
 
+You can also enable code instrumentation with istanbul by specifying
+`node run build --with-coverage` or `node run --with-coverage`. This is needed if you want to
+collect code coverage from end-to-end tests. Don't use `--with-coverage` when running the unit tests.
+`jest` provides its own instrumentation and it will break if we do double instrumentation.
+Disabled by default!
+
 
 ### How to Test
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welder Web
 
 [![Build Status](https://travis-ci.org/weldr/welder-web.svg?branch=master)](https://travis-ci.org/weldr/welder-web)
-[![Coverage Status](https://coveralls.io/repos/github/weldr/welder-web/badge.svg?branch=master)](https://coveralls.io/github/weldr/welder-web?branch=master)
+[![codecov](https://codecov.io/gh/weldr/welder-web/branch/master/graph/badge.svg)](https://codecov.io/gh/weldr/welder-web)
 
 The web interface for Welder!
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-eslint": "^6.1.2",
     "babel-jest": "^16.0.0",
     "babel-loader": "^6.2.4",
+    "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",

--- a/test/end-to-end/.eslintrc
+++ b/test/end-to-end/.eslintrc
@@ -14,6 +14,8 @@
   ],
   "rules": {
     "func-names": ["error", "never"],
+    "no-eval": "off",
+    "no-unused-vars": "off",
     "import/no-unresolved": ["error", { "ignore": ["nightmare'"] }],
     "max-len": ["error", 130]
   }

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -12,9 +12,6 @@ CMD ["xvfb-run", "-a", "-s", "-screen 0 1024x768x24", "npm", "run", "test"]
 
 ## Do the things more likely to change below here. ##
 
-# Volumes for xUnit result file.
-VOLUME /result
-
 # Update node dependencies only if they have changed
 COPY ./package.json /end2end/package.json
 RUN cd /end2end/ && npm install --only=production

--- a/test/end-to-end/README.md
+++ b/test/end-to-end/README.md
@@ -128,6 +128,34 @@ describe('View Recipe Page', function () {             // Which page does this s
 });
 ```
 
+## Code coverage from end-to-end tests
+
+Before running the tests the application code must be instrumented with
+istanbul! Then inside the browser scope all coverage information is available
+from `window__coverage__` which needs to be passed back to the node scope
+and made available for the reporting tools to use. The helper code inside
+`utils/coverage.js` already to this and store the report files inder
+`/tmp/coverage-<HASH>.json`. The hash value is the sha256 sum of the coverage
+report itself.
+
+There are several things to be noted when writing and executing the tests:
+
+1. Some cases may have identical coverage so the number of json files will be
+   equal or less to the number of test cases;
+2. When constructing the Nightmare sequence make sure you **DO NOT** call the
+   `.end()` method and the `done()` callback! This is done inside `utils/coverage.js`;
+3. `utils/coverage.js` must be executed inside the last `.then()` method in the
+   Nightmare sequence. This is usually after the last expectation (assertion);
+4. `utils/coverage.js` takes care to call `.end()` and close the electron process;
+5. We're using `eval()` to *include* the contents of `utils/coverage.js` inside the
+   last `.then()` method because attempts to execute the same code as a method of
+   a helper module have failed. You will likely get something like
+   `nightmare is not defined` or
+   `Unhandled promise rejection (rejection id: 1): cov_23rlop1885 is not defined`;
+6. `eval()` **must be** called from the global scope, it can't be made into a
+   helper function. Thus the syntax is abit ugly but at least it is a one liner;
+
+
 ## Test Result
 
 The result should be read like a sentence.

--- a/test/end-to-end/test/test_createRecipe.js
+++ b/test/end-to-end/test/test_createRecipe.js
@@ -4,6 +4,8 @@ const CreateRecipePage = require('../pages/createRecipe');
 const EditRecipePage = require('../pages/editRecipe');
 const apiCall = require('../utils/apiCall');
 const pageConfig = require('../config');
+const fs = require('fs');
+
 
 describe('Create Recipe Page', () => {
   // Set case running timeout
@@ -43,11 +45,11 @@ describe('Create Recipe Page', () => {
           .then(() => nightmare
             .wait(createRecipePage.spanHelpBlockMsg)
             .evaluate(page => document.querySelector(page.spanHelpBlockMsg).innerText
-              , createRecipePage)
-            .end())
+              , createRecipePage))
           .then((element) => {
             expect(element).toBe(expectedHelpBlockMsg);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should show alert message by clicking Enter key when create recipe without name @create-recipe-page', (done) => {
@@ -73,11 +75,11 @@ describe('Create Recipe Page', () => {
           .then(() => nightmare
             .wait(createRecipePage.spanHelpBlockMsg)
             .evaluate(page => document.querySelector(page.spanHelpBlockMsg).innerText
-              , createRecipePage)
-            .end())
+              , createRecipePage))
           .then((element) => {
             expect(element).toBe(expectedHelpBlockMsg);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should show alert message by changing focus to description input @create-recipe-page', (done) => {
@@ -96,10 +98,10 @@ describe('Create Recipe Page', () => {
           .wait(createRecipePage.spanHelpBlockMsg)
           .evaluate(page => document.querySelector(page.spanHelpBlockMsg).innerText
             , createRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -124,10 +126,10 @@ describe('Create Recipe Page', () => {
           .click(createRecipePage.btnSave)
           .wait(editRecipePage.componentListItemRootElement)
           .exists(editRecipePage.componentListItemRootElement)
-          .end()
           .then((element) => {
             expect(element).toBe(true);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });

--- a/test/end-to-end/test/test_editRecipe.js
+++ b/test/end-to-end/test/test_editRecipe.js
@@ -5,6 +5,7 @@ const ToastNotifPage = require('../pages/toastNotif');
 const ExportRecipePage = require('../pages/exportRecipe');
 const apiCall = require('../utils/apiCall');
 const pageConfig = require('../config');
+const fs = require('fs');
 
 describe('Edit Recipe Page', () => {
   // Set case running timeout
@@ -50,11 +51,11 @@ describe('Edit Recipe Page', () => {
           })
           .then(() => nightmare
             .evaluate(page => document.querySelector(page.linkRecipeName).href
-              , editRecipePage)
-            .end())
+              , editRecipePage))
           .then((element) => {
             expect(element).toBe(expectedViewRecipeLinke);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -70,10 +71,10 @@ describe('Edit Recipe Page', () => {
           .wait(editRecipePage.labelRecipeTitle)
           .evaluate(page => document.querySelector(page.labelRecipeTitle).innerText
             , editRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should have Create Composition button @edit-recipe-page', (done) => {
@@ -87,10 +88,10 @@ describe('Edit Recipe Page', () => {
           .wait(editRecipePage.btnCreateCompos)
           .evaluate(page => document.querySelector(page.btnCreateCompos).innerText
             , editRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -115,10 +116,10 @@ describe('Edit Recipe Page', () => {
             .wait(createComposPage.labelCreateCompos)
             .evaluate(page => document.querySelector(page.labelCreateCompos).innerText
               , createComposPage)
-            .end()
             .then((element) => {
               expect(element).toBe(expected);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
         test('should have toast notification pop up when new composition added @edit-recipe-page', (done) => {
@@ -157,11 +158,11 @@ describe('Edit Recipe Page', () => {
                 return recipeName !== page.varEmptyName && recipeName.includes(page.varEmptyName);
               }, toastNotifPage)
               .evaluate(page => document.querySelector(page.labelStatus).innerText
-              , toastNotifPage)
-              .end())
+              , toastNotifPage))
             .then((element) => {
               expect(element).toBe(expectedComplete);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
       });
@@ -186,10 +187,9 @@ describe('Edit Recipe Page', () => {
           .wait(menuActionExport)
           .evaluate(element => document.querySelector(element).innerText
             , menuActionExport)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -209,10 +209,10 @@ describe('Edit Recipe Page', () => {
           .wait(exportRecipePage.labelExportTitle)
           .evaluate(page => document.querySelector(page.labelExportTitle).innerText
             , exportRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -245,11 +245,11 @@ describe('Edit Recipe Page', () => {
             })
             .then(() => nightmare
               .evaluate(page => document.querySelector(page.textAreaContent).value
-                , exportRecipePage)
-              .end())
+                , exportRecipePage))
             .then((element) => {
               expect(element).toBe(expectedContent);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }
 
@@ -311,12 +311,12 @@ describe('Edit Recipe Page', () => {
 
               // return the text
               return clipboardText;
-            })
-            .end())
+            }))
           .then((element) => {
             // remove the last "\n" from paste result with trim()
             expect(element.trim()).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -352,11 +352,11 @@ describe('Edit Recipe Page', () => {
               return recipeName !== page.varEmptyName && recipeName.includes(page.varEmptyName);
             }, toastNotifPage)
             .evaluate(page => document.querySelector(page.labelStatus).innerText
-            , toastNotifPage)
-            .end())
+            , toastNotifPage))
           .then((element) => {
             expect(element).toBe(expectedSaved);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });

--- a/test/end-to-end/test/test_importSanity.js
+++ b/test/end-to-end/test/test_importSanity.js
@@ -31,7 +31,7 @@ describe('Imported Content Sanity Testing', () => {
   });
 
   afterAll((done) => {
-    // Delete added recipe after all tests completed in this sute
+    // Delete added recipe after all tests completed in this suite
     apiCall.deleteRecipe(pageConfig.recipe.simple.name, done);
     // Close connection with sqlite db
     db.close();
@@ -47,13 +47,12 @@ describe('Imported Content Sanity Testing', () => {
       nightmare
         .goto(editRecipePage.url)
         .wait(editRecipePage.componentListItemRootElement) // list item and total number are rendered at the same time
-        .then(() => nightmare
-          .evaluate(page => document.querySelector(page.totalComponentCount).innerText
-            , editRecipePage)
-          .end())
+        .evaluate(page => document.querySelector(page.totalComponentCount).innerText, editRecipePage)
         .then((element) => {
           expect(element).toBe(expectedText);
-          done();
+
+          // note eval() can't be called from within another function
+          eval(fs.readFileSync('utils/coverage.js').toString());
         });
     });
   }, timeout);

--- a/test/end-to-end/test/test_recipes.js
+++ b/test/end-to-end/test/test_recipes.js
@@ -6,6 +6,7 @@ const ToastNotifPage = require('../pages/toastNotif');
 const ExportRecipePage = require('../pages/exportRecipe');
 const apiCall = require('../utils/apiCall');
 const pageConfig = require('../config');
+const fs = require('fs');
 
 describe('Recipes Page', () => {
   // Set case running timeout
@@ -28,10 +29,10 @@ describe('Recipes Page', () => {
         nightmare
           .goto(recipesPage.url)
           .title()
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -49,10 +50,10 @@ describe('Recipes Page', () => {
           .wait(recipesPage.btnCreateRecipe)
           .evaluate(page => document.querySelector(page.btnCreateRecipe).innerText
             , recipesPage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should pop up Create Recipe window when click Create Recipe button @recipes-page', (done) => {
@@ -72,10 +73,10 @@ describe('Recipes Page', () => {
           .wait(createRecipePage.labelCreateRecipe)
           .evaluate(page => document.querySelector(page.labelCreateRecipe).innerText
             , createRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -109,10 +110,10 @@ describe('Recipes Page', () => {
             .wait(recipeNameSelector)
             .evaluate(selector => document.querySelector(selector).innerText
               , recipeNameSelector)
-            .end()
             .then((element) => {
               expect(element).toBe(expected);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
         test('should have correct recipe description on list after new recipe added @recipes-page', (done) => {
@@ -125,10 +126,10 @@ describe('Recipes Page', () => {
             .wait(recipesPage.labelRecipeDescr)
             .evaluate(page => Array.prototype.slice.call(document.querySelectorAll(page.labelRecipeDescr)).map(x => x.innerText)
               , recipesPage)
-            .end()
             .then((element) => {
               expect(element).toContain(expected);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
       });
@@ -156,10 +157,10 @@ describe('Recipes Page', () => {
               .wait(createComposPage.labelCreateCompos)
               .evaluate(page => document.querySelector(page.labelCreateCompos).innerText
                 , createComposPage)
-              .end()
               .then((element) => {
                 expect(element).toBe(expected);
-                done();
+
+                eval(fs.readFileSync('utils/coverage.js').toString());
               });
           }, timeout);
           test('should have toast notification pop up when new composition added @recipes-page', (done) => {
@@ -197,11 +198,11 @@ describe('Recipes Page', () => {
                   return recipeName !== page.varEmptyName && recipeName.includes(page.varEmptyName);
                 }, toastNotifPage)
                 .evaluate(page => document.querySelector(page.labelStatus).innerText
-                , toastNotifPage)
-                .end())
+                , toastNotifPage))
               .then((element) => {
                 expect(element).toBe(expectedComplete);
-                done();
+
+                eval(fs.readFileSync('utils/coverage.js').toString());
               });
           }, timeout);
         });
@@ -225,10 +226,10 @@ describe('Recipes Page', () => {
             .wait(menuActionExport)
             .evaluate(element => document.querySelector(element).innerText
               , menuActionExport)
-            .end()
             .then((element) => {
               expect(element).toBe(expected);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
         test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -247,10 +248,10 @@ describe('Recipes Page', () => {
             .wait(exportRecipePage.labelExportTitle)
             .evaluate(page => document.querySelector(page.labelExportTitle).innerText
               , exportRecipePage)
-            .end()
             .then((element) => {
               expect(element).toBe(expected);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
         test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -283,11 +284,11 @@ describe('Recipes Page', () => {
               })
               .then(() => nightmare
                 .evaluate(page => document.querySelector(page.textAreaContent).value
-                  , exportRecipePage)
-                .end())
+                  , exportRecipePage))
               .then((element) => {
                 expect(element).toBe(expectedContent);
-                done();
+
+                eval(fs.readFileSync('utils/coverage.js').toString());
               });
           }
 
@@ -348,12 +349,12 @@ describe('Recipes Page', () => {
 
                 // return the text
                 return clipboardText;
-              })
-              .end())
+              }))
             .then((element) => {
               // remove the last "\n" from paste result with trim()
               expect(element.trim()).toBe(expected);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
       });

--- a/test/end-to-end/test/test_viewRecipe.js
+++ b/test/end-to-end/test/test_viewRecipe.js
@@ -5,6 +5,7 @@ const ToastNotifPage = require('../pages/toastNotif');
 const ExportRecipePage = require('../pages/exportRecipe');
 const apiCall = require('../utils/apiCall');
 const pageConfig = require('../config');
+const fs = require('fs');
 
 describe('View Recipe Page', () => {
   // Set case running timeout
@@ -42,10 +43,10 @@ describe('View Recipe Page', () => {
           .wait(viewRecipePage.labelRecipeName)
           .evaluate(page => document.querySelector(page.labelRecipeName).innerText
             , viewRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -60,10 +61,10 @@ describe('View Recipe Page', () => {
           .wait(viewRecipePage.labelRecipeTitle)
           .evaluate(page => document.querySelector(page.labelRecipeTitle).innerText
             , viewRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should have Create Composition button @view-recipe-page', (done) => {
@@ -76,10 +77,10 @@ describe('View Recipe Page', () => {
           .wait(viewRecipePage.btnCreateCompos)
           .evaluate(page => document.querySelector(page.btnCreateCompos).innerText
             , viewRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -101,10 +102,10 @@ describe('View Recipe Page', () => {
               , createComposPage)
             .evaluate(page => document.querySelector(page.labelCreateCompos).innerText
               , createComposPage)
-            .end()
             .then((element) => {
               expect(element).toBe(expected);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
         test('should have toast notification pop up when new composition added @view-recipe-page', (done) => {
@@ -142,11 +143,11 @@ describe('View Recipe Page', () => {
                 return recipeName !== page.varEmptyName && recipeName.includes(page.varEmptyName);
               }, toastNotifPage)
               .evaluate(page => document.querySelector(page.labelStatus).innerText
-              , toastNotifPage)
-              .end())
+              , toastNotifPage))
             .then((element) => {
               expect(element).toBe(expectedComplete);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }, timeout);
       });
@@ -174,10 +175,10 @@ describe('View Recipe Page', () => {
           .wait(menuActionExport)
           .evaluate(element => document.querySelector(element).innerText
             , menuActionExport)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -198,10 +199,10 @@ describe('View Recipe Page', () => {
           .wait(exportRecipePage.labelExportTitle)
           .evaluate(page => document.querySelector(page.labelExportTitle).innerText
             , exportRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -236,11 +237,11 @@ describe('View Recipe Page', () => {
             })
             .then(() => nightmare
               .evaluate(page => document.querySelector(page.textAreaContent).value
-                , exportRecipePage)
-              .end())
+                , exportRecipePage))
             .then((element) => {
               expect(element).toBe(expectedContent);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }
 
@@ -303,12 +304,12 @@ describe('View Recipe Page', () => {
 
               // return the text
               return clipboardText;
-            })
-            .end())
+            }))
           .then((element) => {
             // remove the last "\n" from paste result with trim()
             expect(element.trim()).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -335,10 +336,10 @@ describe('View Recipe Page', () => {
           .wait(menuActionExport)
           .evaluate(element => document.querySelector(element).innerText
             , menuActionExport)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -359,10 +360,10 @@ describe('View Recipe Page', () => {
           .wait(exportRecipePage.labelExportTitle)
           .evaluate(page => document.querySelector(page.labelExportTitle).innerText
             , exportRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -397,11 +398,11 @@ describe('View Recipe Page', () => {
             })
             .then(() => nightmare
               .evaluate(page => document.querySelector(page.textAreaContent).value
-                , exportRecipePage)
-              .end())
+                , exportRecipePage))
             .then((element) => {
               expect(element).toBe(expectedContent);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }
 
@@ -464,12 +465,12 @@ describe('View Recipe Page', () => {
 
               // return the text
               return clipboardText;
-            })
-            .end())
+            }))
           .then((element) => {
             // remove the last "\n" from paste result with trim()
             expect(element.trim()).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });
@@ -496,10 +497,10 @@ describe('View Recipe Page', () => {
           .wait(menuActionExport)
           .evaluate(element => document.querySelector(element).innerText
             , menuActionExport)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -520,10 +521,10 @@ describe('View Recipe Page', () => {
           .wait(exportRecipePage.labelExportTitle)
           .evaluate(page => document.querySelector(page.labelExportTitle).innerText
             , exportRecipePage)
-          .end()
           .then((element) => {
             expect(element).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
       test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -558,11 +559,11 @@ describe('View Recipe Page', () => {
             })
             .then(() => nightmare
               .evaluate(page => document.querySelector(page.textAreaContent).value
-                , exportRecipePage)
-              .end())
+                , exportRecipePage))
             .then((element) => {
               expect(element).toBe(expectedContent);
-              done();
+
+              eval(fs.readFileSync('utils/coverage.js').toString());
             });
         }
 
@@ -625,12 +626,12 @@ describe('View Recipe Page', () => {
 
               // return the text
               return clipboardText;
-            })
-            .end())
+            }))
           .then((element) => {
             // remove the last "\n" from paste result with trim()
             expect(element.trim()).toBe(expected);
-            done();
+
+            eval(fs.readFileSync('utils/coverage.js').toString());
           });
       }, timeout);
     });

--- a/test/end-to-end/utils/coverage.js
+++ b/test/end-to-end/utils/coverage.js
@@ -1,0 +1,24 @@
+/* eslint no-undef: off */
+/* eslint no-console: off */
+/* eslint global-require: off */
+/* eslint no-underscore-dangle: off */
+
+
+// collects coverage from the tested page,
+// calls nightmare.end() and calls done()
+// executed via eval() as a last step of every test!
+
+nightmare
+  .evaluate(() => window.__coverage__)
+  .end()
+  .then((cov) => {
+    const strCoverage = JSON.stringify(cov);
+    const hash = require('crypto').createHmac('sha256', '')
+      .update(strCoverage)
+      .digest('hex');
+    const fileName = `/tmp/coverage-${hash}.json`;
+    require('fs').writeFileSync(fileName, strCoverage);
+
+    done();
+  })
+.catch(err => console.log(err));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,11 +15,18 @@ const AssetsPlugin = require('assets-webpack-plugin');
 const pkg = require('./package.json');
 const isDebug = global.DEBUG === false ? false : !process.argv.includes('--release');
 const isVerbose = process.argv.includes('--verbose') || process.argv.includes('-v');
+const enableCoverage = process.argv.includes('--with-coverage');
 const useHMR = !!global.HMR; // Hot Module Replacement (HMR)
 const babelConfig = Object.assign({}, pkg.babel, {
   babelrc: false,
   cacheDirectory: useHMR,
 });
+// if coverage needs to be enabled
+// NOTE: use this only when running e2e tests
+// because double instrumentation breaks coverage from unit tests
+if (enableCoverage) {
+  babelConfig.plugins.push('istanbul');
+}
 // Webpack configuration (main.js => public/dist/main.{hash}.js)
 // http://webpack.github.io/docs/configuration.html
 const config = {


### PR DESCRIPTION
This is all the works necessary to support this. See the commit logs for more details but it boils down to:

1) Instrument the application code (main.js, pages, etc) with babel-plugin-istanbul. Only do this if --with-coverage has been passed on the command line otherwise we mess up unit tests (more precisely coverage from them)

2) In e2e tests make a slight modification how we chain and terminate Nightmare calls. This is necessary b/c we have to bring that coverage information from the browser scope (the page under test) to nodejs scope (the code doing the testing) and finally close the electron instance running the application.

**WARNING**: the above requires a bit of change in the way tests are written, in particular don't call `.end()` and `done()` but instead call the coverage handling code inside the last `.then()` method after all assertions have been executed. This is described in README but fyi <--- @jgiardino @henrywang @jkozol 

**NOTE** I do use a soft of ugly and hackish `eval()` to execute my coverage helper. I've tried splitting this out into a proper module and instead calling a function from the module but for some reason it doesn't work. I've asked around several experienced nodejs developers and they couldn't figure it out. It works for now and is only a one line, which is easy to copy&paste. If necessary we can change it in the future, provided somebody figures out how. Honestly I've spent too much time on this just trying to figure out why it doesn't work when the code is split into a helper function instead of copying the same code into the last `.then()` method body.

3) e2e coverage reports are stored under `.nyc_output` on the host and the nyc tool can be used to generate the reports.

4) Finally I've switched from Coveralls to CodeCov in order to be able to unify the two coverage reports. This is the easiest way given that Travis executes everything in a separate environment and doesn't allow sharing of artifacts between them

You can see an example report against my fork at:
https://codecov.io/gh/atodorov/welder-web/commits
