### PR TITLE
Sorting PR

### DIFF
--- a/components/ListView/DependencyListView.js
+++ b/components/ListView/DependencyListView.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import ListView from '../../components/ListView/ListView';
 import ListItemComponents from '../../components/ListView/ListItemComponents';
 
-class DependencyListView extends React.PureComponent {
+class DependencyListView extends React.Component {
+  componentWillMount() {}
+
   render() {
     return (
       <div>
@@ -39,6 +41,7 @@ DependencyListView.propTypes = {
   handleComponentDetails: PropTypes.func,
   handleRemoveComponent: PropTypes.func,
   componentDetailsParent: PropTypes.object,
+  className: PropTypes.string,
 };
 
 export default DependencyListView;

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -41,9 +41,30 @@ const Toolbar = props => (
             <li><a>Version</a></li>
           </ul>
         </div>
-        <button className="btn btn-link" type="button">
-          <span className="fa fa-sort-alpha-asc" />
-        </button>
+        {props.componentsSortKey === 'name' && props.componentsSortValue === 'DESC' &&
+          <button
+            className="btn btn-link"
+            type="button"
+            onClick={() => {
+              props.componentsSortSetValue('ASC');
+              props.dependenciesSortSetValue('ASC');
+            }}
+          >
+            <span className="fa fa-sort-alpha-asc" />
+          </button>
+        ||
+        props.componentsSortKey === 'name' && props.componentsSortValue === 'ASC' &&
+          <button
+            className="btn btn-link"
+            type="button"
+            onClick={() => {
+              props.componentsSortSetValue('DESC');
+              props.dependenciesSortSetValue('DESC');
+            }}
+          >
+            <span className="fa fa-sort-alpha-desc" />
+          </button>
+        }
       </div>
 
       <div className="toolbar-pf-action-right">

--- a/core/actions/sort.js
+++ b/core/actions/sort.js
@@ -1,0 +1,47 @@
+export const RECIPES_SORT_SET_KEY = 'RECIPES_SORT_SET_KEY';
+export const recipesSortSetKey = (key) => ({
+  type: RECIPES_SORT_SET_KEY,
+  payload: {
+    key,
+  },
+});
+
+export const RECIPES_SORT_SET_VALUE = 'RECIPES_SORT_SET_VALUE';
+export const recipesSortSetValue = (value) => ({
+  type: RECIPES_SORT_SET_VALUE,
+  payload: {
+    value,
+  },
+});
+
+export const DEPENDENCIES_SORT_SET_KEY = 'DEPENDENCIES_SORT_SET_KEY';
+export const dependenciesSortSetKey = (key) => ({
+  type: DEPENDENCIES_SORT_SET_KEY,
+  payload: {
+    key,
+  },
+});
+
+export const DEPENDENCIES_SORT_SET_VALUE = 'DEPENDENCIES_SORT_SET_VALUE';
+export const dependenciesSortSetValue = (value) => ({
+  type: DEPENDENCIES_SORT_SET_VALUE,
+  payload: {
+    value,
+  },
+});
+
+export const COMPONENTS_SORT_SET_KEY = 'COMPONENTS_SORT_SET_KEY';
+export const componentsSortSetKey = (key) => ({
+  type: COMPONENTS_SORT_SET_KEY,
+  payload: {
+    key,
+  },
+});
+
+export const COMPONENTS_SORT_SET_VALUE = 'COMPONENTS_SORT_SET_VALUE';
+export const componentsSortSetValue = (value) => ({
+  type: COMPONENTS_SORT_SET_VALUE,
+  payload: {
+    value,
+  },
+});

--- a/core/reducers/index.js
+++ b/core/reducers/index.js
@@ -6,6 +6,7 @@ import recipePage from './recipePage';
 import inputs from './inputs';
 import modals from './modals';
 import rehydrated from './rehydrated';
+import sort from './sort';
 
 const rootReducer = combineReducers({
   states,
@@ -15,6 +16,7 @@ const rootReducer = combineReducers({
   inputs,
   modals,
   rehydrated,
+  sort,
 });
 
 export default rootReducer;

--- a/core/reducers/sort.js
+++ b/core/reducers/sort.js
@@ -1,0 +1,65 @@
+import {
+  RECIPES_SORT_SET_KEY,
+  RECIPES_SORT_SET_VALUE,
+  DEPENDENCIES_SORT_SET_KEY,
+  DEPENDENCIES_SORT_SET_VALUE,
+  COMPONENTS_SORT_SET_KEY,
+  COMPONENTS_SORT_SET_VALUE,
+} from '../actions/sort';
+
+const sort = (state = [], action) => {
+  switch (action.type) {
+    case RECIPES_SORT_SET_KEY:
+      return {
+        ...state,
+        recipes: {
+          ...state.recipes,
+          key: action.payload.key,
+        },
+      };
+    case RECIPES_SORT_SET_VALUE:
+      return {
+        ...state,
+        recipes: {
+          ...state.recipes,
+          value: action.payload.value,
+        },
+      };
+    case COMPONENTS_SORT_SET_KEY:
+      return {
+        ...state,
+        components: {
+          ...state.components,
+          key: action.payload.key,
+        },
+      };
+    case COMPONENTS_SORT_SET_VALUE:
+      return {
+        ...state,
+        components: {
+          ...state.components,
+          value: action.payload.value,
+        },
+      };
+    case DEPENDENCIES_SORT_SET_KEY:
+      return {
+        ...state,
+        dependencies: {
+          ...state.dependencies,
+          key: action.payload.key,
+        },
+      };
+    case DEPENDENCIES_SORT_SET_VALUE:
+      return {
+        ...state,
+        dependencies: {
+          ...state.dependencies,
+          value: action.payload.value,
+        },
+      };
+    default:
+      return state;
+  }
+};
+
+export default sort;

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -9,3 +9,61 @@ export const makeGetRecipeById = () => createSelector(
   [getRecipeById],
   (recipe) => recipe
 );
+
+const getSortedComponents = (state, recipe) => {
+  // TODO; sort
+  const sortedComponents = recipe.components;
+  if (sortedComponents === undefined) {
+    return [];
+  }
+  const key = state.sort.components.key;
+  const value = state.sort.components.value;
+  sortedComponents.sort((a, b) => {
+    if (a[key] > b[key]) return value === 'DESC' ? 1 : -1;
+    if (b[key] > a[key]) return value === 'DESC' ? -1 : 1;
+    return 0;
+  });
+  return sortedComponents;
+};
+
+export const makeGetSortedComponents = () => createSelector(
+  [getSortedComponents],
+  (components) => components
+);
+
+const getSortedDependencies = (state, recipe) => {
+  const sortedDependencies = recipe.dependencies;
+  if (sortedDependencies === undefined) {
+    return [];
+  }
+  const key = state.sort.dependencies.key;
+  const value = state.sort.dependencies.value;
+  sortedDependencies.sort((a, b) => {
+    if (a[key] > b[key]) return value === 'DESC' ? 1 : -1;
+    if (b[key] > a[key]) return value === 'DESC' ? -1 : 1;
+    return 0;
+  });
+  return sortedDependencies;
+};
+
+export const makeGetSortedDependencies = () => createSelector(
+  [getSortedDependencies],
+  (dependencies) => dependencies
+);
+
+const getSortedRecipes = (state) => {
+  const sortedRecipes = state.recipes;
+  const key = state.sort.recipes.key;
+  const value = state.sort.recipes.value;
+  sortedRecipes.sort((a, b) => {
+    if (a[key] > b[key]) return value === 'DESC' ? 1 : -1;
+    if (b[key] > a[key]) return value === 'DESC' ? -1 : 1;
+    return 0;
+  });
+  return sortedRecipes;
+};
+
+export const makeGetSortedRecipes = () => createSelector(
+  [getSortedRecipes],
+  (recipes) => recipes
+);

--- a/core/store.js
+++ b/core/store.js
@@ -50,6 +50,20 @@ const initialState = {
       },
     },
   },
+  sort: {
+    recipes: {
+      key: 'name',
+      value: 'ASC',
+    },
+    components: {
+      key: 'name',
+      value: 'ASC',
+    },
+    dependencies: {
+      key: 'name',
+      value: 'ASC',
+    },
+  },
 };
 
 const store = createStore(

--- a/core/store.js
+++ b/core/store.js
@@ -53,15 +53,15 @@ const initialState = {
   sort: {
     recipes: {
       key: 'name',
-      value: 'ASC',
+      value: 'DESC',
     },
     components: {
       key: 'name',
-      value: 'ASC',
+      value: 'DESC',
     },
     dependencies: {
       key: 'name',
-      value: 'ASC',
+      value: 'DESC',
     },
   },
 };

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -789,8 +789,8 @@ const makeMapStateToProps = () => {
     return {
       rehydrated: state.rehydrated,
       recipe: {},
-      components: {},
-      dependencies: {},
+      components: [],
+      dependencies: [],
       recipePage: state.recipePage,
       exportModalVisible: state.modals.exportRecipe.visible,
       compositionTypes: state.modals.createComposition.compositionTypes,

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -642,8 +642,8 @@ const makeMapStateToProps = () => {
     return {
       rehydrated: state.rehydrated,
       recipe: {},
-      components: {},
-      dependencies: {},
+      components: [],
+      dependencies: [],
       componentsSortKey: state.sort.components.key,
       componentsSortValue: state.sort.components.value,
       createComposition: state.modals.createComposition,


### PR DESCRIPTION
Recipes, components, and dependencies can be sorting by name in either ascending or descending order on the recipes page, recipe page, and editRecipe page. The tests all pass locally and I am unsure why they fail on travis. 