### PR TITLE
Drop references to external code

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import FastClick from 'fastclick';
 import { Provider } from 'react-redux';
+import 'bootstrap';
+import 'bootstrap-select';
 
 import store from './core/store';
 import router from './core/router';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-register": "^6.11.6",
     "babel-runtime": "^6.11.6",
     "bootstrap": "^3.3.7",
+    "bootstrap-select": "^1.12.4",
     "browser-sync": "^2.13.0",
     "connect-history-api-fallback": "^1.2.0",
     "copy-webpack-plugin": "^3.0.1",

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -12,11 +12,9 @@
     <link rel="stylesheet" href="./custom.css">
 
     <!-- js dependencies -->
-    <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="dist/jquery.min.js"></script>
+    <script src="dist/jquery.matchHeight-min.js"></script>
     <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/bootstrap-select.min.js"></script>
     <script src="dist/webcomponents-lite.js"></script>
     <script src="dist/native-shim.js"></script>
     <script src="./js/config.js"></script>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,5 +10,5 @@
             "order": 8
         }
     },
-    "content-security-policy": "default-src 'self' code.jquery.com maxcdn.bootstrapcdn.com  cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ if (enableCoverage) {
 // Webpack configuration (main.js => public/dist/main.{hash}.js)
 // http://webpack.github.io/docs/configuration.html
 const config = {
-  externals: { cockpit: 'cockpit' },
+  externals: { cockpit: 'cockpit', jQuery: 'jquery' },
 
   // The base directory for resolving the entry option
   context: __dirname,
@@ -116,6 +116,16 @@ const config = {
         from: {
           glob: 'node_modules/@webcomponents/custom-elements/src/native-shim.js',
         },
+        to: '../dist',
+        flatten: true,
+      },
+      {
+        from: { glob: './node_modules/jquery/dist/jquery.min.js' },
+        to: '../dist',
+        flatten: true,
+      },
+      {
+        from: { glob: './node_modules/jquery-match-height/dist/jquery.matchHeight-min.js' },
         to: '../dist',
         flatten: true,
       },


### PR DESCRIPTION
Pull in jQuery, jquery.matchHeight, bootstrap, and bootstrap-select via
npm and webpack instead of external URLs. Drop these from
Content-Security-Policy.

---

Official cockpit modules must have a "strict" C-S-P without external code and also without `unsafe-inline` and `unsafe-eval`. This PR gets rid of the former.

I kept jQuery as separate .js files, I think (for some reason, not sure why) that is a common pattern. However, bootstrap should be fine to get pulled in via `import` and bundled via webpack (so it ends up in the bundled main.js), and in my manual tests that seems to work.