### PR TITLE
Move/remove actions on Recipe page

### DIFF
--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -263,6 +263,41 @@ class RecipePage extends React.Component {
             <li><Link to="/recipes">Back to Recipes</Link></li>
             <li className="active"><strong>{this.props.route.params.recipe}</strong></li>
           </ol>
+          <div className="cmpsr-header__actions">
+            <ul className="list-inline">
+              <li>
+                <Link to={`/edit/${this.props.route.params.recipe}`} className="btn btn-default">Edit Recipe</Link>
+              </li>
+              <li>
+                <button
+                  className="btn btn-default"
+                  id="cmpsr-btn-crt-compos"
+                  data-toggle="modal"
+                  data-target="#cmpsr-modal-crt-compos"
+                  type="button"
+                >
+                  Create Composition
+                </button>
+              </li>
+              <li>
+                <div className="dropdown dropdown-kebab-pf">
+                  <button
+                    className="btn btn-link dropdown-toggle"
+                    type="button"
+                    id="dropdownKebab"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
+                    <span className="fa fa-ellipsis-v" />
+                  </button>
+                  <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
+                    <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
+                  </ul>
+                </div>
+              </li>
+            </ul>
+          </div>
           <div className="cmpsr-title">
             <h1 className="cmpsr-title__item">{this.props.route.params.recipe}</h1>
             <p className="cmpsr-title__item">
@@ -273,61 +308,6 @@ class RecipePage extends React.Component {
         </header>
         <Tabs key="pf-tabs" ref="pfTabs" tabChanged={this.handleTabChanged}>
           <Tab tabTitle="Details" active={activeTab === 'Details'}>
-            <div className="row toolbar-pf">
-              <div className="col-sm-12">
-                <form className="toolbar-pf-actions">
-                  <div className="toolbar-pf-action-right">
-                    <div className="form-group">
-                      <Link to={`/edit/${this.props.route.params.recipe}`} className="btn btn-default">Edit Recipe</Link>
-                      <button
-                        className="btn btn-default"
-                        id="cmpsr-btn-crt-compos"
-                        data-toggle="modal"
-                        data-target="#cmpsr-modal-crt-compos"
-                        type="button"
-                      >
-                        Create Composition
-                      </button>
-                      <div className="dropdown btn-group  dropdown-kebab-pf">
-                        <button
-                          className="btn btn-link dropdown-toggle"
-                          type="button"
-                          id="dropdownKebab"
-                          data-toggle="dropdown"
-                          aria-haspopup="true"
-                          aria-expanded="false"
-                        >
-                          <span className="fa fa-ellipsis-v" />
-                        </button>
-                        <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
-                        </ul>
-                      </div>
-                    </div>
-                    <div className="form-group toolbar-pf-find">
-                      <button className="btn btn-link btn-find" type="button">
-                        <span className="fa fa-search" />
-                      </button>
-                      <div className="find-pf-dropdown-container">
-                        <input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
-                        <div className="find-pf-buttons">
-                          <span className="find-pf-nums">1 of 3</span>
-                          <button className="btn btn-link" type="button">
-                            <span className="fa fa-angle-up" />
-                          </button>
-                          <button className="btn btn-link" type="button">
-                            <span className="fa fa-angle-down" />
-                          </button>
-                          <button className="btn btn-link btn-find-close" type="button">
-                            <span className="pficon pficon-close" />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </form>
-              </div>
-            </div>
             <div className="tab-container row">
               <div className="col-md-6">
                 <dl className="dl-horizontal mt-">
@@ -495,55 +475,6 @@ class RecipePage extends React.Component {
                             </button>
                           }
                         </div>
-                        <div className="toolbar-pf-action-right">
-                          <div className="form-group">
-                            <Link to={`/edit/${this.props.route.params.recipe}`} className="btn btn-default">Edit Recipe</Link>
-                            <button
-                              className="btn btn-default"
-                              id="cmpsr-btn-crt-compos"
-                              data-toggle="modal"
-                              data-target="#cmpsr-modal-crt-compos"
-                              type="button"
-                            >
-                              Create Composition
-                            </button>
-                            <div className="dropdown btn-group  dropdown-kebab-pf">
-                              <button
-                                className="btn btn-link dropdown-toggle"
-                                type="button"
-                                id="dropdownKebab"
-                                data-toggle="dropdown"
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                              >
-                                <span className="fa fa-ellipsis-v" />
-                              </button>
-                              <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                                <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
-                              </ul>
-                            </div>
-                          </div>
-                          <div className="form-group toolbar-pf-find">
-                            <button className="btn btn-link btn-find" type="button">
-                              <span className="fa fa-search" />
-                            </button>
-                            <div className="find-pf-dropdown-container">
-                              <input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
-                              <div className="find-pf-buttons">
-                                <span className="find-pf-nums">1 of 3</span>
-                                <button className="btn btn-link" type="button">
-                                  <span className="fa fa-angle-up" />
-                                </button>
-                                <button className="btn btn-link" type="button">
-                                  <span className="fa fa-angle-down" />
-                                </button>
-                                <button className="btn btn-link btn-find-close" type="button">
-                                  <span className="pficon pficon-close" />
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
                       </form>
                     </div>
                   </div>
@@ -578,34 +509,6 @@ class RecipePage extends React.Component {
             </div>
           </Tab>
           <Tab tabTitle="Revisions" active={activeTab === 'Revisions'}>
-            <div className="row toolbar-pf">
-              <div className="col-sm-12">
-                <form className="toolbar-pf-actions">
-                  <div className="toolbar-pf-action-right">
-                    <div className="form-group toolbar-pf-find">
-                      <button className="btn btn-link btn-find" type="button">
-                        <span className="fa fa-search" />
-                      </button>
-                      <div className="find-pf-dropdown-container">
-                        <input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
-                        <div className="find-pf-buttons">
-                          <span className="find-pf-nums">1 of 3</span>
-                          <button className="btn btn-link" type="button">
-                            <span className="fa fa-angle-up" />
-                          </button>
-                          <button className="btn btn-link" type="button">
-                            <span className="fa fa-angle-down" />
-                          </button>
-                          <button className="btn btn-link btn-find-close" type="button">
-                            <span className="pficon pficon-close" />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </form>
-              </div>
-            </div>
             <div className="tab-container">
               <ListView className="cmpsr-recipe__revisions cmpsr-list">
                 <div className="list-pf-item list-group-item__separator">
@@ -647,61 +550,6 @@ class RecipePage extends React.Component {
             </div>
           </Tab>
           <Tab tabTitle="Compositions" active={activeTab === 'Compositions'}>
-            <div className="row toolbar-pf">
-              <div className="col-sm-12">
-                <form className="toolbar-pf-actions">
-                  <div className="toolbar-pf-action-right">
-                    <div className="form-group">
-                      <Link to={`/edit/${this.props.route.params.recipe}`} className="btn btn-default">Edit Recipe</Link>
-                      <button
-                        className="btn btn-default"
-                        id="cmpsr-btn-crt-compos"
-                        data-toggle="modal"
-                        data-target="#cmpsr-modal-crt-compos"
-                        type="button"
-                      >
-                        Create Composition
-                      </button>
-                      <div className="dropdown btn-group  dropdown-kebab-pf">
-                        <button
-                          className="btn btn-link dropdown-toggle"
-                          type="button"
-                          id="dropdownKebab"
-                          data-toggle="dropdown"
-                          aria-haspopup="true"
-                          aria-expanded="false"
-                        >
-                          <span className="fa fa-ellipsis-v" />
-                        </button>
-                        <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                          <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
-                        </ul>
-                      </div>
-                    </div>
-                    <div className="form-group toolbar-pf-find">
-                      <button className="btn btn-link btn-find" type="button">
-                        <span className="fa fa-search" />
-                      </button>
-                      <div className="find-pf-dropdown-container">
-                        <input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
-                        <div className="find-pf-buttons">
-                          <span className="find-pf-nums">1 of 3</span>
-                          <button className="btn btn-link" type="button">
-                            <span className="fa fa-angle-up" />
-                          </button>
-                          <button className="btn btn-link" type="button">
-                            <span className="fa fa-angle-down" />
-                          </button>
-                          <button className="btn btn-link btn-find-close" type="button">
-                            <span className="pficon pficon-close" />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </form>
-              </div>
-            </div>
             <div className="tab-container">
               {(this.state.compositions.length === 0 &&
                 <EmptyState title={'No Compositions'} message={'No compositions have been created from this recipe.'}>
@@ -726,9 +574,6 @@ class RecipePage extends React.Component {
                   ))}
                 </ListView>}
             </div>
-          </Tab>
-          <Tab tabTitle="Errata" active={activeTab === 'Errata'}>
-            <p>Errata</p>
           </Tab>
         </Tabs>
         <CreateComposition recipe={recipe.name} compositionTypes={compositionTypes} setNotifications={this.setNotifications} />

--- a/test/end-to-end/pages/viewRecipe.js
+++ b/test/end-to-end/pages/viewRecipe.js
@@ -42,7 +42,7 @@ module.exports = class ViewRecipePage extends MainPage {
     this.labelRecipeTitle = `${this.titleRootElement} h1[class="cmpsr-title__item"]`;
 
     // Page-level actions
-    this.pagelevelActions = '[class="cmpsr-header__actions"]'
+    this.pagelevelActions = '[class="cmpsr-header__actions"]';
 
     // Create Composition button
     this.varCreateCompos = 'Create Composition';

--- a/test/end-to-end/pages/viewRecipe.js
+++ b/test/end-to-end/pages/viewRecipe.js
@@ -41,6 +41,9 @@ module.exports = class ViewRecipePage extends MainPage {
     // Title-bar: Recipe Title label
     this.labelRecipeTitle = `${this.titleRootElement} h1[class="cmpsr-title__item"]`;
 
+    // Page-level actions
+    this.pagelevelActions = '[class="cmpsr-header__actions"]'
+
     // Create Composition button
     this.varCreateCompos = 'Create Composition';
     this.btnCreateCompos = '#cmpsr-btn-crt-compos';

--- a/test/end-to-end/test/test_viewRecipe.js
+++ b/test/end-to-end/test/test_viewRecipe.js
@@ -151,22 +151,18 @@ describe('View Recipe Page', () => {
         }, timeout);
       });
     });
-    describe('Components tab - Export Recipe To Manifest Test #acceptance', () => {
+    describe('Recipe page - Export Recipe To Manifest Test #acceptance', () => {
       const exportRecipePage = new ExportRecipePage();
 
       // More action menu
-      const btnMoreAction = `${viewRecipePage.componentsTabRootElement} ${viewRecipePage.btnMore}`;
-      const menuActionExport = `${viewRecipePage.componentsTabRootElement} ${viewRecipePage.menuActionExport}`;
-
-      const tabComponents = viewRecipePage.tabLink('Components');
+      const btnMoreAction = `${viewRecipePage.pagelevelActions} ${viewRecipePage.btnMore}`;
+      const menuActionExport = `${viewRecipePage.pagelevelActions} ${viewRecipePage.menuActionExport}`;
 
       test('should pop up dropdown-menu by clicking ":" button', (done) => {
         // Highlight the expected result
         const expected = viewRecipePage.toolBarMoreActionList.Export;
 
         nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
           .wait(btnMoreAction)
           .click(btnMoreAction)
           .wait(menuActionExport)
@@ -183,8 +179,6 @@ describe('View Recipe Page', () => {
         const expected = exportRecipePage.varExportTitle;
 
         nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
           .wait(btnMoreAction)
           .click(btnMoreAction)
           .wait(menuActionExport)
@@ -214,8 +208,6 @@ describe('View Recipe Page', () => {
           const expectedContent = [...depCompSet].sort().join('\n');
 
           nightmare
-            .wait(tabComponents)
-            .click(tabComponents)
             .wait(btnMoreAction)
             .click(btnMoreAction)
             .wait(menuActionExport)
@@ -245,314 +237,6 @@ describe('View Recipe Page', () => {
         let expected = '';
 
         nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
-          .wait(btnMoreAction)
-          .click(btnMoreAction)
-          .wait(menuActionExport)
-          .click(menuActionExport)
-          .wait(page => document.querySelector(page.rootElement).style.display === 'block'
-            , exportRecipePage)
-          .wait(exportRecipePage.textAreaContent)
-          .evaluate(page => document.querySelector(page.textAreaContent).value
-            , exportRecipePage)
-          .then((element) => { expected = element; })
-          .then(() => nightmare
-            .wait(exportRecipePage.btnCopy)
-            .click(exportRecipePage.btnCopy)
-            .evaluate(() => {
-              // create div element for pasting into
-              const pasteDiv = document.createElement('div');
-
-              // place div outside the visible area
-              pasteDiv.style.position = 'absolute';
-              pasteDiv.style.left = '-10000px';
-              pasteDiv.style.top = '-10000px';
-
-              // set contentEditable mode
-              pasteDiv.contentEditable = true;
-
-              // find a good place to add the div to the document
-              let insertionElement = document.activeElement;
-              let nodeName = insertionElement.nodeName.toLowerCase();
-              while (nodeName !== 'body' && nodeName !== 'div' && nodeName !== 'li' && nodeName !== 'th' && nodeName !== 'td') {
-                insertionElement = insertionElement.parentNode;
-                nodeName = insertionElement.nodeName.toLowerCase();
-              }
-
-              // add element to document
-              insertionElement.appendChild(pasteDiv);
-
-              // paste the current clipboard text into the element
-              pasteDiv.focus();
-              document.execCommand('paste');
-
-              // get the pasted text from the div
-              const clipboardText = pasteDiv.innerText;
-
-              // remove the temporary element
-              insertionElement.removeChild(pasteDiv);
-
-              // return the text
-              return clipboardText;
-            }))
-          .then((element) => {
-            // remove the last "\n" from paste result with trim()
-            expect(element.trim()).toBe(expected);
-
-            eval(fs.readFileSync('utils/coverage.js').toString());
-          });
-      }, timeout);
-    });
-    describe('Details tab - Export Recipe To Manifest Test #acceptance', () => {
-      const exportRecipePage = new ExportRecipePage();
-
-      // More action menu
-      const btnMoreAction = `${viewRecipePage.detailTabRootElement} ${viewRecipePage.btnMore}`;
-      const menuActionExport = `${viewRecipePage.detailTabRootElement} ${viewRecipePage.menuActionExport}`;
-
-      const tabComponents = viewRecipePage.tabLink('Details');
-
-      test('should pop up dropdown-menu by clicking ":" button', (done) => {
-        // Highlight the expected result
-        const expected = viewRecipePage.toolBarMoreActionList.Export;
-
-        nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
-          .wait(btnMoreAction)
-          .click(btnMoreAction)
-          .wait(menuActionExport)
-          .evaluate(element => document.querySelector(element).innerText
-            , menuActionExport)
-          .then((element) => {
-            expect(element).toBe(expected);
-
-            eval(fs.readFileSync('utils/coverage.js').toString());
-          });
-      }, timeout);
-      test('should pop up Export Recipe window by clicking "Export"', (done) => {
-        // Highlight the expected result
-        const expected = exportRecipePage.varExportTitle;
-
-        nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
-          .wait(btnMoreAction)
-          .click(btnMoreAction)
-          .wait(menuActionExport)
-          .click(menuActionExport)
-          .wait(page => document.querySelector(page.rootElement).style.display === 'block'
-            , exportRecipePage)
-          .wait(exportRecipePage.labelExportTitle)
-          .evaluate(page => document.querySelector(page.labelExportTitle).innerText
-            , exportRecipePage)
-          .then((element) => {
-            expect(element).toBe(expected);
-
-            eval(fs.readFileSync('utils/coverage.js').toString());
-          });
-      }, timeout);
-      test('should show the correct dependence packages and total numbers of dependencies', (done) => {
-        // Convert package name into a string
-        const packNames = `${pageConfig.recipe.simple.packages[0].name},${pageConfig.recipe.simple.packages[1].name}`;
-
-        function callback(packs) {
-          const depList = packs.map(
-            pack => pack.dependencies.map(module => `${module.name}-${module.version}-${module.release}`));
-          const depCompSet = new Set(depList.reduce((acc, val) => [...acc, ...val]));
-
-          // Highlight the expected result
-          const expectedNumber = `${[...depCompSet].length} ${exportRecipePage.varTotalComponents}`;
-          const expectedContent = [...depCompSet].sort().join('\n');
-
-          nightmare
-            .wait(tabComponents)
-            .click(tabComponents)
-            .wait(btnMoreAction)
-            .click(btnMoreAction)
-            .wait(menuActionExport)
-            .click(menuActionExport)
-            .wait(page => document.querySelector(page.rootElement).style.display === 'block'
-              , exportRecipePage)
-            .wait(exportRecipePage.labelTotalComponents)
-            .evaluate(page => document.querySelector(page.labelTotalComponents).innerText
-              , exportRecipePage)
-            .then((element) => {
-              expect(element).toBe(expectedNumber);
-            })
-            .then(() => nightmare
-              .evaluate(page => document.querySelector(page.textAreaContent).value
-                , exportRecipePage))
-            .then((element) => {
-              expect(element).toBe(expectedContent);
-
-              eval(fs.readFileSync('utils/coverage.js').toString());
-            });
-        }
-
-        apiCall.moduleInfo(packNames, callback, done);
-      }, timeout);
-      test('should copy and paste correct components', (done) => {
-        // expected result should be the content in textarea
-        let expected = '';
-
-        nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
-          .wait(btnMoreAction)
-          .click(btnMoreAction)
-          .wait(menuActionExport)
-          .click(menuActionExport)
-          .wait(page => document.querySelector(page.rootElement).style.display === 'block'
-            , exportRecipePage)
-          .wait(exportRecipePage.textAreaContent)
-          .evaluate(page => document.querySelector(page.textAreaContent).value
-            , exportRecipePage)
-          .then((element) => { expected = element; })
-          .then(() => nightmare
-            .wait(exportRecipePage.btnCopy)
-            .click(exportRecipePage.btnCopy)
-            .evaluate(() => {
-              // create div element for pasting into
-              const pasteDiv = document.createElement('div');
-
-              // place div outside the visible area
-              pasteDiv.style.position = 'absolute';
-              pasteDiv.style.left = '-10000px';
-              pasteDiv.style.top = '-10000px';
-
-              // set contentEditable mode
-              pasteDiv.contentEditable = true;
-
-              // find a good place to add the div to the document
-              let insertionElement = document.activeElement;
-              let nodeName = insertionElement.nodeName.toLowerCase();
-              while (nodeName !== 'body' && nodeName !== 'div' && nodeName !== 'li' && nodeName !== 'th' && nodeName !== 'td') {
-                insertionElement = insertionElement.parentNode;
-                nodeName = insertionElement.nodeName.toLowerCase();
-              }
-
-              // add element to document
-              insertionElement.appendChild(pasteDiv);
-
-              // paste the current clipboard text into the element
-              pasteDiv.focus();
-              document.execCommand('paste');
-
-              // get the pasted text from the div
-              const clipboardText = pasteDiv.innerText;
-
-              // remove the temporary element
-              insertionElement.removeChild(pasteDiv);
-
-              // return the text
-              return clipboardText;
-            }))
-          .then((element) => {
-            // remove the last "\n" from paste result with trim()
-            expect(element.trim()).toBe(expected);
-
-            eval(fs.readFileSync('utils/coverage.js').toString());
-          });
-      }, timeout);
-    });
-    describe('Compositions tab - Export Recipe To Manifest Test #acceptance', () => {
-      const exportRecipePage = new ExportRecipePage();
-
-      // More action menu
-      const btnMoreAction = `${viewRecipePage.compositionsTabRootElement} ${viewRecipePage.btnMore}`;
-      const menuActionExport = `${viewRecipePage.compositionsTabRootElement} ${viewRecipePage.menuActionExport}`;
-
-      const tabComponents = viewRecipePage.tabLink('Compositions');
-
-      test('should pop up dropdown-menu by clicking ":" button', (done) => {
-        // Highlight the expected result
-        const expected = viewRecipePage.toolBarMoreActionList.Export;
-
-        nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
-          .wait(btnMoreAction)
-          .click(btnMoreAction)
-          .wait(menuActionExport)
-          .evaluate(element => document.querySelector(element).innerText
-            , menuActionExport)
-          .then((element) => {
-            expect(element).toBe(expected);
-
-            eval(fs.readFileSync('utils/coverage.js').toString());
-          });
-      }, timeout);
-      test('should pop up Export Recipe window by clicking "Export"', (done) => {
-        // Highlight the expected result
-        const expected = exportRecipePage.varExportTitle;
-
-        nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
-          .wait(btnMoreAction)
-          .click(btnMoreAction)
-          .wait(menuActionExport)
-          .click(menuActionExport)
-          .wait(page => document.querySelector(page.rootElement).style.display === 'block'
-            , exportRecipePage)
-          .wait(exportRecipePage.labelExportTitle)
-          .evaluate(page => document.querySelector(page.labelExportTitle).innerText
-            , exportRecipePage)
-          .then((element) => {
-            expect(element).toBe(expected);
-
-            eval(fs.readFileSync('utils/coverage.js').toString());
-          });
-      }, timeout);
-      test('should show the correct dependence packages and total numbers of dependencies', (done) => {
-        // Convert package name into a string
-        const packNames = `${pageConfig.recipe.simple.packages[0].name},${pageConfig.recipe.simple.packages[1].name}`;
-
-        function callback(packs) {
-          const depList = packs.map(
-            pack => pack.dependencies.map(module => `${module.name}-${module.version}-${module.release}`));
-          const depCompSet = new Set(depList.reduce((acc, val) => [...acc, ...val]));
-
-          // Highlight the expected result
-          const expectedNumber = `${[...depCompSet].length} ${exportRecipePage.varTotalComponents}`;
-          const expectedContent = [...depCompSet].sort().join('\n');
-
-          nightmare
-            .wait(tabComponents)
-            .click(tabComponents)
-            .wait(btnMoreAction)
-            .click(btnMoreAction)
-            .wait(menuActionExport)
-            .click(menuActionExport)
-            .wait(page => document.querySelector(page.rootElement).style.display === 'block'
-              , exportRecipePage)
-            .wait(exportRecipePage.labelTotalComponents)
-            .evaluate(page => document.querySelector(page.labelTotalComponents).innerText
-              , exportRecipePage)
-            .then((element) => {
-              expect(element).toBe(expectedNumber);
-            })
-            .then(() => nightmare
-              .evaluate(page => document.querySelector(page.textAreaContent).value
-                , exportRecipePage))
-            .then((element) => {
-              expect(element).toBe(expectedContent);
-
-              eval(fs.readFileSync('utils/coverage.js').toString());
-            });
-        }
-
-        apiCall.moduleInfo(packNames, callback, done);
-      }, timeout);
-      test('should copy and paste correct components', (done) => {
-        // expected result should be the content in textarea
-        let expected = '';
-
-        nightmare
-          .wait(tabComponents)
-          .click(tabComponents)
           .wait(btnMoreAction)
           .click(btnMoreAction)
           .wait(menuActionExport)


### PR DESCRIPTION
The actions Edit Recipe, Create Composition, and Export should not display
below the tabs as tab-level actions, but instead display in the page header as
page-level actions. The Search icon that displays in the toolbar for some of
these tabs is non-functional and should be removed. Finally, if these changes
result in any of the tabs having an empty toolbar, then the toolbar should be
removed.