### PR TITLE
Explicitly eslint-declare jQuery where needed

### DIFF
--- a/components/CardView/CardView.js
+++ b/components/CardView/CardView.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import Link from '../Link';
 import history from '../../core/history';

--- a/components/Layout/PfBreakpoints.js
+++ b/components/Layout/PfBreakpoints.js
@@ -1,3 +1,5 @@
+/* global jQuery */
+
 // Util: definition of breakpoint sizes for tablet and desktop modes
 (($ => {
   $.pfBreakpoints = { // eslint-disable-line no-param-reassign

--- a/components/Layout/PfVerticalNavigation.js
+++ b/components/Layout/PfVerticalNavigation.js
@@ -1,3 +1,5 @@
+/* global jQuery */
+
 // Util: PatternFly Vertical Navigation broken apart and converted to ES6 :)
 // Must have navbar-toggle in navbar-pf-vertical for expand/collapse
 (($ => {

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';

--- a/components/ListView/ListItemComponents.js
+++ b/components/ListView/ListItemComponents.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';

--- a/components/ListView/ListItemRevisions.js
+++ b/components/ListView/ListItemRevisions.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from '../../components/Link';

--- a/components/ListView/RecipeListView.js
+++ b/components/ListView/RecipeListView.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from '../../components/Link';

--- a/components/Modal/CreateComposition.js
+++ b/components/Modal/CreateComposition.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import NotificationsApi from '../../data/NotificationsApi';

--- a/components/Modal/CreateRecipe.js
+++ b/components/Modal/CreateRecipe.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import RecipeApi from '../../data/RecipeApi';

--- a/components/Modal/ExportRecipe.js
+++ b/components/Modal/ExportRecipe.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/components/Wizard/Wizard.js
+++ b/components/Wizard/Wizard.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 class Wizard {
 
   constructor(id) {

--- a/components/Wizard/WizardView.js
+++ b/components/Wizard/WizardView.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 // import Wizard from './Wizard';

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
       "no-console": 0
     },
     "env": {
-      "jquery": true,
       "jest": true
     }
   },

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from '../../components/Link';


### PR DESCRIPTION
Don't ignore undefined "$" references (jQuery) globally in eslint, as
that cannot be done when building from Cockpit. Declare it per-file
instead.

----

In Cockpit we avoid using jQuery in new code, and it is really discouraged to use *both* React and jQuery in the same module. Thus we don't want a blanket exception for it in eslint, and this makes it easier to track the jQuery removal from welder-web code.