### PR TITLE
Enable recommended eslint checks and fix resulting errors

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -1,4 +1,3 @@
-/* global welderApiHost */
 /* *
   Application Constants
  */

--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -2,6 +2,7 @@ import { call, put, takeEvery } from 'redux-saga/effects';
 import { fetchRecipeInputsApi } from '../apiCalls';
 import { FETCHING_INPUTS, fetchingInputsSucceeded } from '../actions/inputs';
 
+/* eslint require-yield: "warn" */ // FIXME: issue #151
 function* updateInputComponentData(inputs, componentData) {
   let updatedInputs = inputs;
   if (componentData !== undefined && componentData.length > 0) {

--- a/core/store.js
+++ b/core/store.js
@@ -71,8 +71,8 @@ const store = createStore(
   initialState,
   composeEnhancers(
     applyMiddleware(sagaMiddleware),
-    autoRehydrate(),
-  ),
+    autoRehydrate()
+  )
 );
 sagaMiddleware.run(rootSaga);
 

--- a/core/utils.js
+++ b/core/utils.js
@@ -1,7 +1,7 @@
 /* global somefunction welderApiHost:true */
 /* global somefunction welderApiScheme:true */
 /* global somefunction welderApiPort:true */
-/* global somefunction welderApiRelative:true */
+/* global somefunction welderApiRelative:true */ // eslint-disable-line no-unused-vars
 
 let cockpit;
 let cockpitHttp;

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
   },
   "eslintConfig": {
     "parser": "babel-eslint",
-    "extends": "airbnb",
+    "extends": ["airbnb", "eslint:recommended"],
     "rules": {
       "max-len": [
         "error",


### PR DESCRIPTION
This triggers a few errors for unused variables, trailing commas in
function arguments, but most importantly a missing `yield` in
core/sagas/inputs.js (see issue #151). Tone down that error into a
warning for the time being, until this gets fixed properly.

---
I stumbled over these when trying to build welder-web in Cockpit. That has these eslint errors on, so the build failed due to these.