### PR TITLE
Only install firebase-tools on demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "eslint-plugin-redux-saga": "^0.4.0",
     "faker": "^4.1.0",
     "file-loader": "^0.9.0",
-    "firebase-tools": "^3.0.4",
     "front-matter": "^2.1.0",
     "highlight.js": "^9.5.0",
     "jest": "^20.0.4",

--- a/run.js
+++ b/run.js
@@ -77,7 +77,19 @@ tasks.set('build', () => {
 // Build and publish the website
 // -----------------------------------------------------------------------------
 tasks.set('publish', () => {
-  const firebase = require('firebase-tools');
+  /* firebase is huge, and not required for development, so install on demand */
+  let firebase;
+  try {
+    firebase = require('firebase-tools');  // eslint-disable-line import/no-unresolved
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      const execSync = require('child_process').execSync;
+      execSync('npm install --no-save firebase-tools', { stdio: ['pipe', 'inherit', 'inherit'] });
+      firebase = require('firebase-tools');  // eslint-disable-line import/no-unresolved
+    } else {
+      throw err;
+    }
+  }
   return run('build')
     .then(() => firebase.login({ nonInteractive: false }))
     .then(() => firebase.deploy({


### PR DESCRIPTION
The firebase-tools NPM module and its dependendies take over 230 MB, and
for normal building, development, and CI it's not necessary. Thus move
it out of package.json and install it on demand for "npm run publish".