### PR TITLE
Lower required jquery version to 2.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "classnames": "^2.2.5",
     "fastclick": "^1.0.6",
     "history": "^3.0.0",
-    "jquery": "^3.1.1",
+    "jquery": "^2.1",
     "jquery-match-height": "^0.7.0",
     "patternfly": "^3.23.1",
     "patternfly-webcomponents": "0.0.8",


### PR DESCRIPTION
The dependency was added in 71a63b230d51 without a particular reason,
thus presumably to just whichever version was current at that time.
However, Cockpit currently uses (and exposes as part of its API) jQuery
2.x only, so lower the minimum version.

----

I went through all the pages, and everything seems to work normally. I also locally ran the tests.