### PR TITLE
Drop duplicate jquery from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "front-matter": "^2.1.0",
     "highlight.js": "^9.5.0",
     "jest": "^20.0.4",
-    "jquery": "^3.2.1",
     "json-loader": "^0.5.4",
     "markdown-it": "^7.0.0",
     "path-to-regexp": "^1.5.3",


### PR DESCRIPTION
Commit fc8cff732bb (PR #154) lowered the jquery version, but there is
still a second one in devDependencies. Drop it.

----

This isn't the most important thing in the world, but I'm still struggling with lots of UI bugs when building from Cockpit due to dropdowns and dialogs having *two* event handlers attached: one directly through jquery, the other through dropdown.js. I'm trying to elimate as many differences as possible to track this down.