### PR TITLE
Drop nav bar, and hide header bar in Cockpit

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -4,12 +4,6 @@ function Header() {
   return (
     <nav className="navbar navbar-pf-vertical">
       <div className="navbar-header">
-        <button type="button" className="navbar-toggle">
-          <span className="sr-only">Toggle navigation</span>
-          <span className="icon-bar"></span>
-          <span className="icon-bar"></span>
-          <span className="icon-bar"></span>
-        </button>
         <a href="/" className="navbar-brand">
           <img className="navbar-brand-name" src="/logo-header.svg" alt="" width="220" />
         </a>

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Header from './Header';
-import Navigation from './Navigation';
 import Notification from '../../components/Notifications/Notification';
 import NotificationsApi from '../../data/NotificationsApi';
 import utils from '../../core/utils';
@@ -31,7 +30,6 @@ class Layout extends React.Component {
     return (
       <div className={this.headerClass()}>
         <Header />
-        <Navigation />
         {this.state.notifications &&
           <div className="toast-notifications-list-pf">
             {this.state.notifications.map((notification, i) =>

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -29,7 +29,7 @@ class Layout extends React.Component {
   render() {
     return (
       <div className={this.headerClass()}>
-        <Header />
+        {! utils.inCockpit && <Header />}
         {this.state.notifications &&
           <div className="toast-notifications-list-pf">
             {this.state.notifications.map((notification, i) =>

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -254,7 +254,7 @@ class RecipePage extends React.Component {
     const activeRevision = this.state.revisions.filter((obj) => obj.active === true)[0];
     const pastRevisions = this.state.revisions.filter((obj) => obj.active === false);
     return (
-      <Layout className="container-fluid container-pf-nav-pf-vertical" ref="layout">
+      <Layout className="container-fluid" ref="layout">
         <header className="cmpsr-header">
           <ol className="breadcrumb">
             <li><Link to="/recipes">Back to Recipes</Link></li>

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -395,7 +395,7 @@ class EditRecipePage extends React.Component {
 
     return (
       <Layout
-        className="container-pf-nav-pf-vertical cmpsr-grid__wrapper"
+        className="cmpsr-grid__wrapper"
         ref={c => {
           this.layout = c;
         }}

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -62,7 +62,7 @@ class RecipesPage extends React.Component {
   render() {
     const { recipes, exportRecipe, createComposition, recipeSortKey, recipeSortValue } = this.props;
     return (
-      <Layout className="container-fluid container-pf-nav-pf-vertical" ref="layout">
+      <Layout className="container-fluid" ref="layout">
         <div className="row toolbar-pf">
           <div className="col-sm-12">
             <form className="toolbar-pf-actions">

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en-us" class="layout-pf layout-pf-fixed">
+<html lang="en-us" class="layout-pf">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
Now that the Overview and Users menu entries are gone, "Recipes" is the only one left and thus the navigation bar is currently unused. I left it in the code for now, but not show it. (We can clean up the unused code later).

Also, the header bar is redundant in Cockpit, so hide it there.