### PR TITLE
Avoid using non-standardized ECMAScript features

### DIFF
--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -8,16 +8,15 @@ import utils from '../../core/utils';
 class Layout extends React.Component {
   constructor() {
     super();
+    this.state = { notifications: [] };
     this.setNotifications = this.setNotifications.bind(this);
   }
-
-  state = { notifications: [] }
 
   componentWillMount() {
     this.setNotifications();
   }
 
-  setNotifications = () => {
+  setNotifications() {
     this.setState({ notifications: NotificationsApi.getNotifications() });
   }
 

--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -33,8 +33,9 @@ class Link extends React.Component {
   };
 
   render() {
-    const { to, ...props } = this.props; // eslint-disable-line no-use-before-define
-    return (<a href={history.createHref(to)} {...props} onClick={this.handleClick}>
+    var propsWithoutTo = Object.assign({}, this.props);
+    delete propsWithoutTo.to;
+    return (<a href={history.createHref(this.props.to)} {...propsWithoutTo} onClick={this.handleClick}>
       {this.props.children}
     </a>);
   }

--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import history from '../../core/history';
 
 class Link extends React.Component {
-  handleClick = (event) => {
+  constructor() {
+    super();
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick (event) {
     if (this.props.onClick) {
       this.props.onClick(event);
     }
@@ -30,7 +35,7 @@ class Link extends React.Component {
         search: event.currentTarget.search,
       });
     }
-  };
+  }
 
   render() {
     var propsWithoutTo = Object.assign({}, this.props);

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -7,15 +7,20 @@ import DependencyListView from '../../components/ListView/DependencyListView';
 import MetadataApi from '../../data/MetadataApi';
 
 class ComponentDetailsView extends React.Component {
-  state = {
-    selectedBuildIndex: 0,
-    availableBuilds: [],
-    activeTab: 'Details',
-    parents: [],
-    dependencies: [],
-    componentData: {},
-    editSelected: false,
-  };
+  constructor() {
+    super();
+    this.state = {
+      selectedBuildIndex: 0,
+      availableBuilds: [],
+      activeTab: 'Details',
+      parents: [],
+      dependencies: [],
+      componentData: {},
+      editSelected: false,
+    };
+    this.handleEdit = this.handleEdit.bind(this);
+    this.handleVersionSelect = this.handleVersionSelect.bind(this);
+  }
 
   componentWillMount() {
     this.getMetadata(this.props.component, this.props.status);
@@ -91,7 +96,7 @@ class ComponentDetailsView extends React.Component {
     $('[data-toggle="tooltip"]').tooltip();
   }
 
-  handleEdit = event => {
+  handleEdit(event) {
     if (event) {
       event.preventDefault();
     }
@@ -107,9 +112,9 @@ class ComponentDetailsView extends React.Component {
       .catch(e => console.log(`handleEdit: Error getting component metadata: ${e}`));
     // display the form
     this.setState({ editSelected: true });
-  };
+  }
 
-  handleVersionSelect = event => {
+  handleVersionSelect(event) {
     this.setState({ selectedBuildIndex: event.target.value });
     const builds = this.state.availableBuilds;
     const componentData = this.state.componentData;
@@ -117,7 +122,7 @@ class ComponentDetailsView extends React.Component {
     componentData.release = builds[event.target.value].release;
     // TODO any data that we display that's defined in builds should be added here
     this.setState({ componentData });
-  };
+  }
 
   handleTabChanged(e) {
     if (this.state.activeTab !== e.detail) {
@@ -186,7 +191,7 @@ class ComponentDetailsView extends React.Component {
               {this.props.status === 'selected' &&
                 this.state.editSelected === false &&
                 <li>
-                  <button className="btn btn-primary" type="button" onClick={e => this.handleEdit(e)}>Edit</button>
+                  <button className="btn btn-primary" type="button" onClick={this.handleEdit}>Edit</button>
                 </li>}
               {((this.props.status === 'selected' && this.state.editSelected === true) || this.props.status === 'editSelected') &&
                 <li>
@@ -248,7 +253,7 @@ class ComponentDetailsView extends React.Component {
                     id="cmpsr-compon__version-select"
                     className="form-control"
                     value={this.state.selectedBuildIndex}
-                    onChange={e => this.handleVersionSelect(e)}
+                    onChange={this.handleVersionSelect}
                   >
                     {this.state.availableBuilds.map((build, i) => (
                       <option key={i} value={i}>{build.version}-{build.release}</option>
@@ -283,7 +288,7 @@ class ComponentDetailsView extends React.Component {
                   {' '}
                   {this.props.status === 'selected' &&
                     this.state.editSelected === false &&
-                    <a href="#" onClick={e => this.handleEdit(e)}>Update</a>}
+                    <a href="#" onClick={this.handleEdit}>Update</a>}
                 </dd>
                 <dt>Release</dt>
                 <dd>{this.state.componentData.release}</dd>

--- a/components/ListView/ComponentSummaryList.js
+++ b/components/ListView/ComponentSummaryList.js
@@ -3,15 +3,18 @@ import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';
 
 class ComponentSummaryList extends React.Component {
-  state = { showAll: false };
+  constructor() {
+    super();
+    this.state = { showAll: false };
+  }
 
-  handleShowAll = event => {
+  handleShowAll(event) {
     // the user clicked a list item in the recipe contents area to expand or collapse
     const showState = !this.state.showAll;
     this.setState({ showAll: showState });
     event.preventDefault();
     event.stopPropagation();
-  };
+  }
 
   render() {
     const listItems = this.state.showAll ? this.props.listItems : this.props.listItems.slice(0, 5);

--- a/components/ListView/ListItemComponents.js
+++ b/components/ListView/ListItemComponents.js
@@ -6,7 +6,10 @@ import MetadataApi from '../../data/MetadataApi';
 import constants from '../../core/constants';
 
 class ListItemComponents extends React.Component {
-  state = { expanded: false, dependencies: [], showAllDeps: false };
+  constructor() {
+    super();
+    this.state = { expanded: false, dependencies: [], showAllDeps: false };
+  }
 
   componentWillReceiveProps(newProps) {
     // compare old value to new value, and if this component is getting new data,
@@ -40,7 +43,7 @@ class ListItemComponents extends React.Component {
     return p;
   }
 
-  handleExpandComponent = event => {
+  handleExpandComponent(event) {
     // the user clicked a list item in the recipe contents area to expand or collapse
     if (!$(event.target).is('button, a, input, .fa-ellipsis-v')) {
       const expandState = !this.state.expanded;
@@ -49,7 +52,7 @@ class ListItemComponents extends React.Component {
         this.getDependencies(this.props.listItem);
       }
     }
-  };
+  }
 
   render() {
     const { listItem } = this.props;

--- a/components/ListView/ListItemRevisions.js
+++ b/components/ListView/ListItemRevisions.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import Link from '../../components/Link';
 
 class ListItemRevisions extends React.Component {
-  state = { expanded: false };
+  constructor() {
+    super();
+    this.state = { expanded: false };
+    this.handleExpandComponent = this.handleExpandComponent.bind(this);
+  }
 
   componentWillReceiveProps(newProps) {
     // compare old value to new value, and if this component is getting new data,
@@ -21,13 +25,13 @@ class ListItemRevisions extends React.Component {
     }
   }
 
-  handleExpandComponent = event => {
+  handleExpandComponent(event) {
     // the user clicked a list item in the recipe contents area to expand or collapse
     if (!$(event.target).is('button, a, input, .fa-ellipsis-v')) {
       const expandState = !this.state.expanded;
       this.setState({ expanded: expandState });
     }
-  };
+  }
 
   render() {
     const { listItem } = this.props;
@@ -38,7 +42,7 @@ class ListItemRevisions extends React.Component {
     return (
       <div className={`list-pf-item ${this.state.expanded ? 'active' : ''}`}>
 
-        <div className="list-pf-container" onClick={e => this.handleExpandComponent(e)}>
+        <div className="list-pf-container" onClick={this.handleExpandComponent}>
           <div className="list-pf-chevron">
             <span className={`fa ${this.state.expanded ? 'fa-angle-down' : 'fa-angle-right'}`} />
           </div>

--- a/components/ListView/RecipeContents.js
+++ b/components/ListView/RecipeContents.js
@@ -9,12 +9,9 @@ import DependencyListView from '../../components/ListView/DependencyListView';
 class RecipeContents extends React.Component {
   constructor() {
     super();
+    this.state = { activeTab: 'Components' };
     this.handleTabChanged = this.handleTabChanged.bind(this);
   }
-
-  state = {
-    activeTab: 'Components',
-  };
 
   handleTabChanged(e) {
     if (this.state.activeTab !== e.detail) {

--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -4,7 +4,10 @@ import Link from '../../components/Link';
 import CreateComposition from '../../components/Modal/CreateComposition';
 
 class RecipeListView extends React.Component {
-  state = { recipe: '' };
+  constructor() {
+    super();
+    this.state = { recipe: '' };
+  }
 
   // The following enables the expand/collapse interaction
   // componentDidMount() {
@@ -50,7 +53,7 @@ class RecipeListView extends React.Component {
   //   $('.list-group-item-container .close').off('click');
   // }
 
-  handleCreateCompos = (recipe) => {
+  handleCreateCompos(recipe) {
     this.setState({ recipe });
     $('#cmpsr-modal-crt-compos').modal('show');
   }

--- a/components/Modal/CreateComposition.js
+++ b/components/Modal/CreateComposition.js
@@ -3,8 +3,12 @@ import PropTypes from 'prop-types';
 import NotificationsApi from '../../data/NotificationsApi';
 
 class CreateComposition extends React.Component {
+  constructor() {
+    super();
+    this.handleCreateCompos = this.handleCreateCompos.bind(this);
+  }
 
-  handleCreateCompos = () => {
+  handleCreateCompos() {
     $('#cmpsr-modal-crt-compos').modal('hide');
     NotificationsApi.displayNotification(this.props.recipe, 'creating');
     this.props.setNotifications();
@@ -66,7 +70,7 @@ class CreateComposition extends React.Component {
             </div>
             <div className="modal-footer">
               <button type="button" className="btn btn-default" data-dismiss="modal">Cancel</button>
-              <button type="button" className="btn btn-primary" onClick={() => this.handleCreateCompos()}>Create</button>
+              <button type="button" className="btn btn-primary" onClick={this.handleCreateCompos}>Create</button>
             </div>
           </div>
         </div>

--- a/components/Modal/CreateRecipe.js
+++ b/components/Modal/CreateRecipe.js
@@ -40,7 +40,7 @@ class CreateRecipe extends React.Component {
     $('#cmpsr-modal-crt-compos .btn-primary').off('shown.bs.modal');
   }
 
-  handleChange = (e, prop) => {
+  handleChange(e, prop) {
     const o = Object.assign({}, this.props.createRecipe.recipe);
     o[prop] = e.target.value;
     this.props.setModalCreateRecipeRecipe(o);
@@ -48,7 +48,7 @@ class CreateRecipe extends React.Component {
       this.dismissErrors();
       this.handleErrorDuplicate(e.target.value);
     }
-  };
+  }
 
   handleEnterKey(event) {
     if (event.which === 13 || event.keyCode === 13) {

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -2,15 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class PendingChanges extends React.Component {
-
-  // dummy data
-  state = {
-    componentUpdates: [
-      { componentOld: null, componentNew: 'rsync-3.0-17.317' },
-      { componentOld: 'httpd-2.3-45.el7', componentNew: 'httpd-2.4-45.el7' },
-      { componentOld: 'basesystem-10.0-7.el7', componentNew: null },
-    ],
-  };
+  constructor() {
+    super();
+    // dummy data
+    this.state = {
+      componentUpdates: [
+        { componentOld: null, componentNew: 'rsync-3.0-17.317' },
+        { componentOld: 'httpd-2.3-45.el7', componentNew: 'httpd-2.4-45.el7' },
+        { componentOld: 'basesystem-10.0-7.el7', componentNew: null },
+      ],
+    };
+  }
 
   componentDidMount() {
     $(this.modal).modal('show');

--- a/components/Notifications/Notification.js
+++ b/components/Notifications/Notification.js
@@ -33,7 +33,7 @@ class Notification extends React.PureComponent {
     this.timeouts.forEach(clearTimeout);
   }
 
-  setFade = (fade) => {
+  setFade(fade) {
     if (fade === true) {
       this.timeouts.push(setTimeout(() => {
         NotificationsApi.closeNotification(this.props.id);
@@ -42,11 +42,11 @@ class Notification extends React.PureComponent {
     }
   }
 
-  stopFade = () => {
+  stopFade() {
     this.clearTimeouts();
   }
 
-  handleClose = (e, id) => {
+  handleClose(e, id) {
     e.preventDefault();
     e.stopPropagation();
     NotificationsApi.closeNotification(id);

--- a/components/Pagination/Pagination.js
+++ b/components/Pagination/Pagination.js
@@ -2,8 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class Pagination extends React.Component {
-
-  state = { pageValue: '' }
+  constructor() {
+    super();
+    this.state = { pageValue: '' }
+    this.handleBlur = this.handleBlur.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+  }
 
   componentWillMount() {
     this.setState({ pageValue: this.props.currentPage });
@@ -18,13 +22,13 @@ class Pagination extends React.Component {
     }
   }
 
-  handleBlur = () => {
+  handleBlur() {
     // if the user exits the field when the value != the current page
     // then reset the page value
     this.setState({ pageValue: this.props.currentPage });
   }
 
-  handleChange = (event) => {
+  handleChange(event) {
     // check if value is a number, if not or if <= 0, then set to ''
     let page;
     if (!isNaN(event.target.value) && event.target.value > 0) {

--- a/components/Tabs/Tabs.js
+++ b/components/Tabs/Tabs.js
@@ -17,8 +17,6 @@ import './pf-tabs.component';
  *
  */
 class Tabs extends React.Component {
-  state = {};
-
   componentDidUpdate() {
     this.refs.pfTabs.addEventListener('tabChanged', e => {
       if (this.props.tabChanged) {

--- a/core/reducers/inputs.js
+++ b/core/reducers/inputs.js
@@ -9,58 +9,61 @@ import {
 const inputs = (state = [], action) => {
   switch (action.type) {
     case SET_INPUT_COMPONENTS:
-      return {
-        ...state,
-        inputComponents: action.payload.inputComponents,
-      };
+      return Object.assign({}, state,
+                           { inputComponents: action.payload.inputComponents });
     case FETCHING_INPUTS_SUCCEEDED:
-      return {
-        ...state,
-        inputFilters: action.payload.filter,
-        inputComponents: action.payload.selectedInputPage > 0
-        ? state.inputComponents.slice(0, action.payload.selectedInputPage)
-          .concat([action.payload.inputs[0]].concat(Array(
-            Math.ceil((action.payload.inputs[1] / action.payload.pageSize) - 1) - action.payload.selectedInputPage).fill([])))
-        : [action.payload.inputs[0]].concat(Array(Math.ceil((action.payload.inputs[1] / action.payload.pageSize) - 1)).fill([])),
-        totalInputs: action.payload.inputs[1],
-        pageSize: action.payload.pageSize,
-      };
+      return Object.assign(
+          {}, state,
+          {
+              inputFilters: action.payload.filter,
+              inputComponents: action.payload.selectedInputPage > 0
+              ? state.inputComponents.slice(0, action.payload.selectedInputPage)
+              .concat([action.payload.inputs[0]].concat(Array(
+                  Math.ceil((action.payload.inputs[1] / action.payload.pageSize) - 1) -
+                             action.payload.selectedInputPage).fill([])))
+              : [action.payload.inputs[0]].concat(Array(
+                  Math.ceil((action.payload.inputs[1] / action.payload.pageSize) - 1)).fill([])),
+              totalInputs: action.payload.inputs[1],
+              pageSize: action.payload.pageSize,
+          });
     case SET_FILTERED_INPUT_COMPONENTS:
-      return {
-        ...state,
-        filteredInputComponents: action.payload.filteredInputComponents,
-      };
+      return Object.assign(
+          {}, state,
+          { filteredInputComponents: action.payload.filteredInputComponents }
+      );
     case SET_SELECTED_INPUT_PAGE:
-      return {
-        ...state,
-        selectedInputPage: action.payload.selectedInputPage,
-      };
+      return Object.assign(
+          {}, state,
+          { selectedInputPage: action.payload.selectedInputPage }
+      );
     case SET_SELECTED_INPUT:
-      return {
-        ...state,
-        selectedInput: { ...state.selectedInput, component: action.payload.selectedInput },
-      };
+      return Object.assign(
+          {}, state,
+          { selectedInput: Object.assign({}, state.selectedInput, { component: action.payload.selectedInput }) }
+      );
     case SET_SELECTED_INPUT_STATUS:
-      return {
-        ...state,
-        selectedInput: { ...state.selectedInput, status: action.payload.selectedInputStatus },
-      };
+      return Object.assign(
+          {}, state,
+          { selectedInput: Object.assign({}, state.selectedInput, { status: action.payload.selectedInputStatus }) }
+      );
     case SET_SELECTED_INPUT_PARENT:
-      return {
-        ...state,
-        selectedInput: { ...state.selectedInput, parent: action.payload.selectedInputParent },
-      };
+      return Object.assign(
+          {}, state,
+          { selectedInput: Object.assign({}, state.selectedInput, { parent: action.payload.selectedInputParent }) }
+      );
     case DELETE_FILTER:
-      return {
-        ...state,
-        filteredInputComponents: [[]],
-        totalFilteredInputs: 0,
-        selectedInputPage: 0,
-        inputFilters: {
-          field: 'name',
-          value: '',
-        },
-      };
+      return Object.assign(
+          {}, state,
+          {
+              filteredInputComponents: [[]],
+              totalFilteredInputs: 0,
+              selectedInputPage: 0,
+              inputFilters: {
+                  field: 'name',
+                  value: '',
+              },
+          }
+      );
     default:
       return state;
   }

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -9,45 +9,30 @@ import {
 const modalCreateRecipe = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_CREATE_RECIPE_ERROR_NAME_VISIBLE:
-      return {
-        ...state,
-        createRecipe: {
-          ...state.createRecipe,
-          errorNameVisible: action.payload.errorNameVisible,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { createRecipe: Object.assign({}, state.createRecipe, { errorNameVisible: action.payload.errorNameVisible }) }
+      );
     case SET_MODAL_CREATE_RECIPE_ERROR_DUPLICATE_VISIBLE:
-      return {
-        ...state,
-        createRecipe: {
-          ...state.createRecipe,
-          errorDuplicateVisible: action.payload.errorDuplicateVisible,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { createRecipe: Object.assign({}, state.createRecipe, { errorDuplicateVisible: action.payload.errorDuplicateVisible }) }
+      );
     case SET_MODAL_CREATE_RECIPE_ERROR_INLINE:
-      return {
-        ...state,
-        createRecipe: {
-          ...state.createRecipe,
-          errorInline: action.payload.errorInline,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { createRecipe: Object.assign({}, state.createRecipe, { errorInline: action.payload.errorInline }) }
+      );
     case SET_MODAL_CREATE_RECIPE_CHECK_ERRORS:
-      return {
-        ...state,
-        createRecipe: {
-          ...state.createRecipe,
-          checkErrors: action.payload.checkErrors,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { checkErrors: Object.assign({}, state.createRecipe, { errorInline: action.payload.checkErrors }) }
+      );
     case SET_MODAL_CREATE_RECIPE_RECIPE:
-      return {
-        ...state,
-        createRecipe: {
-          ...state.createRecipe,
-          recipe: action.payload.recipe,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { createRecipe: Object.assign({}, state.createRecipe, { recipe: action.payload.recipe }) }
+      );
     default:
       return state;
   }
@@ -56,13 +41,10 @@ const modalCreateRecipe = (state = [], action) => {
 const modalCreateComposition = (state = [], action) => {
   switch (action.type) {
     case FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS:
-      return {
-        ...state,
-        createComposition: {
-          ...state.createComposition,
-          compositionTypes: action.payload.compositionTypes,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { createComposition: Object.assign({}, state.createComposition, { compositionTypes: action.payload.compositionTypes }) }
+      );
     default:
       return state;
   }
@@ -71,29 +53,20 @@ const modalCreateComposition = (state = [], action) => {
 const modalExportRecipe = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_EXPORT_RECIPE_NAME:
-      return {
-        ...state,
-        exportRecipe: {
-          ...state.exportRecipe,
-          name: action.payload.recipeName,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { exportRecipe: Object.assign({}, state.exportRecipe, { name: action.payload.recipeName }) }
+      );
     case SET_MODAL_EXPORT_RECIPE_CONTENTS:
-      return {
-        ...state,
-        exportRecipe: {
-          ...state.exportRecipe,
-          contents: action.payload.recipeContents,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { exportRecipe: Object.assign({}, state.exportRecipe, { contents: action.payload.recipeContents }) }
+      );
     case SET_MODAL_EXPORT_RECIPE_VISIBLE:
-      return {
-        ...state,
-        exportRecipe: {
-          ...state.exportRecipe,
-          visible: action.payload.visible,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { exportRecipe: Object.assign({}, state.exportRecipe, { visible: action.payload.visible }) }
+      );
     default:
       return state;
   }
@@ -102,10 +75,7 @@ const modalExportRecipe = (state = [], action) => {
 const modals = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_ACTIVE:
-      return {
-        ...state,
-        modalActive: action.payload.modalActive,
-      };
+      return Object.assign({}, state, { modalActive: action.payload.modalActive });
     case SET_MODAL_CREATE_RECIPE_ERROR_NAME_VISIBLE:
       return modalCreateRecipe(state, action);
     case SET_MODAL_CREATE_RECIPE_ERROR_DUPLICATE_VISIBLE:

--- a/core/reducers/recipePage.js
+++ b/core/reducers/recipePage.js
@@ -7,35 +7,23 @@ import {
 const recipePage = (state = [], action) => {
   switch (action.type) {
     case SET_EDIT_DESCRIPTION_VISIBLE:
-      return {
-        ...state,
-        editDescriptionVisible: action.payload.visible,
-      };
+      return Object.assign({}, state,
+                           { editDescriptionVisible: action.payload.visible });
     case SET_EDIT_DESCRIPTION_VALUE:
-      return {
-        ...state,
-        editDescriptionValue: action.payload.value,
-      };
+      return Object.assign({}, state,
+                           { editDescriptionValue: action.payload.value });
     case SET_SELECTED_COMPONENT:
-      return {
-        ...state,
-        selectedComponent: action.payload.component,
-      };
+      return Object.assign({}, state,
+                           { selectedComponent: action.payload.component });
     case SET_SELECTED_COMPONENT_PARENT:
-      return {
-        ...state,
-        selectedComponentParent: action.payload.componentParent,
-      };
+      return Object.assign({}, state,
+                           { selectedComponentParent: action.payload.componentParent });
     case SET_SELECTED_COMPONENT_STATUS:
-      return {
-        ...state,
-        selectedComponentStatus: action.payload.componentStatus,
-      };
+      return Object.assign({}, state,
+                           { selectedComponentStatus: action.payload.componentStatus });
     case SET_ACTIVE_TAB:
-      return {
-        ...state,
-        activeTab: action.payload.activeTab,
-      };
+      return Object.assign({}, state,
+                           { activeTab: action.payload.activeTab });
     default:
       return state;
   }

--- a/core/reducers/recipes.js
+++ b/core/reducers/recipes.js
@@ -14,7 +14,7 @@ const recipes = (state = [], action) => {
       return [
         ...state.map(recipe => {
           if (recipe.id === action.payload.recipe.id) {
-            return { ...recipe, ...recipe.components.append(action.payload.component) };
+            return Object.assign({}, recipe, recipe.components.append(action.payload.component) );
           }
           return recipe;
         }),
@@ -23,10 +23,10 @@ const recipes = (state = [], action) => {
       return [
         ...state.map(recipe => {
           if (recipe.id === action.payload.recipe.id) {
-            return {
-              ...recipe,
-              components: recipe.components.filter(component => component.name !== action.payload.component.name),
-            };
+            return Object.assign(
+                {},
+                recipe,
+                { components: recipe.components.filter(component => component.name !== action.payload.component.name) });
           }
           return recipe;
         }),
@@ -65,7 +65,7 @@ const recipes = (state = [], action) => {
       return [
         ...state.map(recipe => {
           if (recipe.id === action.payload.recipe.id) {
-            return { ...recipe, components: action.payload.components };
+            return Object.assign({}, recipe, { components: action.payload.components });
           }
           return recipe;
         }),
@@ -74,7 +74,7 @@ const recipes = (state = [], action) => {
       return [
         ...state.map(recipe => {
           if (recipe.id === action.payload.recipe.id) {
-            return { ...recipe, dependencies: action.payload.dependencies };
+            return Object.assign({}, recipe, { dependencies: action.payload.dependencies });
           }
           return recipe;
         }),
@@ -83,7 +83,7 @@ const recipes = (state = [], action) => {
       return [
         ...state.map(recipe => {
           if (recipe.id === action.payload.recipe.id) {
-            return { ...recipe, description: action.payload.description };
+            return Object.assign({}, recipe, { description: action.payload.description });
           }
           return recipe;
         }),

--- a/core/reducers/sort.js
+++ b/core/reducers/sort.js
@@ -10,53 +10,35 @@ import {
 const sort = (state = [], action) => {
   switch (action.type) {
     case RECIPES_SORT_SET_KEY:
-      return {
-        ...state,
-        recipes: {
-          ...state.recipes,
-          key: action.payload.key,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { recipes: Object.assign({}, state.recipes, { key: action.payload.key }) }
+      );
     case RECIPES_SORT_SET_VALUE:
-      return {
-        ...state,
-        recipes: {
-          ...state.recipes,
-          value: action.payload.value,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { recipes: Object.assign({}, state.recipes, { value: action.payload.value }) }
+      );
     case COMPONENTS_SORT_SET_KEY:
-      return {
-        ...state,
-        components: {
-          ...state.components,
-          key: action.payload.key,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { components: Object.assign({}, state.components, { key: action.payload.key }) }
+      );
     case COMPONENTS_SORT_SET_VALUE:
-      return {
-        ...state,
-        components: {
-          ...state.components,
-          value: action.payload.value,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { components: Object.assign({}, state.components, { value: action.payload.value }) }
+      );
     case DEPENDENCIES_SORT_SET_KEY:
-      return {
-        ...state,
-        dependencies: {
-          ...state.dependencies,
-          key: action.payload.key,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { dependencies: Object.assign({}, state.dependencies, { key: action.payload.key }) }
+      );
     case DEPENDENCIES_SORT_SET_VALUE:
-      return {
-        ...state,
-        dependencies: {
-          ...state.dependencies,
-          value: action.payload.value,
-        },
-      };
+      return Object.assign(
+          {}, state,
+          { dependencies: Object.assign({}, state.dependencies, { value: action.payload.value }) }
+      );
     default:
       return state;
   }

--- a/core/router.js
+++ b/core/router.js
@@ -64,12 +64,12 @@ function resolve(routes, context) {
           return fetch(url, { method, credentials: 'same-origin' }).then(resp => resp.json());
         }),
       ]).then(([Page, ...data]) => {
-        const props = keys.reduce((result, key, i) => ({ ...result, [key]: data[i] }), {});
-        return <Page route={{ ...route, params }} error={context.error} {...props} />;
+        const props = keys.reduce((result, key, i) => (Object.assign({}, result, { [key]: data[i] })), {});
+        return <Page route={Object.assign({}, route, { params: params })} error={context.error} {...props} />;
       });
     }
 
-    return route.load().then(Page => <Page route={{ ...route, params }} error={context.error} />);
+    return route.load().then(Page => <Page route={Object.assign({}, route, { params: params })} error={context.error} />);
   }
 
   const error = new Error('Page not found');

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ function renderComponent(component) {
 function render(location) {
   router.resolve(routes, location)
     .then(renderComponent)
-    .catch(error => router.resolve(routes, { ...location, error }).then(renderComponent));
+    .catch(error => router.resolve(routes, Object.assign ({}, location, { error: error })).then(renderComponent));
 }
 
 // Handle client-side navigation by using HTML5 History API

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "babel-jest": "^16.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-istanbul": "^4.1.4",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
@@ -114,7 +113,6 @@
       "es2015"
     ],
     "plugins": [
-      "transform-class-properties",
       "transform-runtime"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -36,10 +36,11 @@
     "babel-jest": "^16.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-istanbul": "^4.1.4",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
-    "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.11.6",
     "babel-runtime": "^6.11.6",
     "bootstrap": "^3.3.7",
@@ -111,16 +112,20 @@
   "babel": {
     "presets": [
       "react",
-      "es2015",
-      "stage-1"
+      "es2015"
     ],
     "plugins": [
+      "transform-object-rest-spread",
+      "transform-class-properties",
       "transform-runtime"
     ]
   },
   "eslintConfig": {
     "parser": "babel-eslint",
-    "extends": ["airbnb", "eslint:recommended"],
+    "extends": [
+      "airbnb",
+      "eslint:recommended"
+    ],
     "rules": {
       "max-len": [
         "error",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
@@ -115,7 +114,6 @@
       "es2015"
     ],
     "plugins": [
-      "transform-object-rest-spread",
       "transform-class-properties",
       "transform-runtime"
     ]

--- a/pages/error/index.js
+++ b/pages/error/index.js
@@ -5,15 +5,20 @@ import Link from '../../components/Link';
 import s from './styles.css';
 
 class ErrorPage extends React.Component {
+  constructor() {
+    super();
+    this.goBack = this.goBack.bind(this);
+  }
+
   componentDidMount() {
     document.title = this.props.error && this.props.error.status === 404 ?
       'Page Not Found' : 'Error';
   }
 
-  goBack = event => {
+  goBack(event) {
     event.preventDefault();
     history.goBack();
-  };
+  }
 
   render() {
     if (this.props.error) console.error(this.props.error); // eslint-disable-line no-console

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -31,149 +31,152 @@ class RecipePage extends React.Component {
     this.setNotifications = this.setNotifications.bind(this);
     this.handleTabChanged = this.handleTabChanged.bind(this);
     this.handleComponentDetails = this.handleComponentDetails.bind(this);
-  }
+    this.handleHideModalExport = this.handleHideModalExport.bind(this);
+    this.handleShowModalExport = this.handleShowModalExport.bind(this);
+    this.handleChangeDescription = this.handleChangeDescription.bind(this);
 
-  state = {
-    revisions: [
-      {
-        number: '3',
-        basedOn: 'Revision 2',
-        components: '8',
-        compositions: '1',
-        size: '2,678 KB',
-        active: true,
-      },
-      {
-        number: '2',
-        basedOn: 'Revision 1',
-        components: '5',
-        compositions: '1',
-        size: '2,345 KB',
-        active: false,
-      },
-      {
-        number: '1',
-        basedOn: 'New recipe',
-        components: '3',
-        compositions: '0',
-        size: '1,234 KB',
-        active: false,
-      },
-    ],
-    comments: [
-      {
-        date: '2/04/17',
-        user: 'Brian Johnson',
-        revision: '3',
-        comment: 'Including components to support php.',
-      },
-      {
-        date: '1/17/17',
-        user: 'Brian Johnson',
-        revision: '2',
-        comment: 'Early test results are good, but new requirements include php support.',
-      },
-      {
-        date: '1/17/17',
-        user: 'Brian Johnson',
-        revision: '2',
-        comment: 'NOT PRODUCTION READY - only creating a composition to do early testing.',
-      },
-      {
-        date: '1/06/17',
-        user: 'Brian Johnson',
-        revision: '1',
-        comment: `Saving this first revision just to capture minimal requirements
-          for comparison against future revisions`,
-      },
-    ],
-    compositions: [
-      {
-        date_created: '2/06/17',
-        date_exported: '2/06/17',
-        user: 'Brian Johnson',
-        type: 'iso',
-        revision: '3',
-        size: '2,345 KB',
-      },
-      {
-        date_created: '1/17/17',
-        date_exported: '1/17/17',
-        user: 'Brian Johnson',
-        type: 'iso',
-        revision: '2',
-        size: '1,234 KB',
-      },
-    ],
-    changelog: [
-      {
-        revision: '3',
-        action: 'Composition exported',
-        date: '2/06/07',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '3',
-        action: 'Composition created',
-        date: '2/06/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '3',
-        action: 'Recipe modified',
-        date: '2/06/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '3',
-        action: 'Recipe modified',
-        date: '2/04/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '3',
-        action: 'Revision created',
-        date: '2/04/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '2',
-        action: 'Composition exported',
-        date: '1/17/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '2',
-        action: 'Composition created',
-        date: '1/17/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '2',
-        action: 'Recipe modified',
-        date: '1/12/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '2',
-        action: 'Revision created',
-        date: '1/06/17',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '1',
-        action: 'Recipe modified',
-        date: '12/15/16',
-        user: 'Brian Johnson',
-      },
-      {
-        revision: '1',
-        action: 'Revision created',
-        date: '12/15/16',
-        user: 'Brian Johnson',
-      },
-    ],
-  };
+    this.state = {
+      revisions: [
+        {
+          number: '3',
+          basedOn: 'Revision 2',
+          components: '8',
+          compositions: '1',
+          size: '2,678 KB',
+          active: true,
+        },
+        {
+          number: '2',
+          basedOn: 'Revision 1',
+          components: '5',
+          compositions: '1',
+          size: '2,345 KB',
+          active: false,
+        },
+        {
+          number: '1',
+          basedOn: 'New recipe',
+          components: '3',
+          compositions: '0',
+          size: '1,234 KB',
+          active: false,
+        },
+      ],
+      comments: [
+        {
+          date: '2/04/17',
+          user: 'Brian Johnson',
+          revision: '3',
+          comment: 'Including components to support php.',
+        },
+        {
+          date: '1/17/17',
+          user: 'Brian Johnson',
+          revision: '2',
+          comment: 'Early test results are good, but new requirements include php support.',
+        },
+        {
+          date: '1/17/17',
+          user: 'Brian Johnson',
+          revision: '2',
+          comment: 'NOT PRODUCTION READY - only creating a composition to do early testing.',
+        },
+        {
+          date: '1/06/17',
+          user: 'Brian Johnson',
+          revision: '1',
+          comment: `Saving this first revision just to capture minimal requirements
+            for comparison against future revisions`,
+        },
+      ],
+      compositions: [
+        {
+          date_created: '2/06/17',
+          date_exported: '2/06/17',
+          user: 'Brian Johnson',
+          type: 'iso',
+          revision: '3',
+          size: '2,345 KB',
+        },
+        {
+          date_created: '1/17/17',
+          date_exported: '1/17/17',
+          user: 'Brian Johnson',
+          type: 'iso',
+          revision: '2',
+          size: '1,234 KB',
+        },
+      ],
+      changelog: [
+        {
+          revision: '3',
+          action: 'Composition exported',
+          date: '2/06/07',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '3',
+          action: 'Composition created',
+          date: '2/06/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '3',
+          action: 'Recipe modified',
+          date: '2/06/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '3',
+          action: 'Recipe modified',
+          date: '2/04/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '3',
+          action: 'Revision created',
+          date: '2/04/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '2',
+          action: 'Composition exported',
+          date: '1/17/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '2',
+          action: 'Composition created',
+          date: '1/17/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '2',
+          action: 'Recipe modified',
+          date: '1/12/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '2',
+          action: 'Revision created',
+          date: '1/06/17',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '1',
+          action: 'Recipe modified',
+          date: '12/15/16',
+          user: 'Brian Johnson',
+        },
+        {
+          revision: '1',
+          action: 'Revision created',
+          date: '12/15/16',
+          user: 'Brian Johnson',
+        },
+      ],
+    };
+  }
 
   componentWillMount() {
     if (this.props.rehydrated) {
@@ -191,7 +194,7 @@ class RecipePage extends React.Component {
     document.title = 'Recipe';
   }
 
-  setNotifications = () => {
+  setNotifications() {
     this.refs.layout.setNotifications();
   }
 
@@ -203,15 +206,15 @@ class RecipePage extends React.Component {
     e.stopPropagation();
   }
 
-  handleComponentDetails = (event, component, parent) => {
+  handleComponentDetails(event, component, parent) {
     // the user selected a component to view more details
     this.props.setSelectedComponent(component);
     this.props.setSelectedComponentParent(parent);
     event.preventDefault();
     event.stopPropagation();
-  };
+  }
 
-  handleEditDescription = (action) => {
+  handleEditDescription(action) {
     const state = !this.props.recipePage.editDescriptionVisible;
     this.props.setEditDescriptionVisible(state);
     if (state) {
@@ -228,10 +231,10 @@ class RecipePage extends React.Component {
   }
 
   // handle show/hide of modal dialogs
-  handleHideModalExport = () => {
+  handleHideModalExport() {
     this.props.setModalExportRecipeVisible(false);
   }
-  handleShowModalExport = (e) => {
+  handleShowModalExport(e) {
     this.props.setModalExportRecipeVisible(true);
     e.preventDefault();
     e.stopPropagation();
@@ -297,7 +300,7 @@ class RecipePage extends React.Component {
                           <span className="fa fa-ellipsis-v" />
                         </button>
                         <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a href="#" onClick={e => this.handleShowModalExport(e)}>Export</a></li>
+                          <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
                         </ul>
                       </div>
                     </div>
@@ -338,7 +341,7 @@ class RecipePage extends React.Component {
                           type="text"
                           className="form-control"
                           value={editDescriptionValue}
-                          onChange={e => this.handleChangeDescription(e)}
+                          onChange={this.handleChangeDescription}
                         />
                         <span className="input-group-btn">
                           <button className="btn btn-link" type="button" onClick={() => this.handleEditDescription('save')}>
@@ -516,7 +519,7 @@ class RecipePage extends React.Component {
                                 <span className="fa fa-ellipsis-v" />
                               </button>
                               <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                                <li><a href="#" onClick={e => this.handleShowModalExport(e)}>Export</a></li>
+                                <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
                               </ul>
                             </div>
                           </div>
@@ -671,7 +674,7 @@ class RecipePage extends React.Component {
                           <span className="fa fa-ellipsis-v" />
                         </button>
                         <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a href="#" onClick={e => this.handleShowModalExport(e)}>Export</a></li>
+                          <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
                         </ul>
                       </div>
                     </div>

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -34,6 +34,13 @@ class EditRecipePage extends React.Component {
     super();
     this.setNotifications = this.setNotifications.bind(this);
     this.handleSave = this.handleSave.bind(this);
+    this.handlePagination = this.handlePagination.bind(this);
+    this.handleAddComponent = this.handleAddComponent.bind(this);
+    this.handleUpdateComponent = this.handleUpdateComponent.bind(this);
+    this.handleRemoveComponent = this.handleRemoveComponent.bind(this);
+    this.handleComponentDetails = this.handleComponentDetails.bind(this);
+    this.handleHideModal = this.handleHideModal.bind(this);
+    this.handleShowModal = this.handleShowModal.bind(this);
   }
 
   componentWillMount() {
@@ -58,7 +65,7 @@ class EditRecipePage extends React.Component {
     document.title = 'Recipe';
   }
 
-  setNotifications = () => {
+  setNotifications() {
     this.layout.setNotifications();
   }
 
@@ -107,7 +114,7 @@ class EditRecipePage extends React.Component {
     event.stopPropagation();
   }
 
-  handlePagination = (event) => {
+  handlePagination(event) {
     // the event target knows what page to get
     // the event target can either be the paging buttons on the page input
     let page;
@@ -139,7 +146,7 @@ class EditRecipePage extends React.Component {
     $('#cmpsr-recipe-inputs .alert').remove();
   }
 
-  handleSave = () => {
+  handleSave () {
     // clear existing notifications
     NotificationsApi.closeNotification(undefined, 'saved');
     NotificationsApi.closeNotification(undefined, 'saving');
@@ -162,7 +169,7 @@ class EditRecipePage extends React.Component {
           .catch(e => console.log(`Error in reload recipe details: ${e}`));
       })
       .catch(e => console.log(`Error in recipe save: ${e}`));
-  };
+  }
 
   addRecipeComponent(componentData) {
     // component data is [[{component}, [{dependency},{}]]]
@@ -177,7 +184,7 @@ class EditRecipePage extends React.Component {
     RecipeApi.updateRecipe(componentData[0][0], 'add');
   }
 
-  handleAddComponent = (event, source, component, dependencies) => {
+  handleAddComponent(event, source, component, dependencies) {
     // the user clicked Add in the sidebar, e.g. source === "input"
     // or the user clicked Add in the details view
     component.inRecipe = true; // eslint-disable-line no-param-reassign
@@ -209,7 +216,7 @@ class EditRecipePage extends React.Component {
     event.stopPropagation();
   }
 
-  handleUpdateComponent = (event, component) => {
+  handleUpdateComponent(event, component) {
     // the user clicked Edit in the details view and saved updates to the component version
     // find component in recipe components
     // let selectedComponent = this.props.recipe.components.filter((obj) => (obj.name === component.name));
@@ -224,7 +231,7 @@ class EditRecipePage extends React.Component {
     event.stopPropagation();
   }
 
-  handleRemoveComponent = (event, component) => {
+  handleRemoveComponent(event, component) {
     // the user clicked Remove for a component in the recipe component list
     // or the component details view
     // update the recipe object that's used during save
@@ -276,7 +283,7 @@ class EditRecipePage extends React.Component {
     return inputs;
   }
 
-  handleComponentDetails = (event, component, parent, mode) => {
+  handleComponentDetails (event, component, parent, mode) {
     // the user selected a component in the sidebar to view more details on the right
     // remove the active state from the current selected component
     let inputs = this.props.inputs.inputComponents.slice(0);
@@ -331,7 +338,7 @@ class EditRecipePage extends React.Component {
     }
     event.preventDefault();
     event.stopPropagation();
-  };
+  }
 
   hideComponentDetails() {
     this.props.setSelectedInput('');
@@ -364,10 +371,10 @@ class EditRecipePage extends React.Component {
   }
 
   // handle show/hide of modal dialogs
-  handleHideModal = () => {
+  handleHideModal() {
     this.props.setModalActive(null);
   }
-  handleShowModal = (e, modalType) => {
+  handleShowModal(e, modalType) {
     switch (modalType) {
       case 'modalPendingChanges':
         this.props.setModalActive('modalPendingChanges');
@@ -415,7 +422,7 @@ class EditRecipePage extends React.Component {
                 <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>View and Comment</a>
               </li>
               <li>
-                <button className="btn btn-primary" type="button" onClick={e => this.handleSave(e)}>Save</button>
+                <button className="btn btn-primary" type="button" onClick={this.handleSave}>Save</button>
               </li>
               <li>
                 <button className="btn btn-default" type="button">Discard Changes</button>

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -17,6 +17,9 @@ class RecipesPage extends React.Component {
   constructor() {
     super();
     this.setNotifications = this.setNotifications.bind(this);
+    this.handleDelete = this.handleDelete.bind(this);
+    this.handleHideModalExport = this.handleHideModalExport.bind(this);
+    this.handleShowModalExport = this.handleShowModalExport.bind(this);
   }
 
   componentWillMount() {
@@ -26,24 +29,24 @@ class RecipesPage extends React.Component {
     document.title = 'Recipes';
   }
 
-  setNotifications = () => {
+  setNotifications() {
     this.refs.layout.setNotifications();
-  };
+  }
 
-  handleDelete = (event, recipe) => {
+  handleDelete(event, recipe) {
     event.preventDefault();
     event.stopPropagation();
     this.props.deletingRecipe(recipe);
-  };
+  }
 
   // handle show/hide of modal dialogs
-  handleHideModalExport = () => {
+  handleHideModalExport() {
     this.props.setModalExportRecipeVisible(false);
     this.props.setModalExportRecipeName('');
     this.props.setModalExportRecipeContents([]);
-  };
+  }
 
-  handleShowModalExport = (e, recipe) => {
+  handleShowModalExport(e, recipe) {
     // This implementation of the dialog only provides a text option, and it's
     // automatically selected. Eventually, the following code should move to a
     // separate function that is called when the user selects the text option
@@ -57,7 +60,7 @@ class RecipesPage extends React.Component {
     this.props.setModalExportRecipeVisible(true);
     e.preventDefault();
     e.stopPropagation();
-  };
+  }
 
   render() {
     const { recipes, exportRecipe, createComposition, recipeSortKey, recipeSortValue } = this.props;


### PR DESCRIPTION
We don't want to condone arbitrary JavaScript syntax proposals which
haven't been standardized yet. So drop the stage-1 babel preset and
replace it with the explicit two features that the code currently uses:
object spreads and class properties.