### PR TITLE
E2e cov fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 before_install:
   - |
         npm install codecov
-        npm install nyc
+        npm install nyc@11.1.0
 
         if [ "$COMMAND" == "cockpit-test" ]; then
             sudo docker pull welder/web-e2e-tests:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ after_success:
                 docker push welder/web
                 docker push welder/web-e2e-tests
             fi
-            if [ "$COMMAND" == "cockpit-test" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+            if [ "$COMMAND" == "cockpit-test" ]; then
                 sudo docker tag welder/web-cockpit:latest welder/web-cockpit:$TRAVIS_BUILD_NUMBER
                 docker push welder/web-cockpit
             fi


### PR DESCRIPTION
1. Remove duplicate condition limitation.

1. Keep nyc on @11.1.0 to fix issue - "nyc report" generates "Unknown" code coverage report for e2e test, but not for cockpit-test.
The issue analysis can be found from: https://trello.com/c/IjYvUgcc/429-automation-bugnyc-report-generates-unknown-code-coverage-report-for-e2e-test-but-not-for-cockpit-test