### PR TITLE
Save Recipe Workflow

### DIFF
--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -10,6 +10,7 @@ class PendingChanges extends React.Component {
       comment: ""
     };
     this.handleChange = this.handleChange.bind(this);
+    this.handleSaveChanges = this.handleSaveChanges.bind(this);
   }
 
   componentWillMount() {
@@ -85,7 +86,7 @@ class PendingChanges extends React.Component {
                 </div>
                 <strong>Pending Changes</strong><span className="text-muted"> (most recent first)</span>
                 <ul className="list-group">
-                  {this.props.componentUpdates.map((componentUpdated, index) => (
+                  {this.props.recipe.pendingChanges.map((componentUpdated, index) => (
                     <li className="list-group-item" key={index}>
                       {componentUpdated.componentNew && componentUpdated.componentOld &&
                         <div className="row">
@@ -129,16 +130,15 @@ PendingChanges.propTypes = {
   recipe: PropTypes.object,
   contents: PropTypes.array,
   handleHideModal: PropTypes.func,
-  componentUpdates: PropTypes.array,
   setRecipeComment: PropTypes.func,
   handleSave: PropTypes.func,
+  modals: PropTypes.object,
 };
-
 const mapStateToProps = state => ({
-  componentUpdates: state.modals.pendingChanges.componentUpdates.present,
+  modals: state.modals,
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   setRecipeComment: (recipe, comment) => {
     dispatch(setRecipeComment(recipe, comment));
   },

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -23,6 +23,7 @@ class PendingChanges extends React.Component {
 
   handleSaveChanges() {
     $('#cmpsr-modal-pending-changes').modal('hide');
+    this.props.handleSave();
   }
 
   handleChange(e) {
@@ -130,6 +131,7 @@ PendingChanges.propTypes = {
   handleHideModal: PropTypes.func,
   componentUpdates: PropTypes.array,
   setRecipeComment: PropTypes.func,
+  handleSave: PropTypes.func,
 };
 
 const mapStateToProps = state => ({

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -29,7 +29,6 @@ class PendingChanges extends React.Component {
     this.setState({comment: e.target.value});
   }
 
-
   render() {
     return (
       <div
@@ -134,7 +133,7 @@ PendingChanges.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  componentUpdates: state.modals.pendingChanges.componentUpdates,
+  componentUpdates: state.modals.pendingChanges.componentUpdates.present,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -1,17 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 class PendingChanges extends React.Component {
   constructor() {
     super();
-    // dummy data
-    this.state = {
-      componentUpdates: [
-        { componentOld: null, componentNew: 'rsync-3.0-17.317' },
-        { componentOld: 'httpd-2.3-45.el7', componentNew: 'httpd-2.4-45.el7' },
-        { componentOld: 'basesystem-10.0-7.el7', componentNew: null },
-      ],
-    };
   }
 
   componentDidMount() {
@@ -76,8 +69,8 @@ class PendingChanges extends React.Component {
                 </div>
                 <strong>Pending Changes</strong><span className="text-muted"> (most recent first)</span>
                 <ul className="list-group">
-                  {this.state.componentUpdates.map((componentUpdated) => (
-                    <li className="list-group-item">
+                  {this.props.componentUpdates.map((componentUpdated) => (
+                    <li className="list-group-item" key={componentUpdated.componentNew}>
                       {componentUpdated.componentNew && componentUpdated.componentOld &&
                         <div className="row">
                           <div className="col-sm-3">Updated</div>
@@ -120,6 +113,12 @@ PendingChanges.propTypes = {
   recipe: PropTypes.string,
   contents: PropTypes.array,
   handleHideModal: PropTypes.func,
+  componentUpdates: PropTypes.array,
 };
 
-export default PendingChanges;
+
+const mapStateToProps = state => ({
+  componentUpdates: state.modals.pendingChanges.componentUpdates,
+});
+
+export default connect(mapStateToProps)(PendingChanges);

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -1,10 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { setRecipeComment } from '../../core/actions/recipes';
 
 class PendingChanges extends React.Component {
   constructor() {
     super();
+    this.state = {
+      comment: ""
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentWillMount() {
+    this.setState({comment: this.props.recipe.comment});
   }
 
   componentDidMount() {
@@ -15,6 +24,11 @@ class PendingChanges extends React.Component {
   handleSaveChanges() {
     $('#cmpsr-modal-pending-changes').modal('hide');
   }
+
+  handleChange(e) {
+    this.setState({comment: e.target.value});
+  }
+
 
   render() {
     return (
@@ -46,7 +60,7 @@ class PendingChanges extends React.Component {
                     className="col-sm-3 control-label"
                   >Recipe</label>
                   <div className="col-sm-9">
-                    <p className="form-control-static">{this.props.recipe}</p>
+                    <p className="form-control-static">{this.props.recipe.name}</p>
                   </div>
                 </div>
                 <div className="form-group">
@@ -59,7 +73,9 @@ class PendingChanges extends React.Component {
                       id="textInput-modal-markup"
                       className="form-control"
                       rows="1"
-                      value={this.props.recipe.comment}
+                      value={this.state.comment}
+                      onChange={(e) => this.handleChange(e)}
+                      onBlur={() => this.props.setRecipeComment(this.props.recipe, this.state.comment)}
                     />
                   </div>
                 </div>
@@ -69,8 +85,8 @@ class PendingChanges extends React.Component {
                 </div>
                 <strong>Pending Changes</strong><span className="text-muted"> (most recent first)</span>
                 <ul className="list-group">
-                  {this.props.componentUpdates.map((componentUpdated) => (
-                    <li className="list-group-item" key={componentUpdated.componentNew}>
+                  {this.props.componentUpdates.map((componentUpdated, index) => (
+                    <li className="list-group-item" key={index}>
                       {componentUpdated.componentNew && componentUpdated.componentOld &&
                         <div className="row">
                           <div className="col-sm-3">Updated</div>
@@ -110,15 +126,21 @@ class PendingChanges extends React.Component {
 
 PendingChanges.propTypes = {
   comment: PropTypes.string,
-  recipe: PropTypes.string,
+  recipe: PropTypes.object,
   contents: PropTypes.array,
   handleHideModal: PropTypes.func,
   componentUpdates: PropTypes.array,
+  setRecipeComment: PropTypes.func,
 };
-
 
 const mapStateToProps = state => ({
   componentUpdates: state.modals.pendingChanges.componentUpdates,
 });
 
-export default connect(mapStateToProps)(PendingChanges);
+const mapDispatchToProps = dispatch => ({
+  setRecipeComment: (recipe, comment) => {
+    dispatch(setRecipeComment(recipe, comment));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(PendingChanges);

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -66,7 +66,26 @@ const Toolbar = props => (
           </button>
         }
       </div>
-
+      <div className="form-group">
+      {props.pastLength > 0 &&
+        <button className="btn btn-link" type="button" onClick={() => {props.undo(); props.handleHistory();}}>
+          <span className="fa fa-undo" aria-hidden="true" />
+        </button>
+      ||
+        <button className="btn btn-link disabled" type="button" onClick={() => {props.undo(); props.handleHistory();}}>
+          <span className="fa fa-undo" aria-hidden="true" />
+        </button>
+      }
+      {props.futureLength > 0 &&
+        <button className="btn btn-link" type="button" onClick={() => {props.redo(); props.handleHistory();}}>
+          <span className="fa fa-repeat" aria-hidden="true" />
+        </button>
+      ||
+        <button className="btn btn-link disabled" type="button" onClick={() => {props.redo(); props.handleHistory();}}>
+          <span className="fa fa-repeat" aria-hidden="true" />
+        </button>
+      }
+      </div>
       <div className="toolbar-pf-action-right">
         <div className="form-group">
           <button

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -68,20 +68,28 @@ const Toolbar = props => (
       </div>
       <div className="form-group">
       {props.pastLength > 0 &&
-        <button className="btn btn-link" type="button" onClick={() => {props.undo(); props.handleHistory();}}>
+        <button className="btn btn-link" type="button" onClick={() => {props.undo(props.recipeId); props.handleHistory();}}>
           <span className="fa fa-undo" aria-hidden="true" />
         </button>
       ||
-        <button className="btn btn-link disabled" type="button" onClick={() => {props.undo(); props.handleHistory();}}>
+        <button
+          className="btn btn-link disabled"
+          type="button"
+          onClick={() => {props.undo(props.recipeId); props.handleHistory();}}
+        >
           <span className="fa fa-undo" aria-hidden="true" />
         </button>
       }
       {props.futureLength > 0 &&
-        <button className="btn btn-link" type="button" onClick={() => {props.redo(); props.handleHistory();}}>
+        <button className="btn btn-link" type="button" onClick={() => {props.redo(props.recipeId); props.handleHistory();}}>
           <span className="fa fa-repeat" aria-hidden="true" />
         </button>
       ||
-        <button className="btn btn-link disabled" type="button" onClick={() => {props.redo(); props.handleHistory();}}>
+        <button
+          className="btn btn-link disabled"
+          type="button"
+          onClick={() => {props.redo(props.recipeId); props.handleHistory();}}
+        >
           <span className="fa fa-repeat" aria-hidden="true" />
         </button>
       }

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -107,3 +107,13 @@ export function fetchingModalExportRecipeContents(recipeName) {
     },
   };
 }
+
+export const APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES = 'APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES';
+export function appendModalPendingChangesComponentUpdates(componentUpdate) {
+  return {
+    type: APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES,
+    payload: {
+      componentUpdate
+    },
+  };
+}

--- a/core/actions/recipes.js
+++ b/core/actions/recipes.js
@@ -129,11 +129,20 @@ export const deletingRecipeSucceeded = (recipeId) => ({
   },
 });
 
-
 export const RECIPES_FAILURE = 'RECIPES_FAILURE';
 export const recipesFailure = (error) => ({
   type: RECIPES_FAILURE,
   payload: {
     error,
   },
+});
+
+export const UNDO = 'UNDO';
+export const undo = () => ({
+  type: UNDO,
+});
+
+export const REDO = 'REDO';
+export const redo = () => ({
+  type: REDO,
 });

--- a/core/actions/recipes.js
+++ b/core/actions/recipes.js
@@ -87,29 +87,23 @@ export const addRecipeComponent = (recipe, component) => ({
 });
 
 export const REMOVE_RECIPE_COMPONENT = 'REMOVE_RECIPE_COMPONENT';
-export const removeRecipeComponent = (recipe, component) => ({
+export const removeRecipeComponent = (recipe, component, pendingChange) => ({
   type: REMOVE_RECIPE_COMPONENT,
   payload: {
     recipe,
     component,
+    pendingChange,
   },
 });
 
 export const SET_RECIPE_COMPONENTS = 'SET_RECIPE_COMPONENTS';
-export const setRecipeComponents = (recipe, components) => ({
+export const setRecipeComponents = (recipe, components, dependencies, pendingChange) => ({
   type: SET_RECIPE_COMPONENTS,
   payload: {
     recipe,
     components,
-  },
-});
-
-export const SET_RECIPE_DEPENDENCIES = 'SET_RECIPE_DEPENDENCIES';
-export const setRecipeDependencies = (recipe, dependencies) => ({
-  type: SET_RECIPE_DEPENDENCIES,
-  payload: {
-    recipe,
     dependencies,
+    pendingChange,
   },
 });
 
@@ -148,11 +142,17 @@ export const recipesFailure = (error) => ({
 });
 
 export const UNDO = 'UNDO';
-export const undo = () => ({
+export const undo = (recipeId) => ({
   type: UNDO,
+  payload: {
+    recipeId,
+  },
 });
 
 export const REDO = 'REDO';
-export const redo = () => ({
+export const redo = (recipeId) => ({
   type: REDO,
+  payload: {
+    recipeId,
+  },
 });

--- a/core/actions/recipes.js
+++ b/core/actions/recipes.js
@@ -113,6 +113,16 @@ export const setRecipeDependencies = (recipe, dependencies) => ({
   },
 });
 
+export const SET_RECIPE_COMMENT = 'SET_RECIPE_COMMENT';
+export const setRecipeComment = (recipe, comment) => ({
+  type: SET_RECIPE_COMMENT,
+  payload: {
+    recipe,
+    comment,
+  },
+});
+
+
 export const DELETING_RECIPE = 'DELETING_RECIPE';
 export const deletingRecipe = (recipeId) => ({
   type: DELETING_RECIPE,

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -4,12 +4,12 @@ import {
   SET_MODAL_CREATE_RECIPE_ERROR_NAME_VISIBLE, SET_MODAL_CREATE_RECIPE_ERROR_DUPLICATE_VISIBLE,
   SET_MODAL_CREATE_RECIPE_ERROR_INLINE, SET_MODAL_CREATE_RECIPE_CHECK_ERRORS, SET_MODAL_CREATE_RECIPE_RECIPE,
   FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS,
-  APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES,
+  // APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES,
 } from '../actions/modals';
 
-import {
-  UNDO, REDO
-} from '../actions/recipes';
+// import {
+//   UNDO, REDO
+// } from '../actions/recipes';
 
 const modalCreateRecipe = (state = [], action) => {
   switch (action.type) {
@@ -77,55 +77,6 @@ const modalExportRecipe = (state = [], action) => {
   }
 };
 
-const modalPendingChanges = (state = [], action) => {
-  switch (action.type) {
-    case UNDO:
-      return Object.assign(
-        {}, state, {
-          pendingChanges: Object.assign({}, state.pendingChanges, {
-            componentUpdates: Object.assign({}, state.pendingChanges.componentUpdates, {
-              future: state.pendingChanges.componentUpdates.future.concat([state.pendingChanges.componentUpdates.present]),
-              present: state.pendingChanges.componentUpdates.past.pop(),
-            })
-          })
-        }
-      );
-    case REDO:
-      return Object.assign(
-        {}, state, {
-          pendingChanges: Object.assign({}, state.pendingChanges, {
-            componentUpdates: Object.assign({}, state.pendingChanges.componentUpdates, {
-              past: state.pendingChanges.componentUpdates.past.concat([state.pendingChanges.componentUpdates.present]),
-              present: state.pendingChanges.componentUpdates.future.pop(),
-            })
-          })
-        }
-      );
-    case APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES:
-      // This checks if there is already a pending update for that component.
-      // If so it gets removed from the pending changes. Otherwise the new change is added.
-      // We are also maintaining a history of pendingChanges
-      return Object.assign(
-        {}, state, {
-          pendingChanges: Object.assign({}, state.pendingChanges, {
-            componentUpdates: Object.assign({}, state.pendingChanges.componentUpdates, {
-              past: state.pendingChanges.componentUpdates.past.concat([state.pendingChanges.componentUpdates.present]),
-              present: state.pendingChanges.componentUpdates.present.some((component) => {
-                return (component.componentNew === action.payload.componentUpdate.componentOld && component.componentNew !== null)
-                 || (component.componentOld === action.payload.componentUpdate.componentNew && component.componentOld !== null)
-              }) ? state.pendingChanges.componentUpdates.present.filter((component) => {
-                return component.componentNew != action.payload.componentUpdate.componentOld
-                || component.componentOld != action.payload.componentUpdate.componentNew
-              }) : [action.payload.componentUpdate].concat(state.pendingChanges.componentUpdates.present),
-            }),
-          }),
-        }
-      );
-    default:
-      return state;
-  }
-};
-
 
 const modals = (state = [], action) => {
   switch (action.type) {
@@ -149,12 +100,6 @@ const modals = (state = [], action) => {
       return modalExportRecipe(state, action);
     case SET_MODAL_EXPORT_RECIPE_VISIBLE:
       return modalExportRecipe(state, action);
-    case APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES:
-      return modalPendingChanges(state, action);
-    case UNDO:
-      return modalPendingChanges(state, action);
-    case REDO:
-      return modalPendingChanges(state, action);
     default:
       return state;
   }

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -4,6 +4,7 @@ import {
   SET_MODAL_CREATE_RECIPE_ERROR_NAME_VISIBLE, SET_MODAL_CREATE_RECIPE_ERROR_DUPLICATE_VISIBLE,
   SET_MODAL_CREATE_RECIPE_ERROR_INLINE, SET_MODAL_CREATE_RECIPE_CHECK_ERRORS, SET_MODAL_CREATE_RECIPE_RECIPE,
   FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS,
+  APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES,
 } from '../actions/modals';
 
 const modalCreateRecipe = (state = [], action) => {
@@ -72,6 +73,19 @@ const modalExportRecipe = (state = [], action) => {
   }
 };
 
+const modalPendingChanges = (state = [], action) => {
+  switch (action.type) {
+    case APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES:
+      return Object.assign(
+        {}, state,
+        state.pendingChanges.componentUpdates.push(action.payload.componentUpdate),
+      );
+    default:
+      return state;
+  }
+};
+
+
 const modals = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_ACTIVE:
@@ -94,6 +108,8 @@ const modals = (state = [], action) => {
       return modalExportRecipe(state, action);
     case SET_MODAL_EXPORT_RECIPE_VISIBLE:
       return modalExportRecipe(state, action);
+    case APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES:
+      return modalPendingChanges(state, action);
     default:
       return state;
   }

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -77,8 +77,11 @@ const modalPendingChanges = (state = [], action) => {
   switch (action.type) {
     case APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES:
       return Object.assign(
-        {}, state,
-        state.pendingChanges.componentUpdates.push(action.payload.componentUpdate),
+        {}, state, {
+          pendingChanges: Object.assign({}, state.pendingChanges, {
+            componentUpdates: [action.payload.componentUpdate].concat(state.pendingChanges.componentUpdates)
+          })
+        }
       );
     default:
       return state;

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -111,12 +111,12 @@ const modalPendingChanges = (state = [], action) => {
             componentUpdates: Object.assign({}, state.pendingChanges.componentUpdates, {
               past: state.pendingChanges.componentUpdates.past.concat([state.pendingChanges.componentUpdates.present]),
               present: state.pendingChanges.componentUpdates.present.some((component) => {
-                   return component.componentNew === action.payload.componentUpdate.componentOld
-                   || component.componentOld === action.payload.componentUpdate.componentNew
-                }) ? state.pendingChanges.componentUpdates.present.filter((component) => {
-                   return component.componentNew != action.payload.componentUpdate.componentOld
-                   || component.componentOld != action.payload.componentUpdate.componentNew
-                }) : [action.payload.componentUpdate].concat(state.pendingChanges.componentUpdates.present),
+                return (component.componentNew === action.payload.componentUpdate.componentOld && component.componentNew !== null)
+                 || (component.componentOld === action.payload.componentUpdate.componentNew && component.componentOld !== null)
+              }) ? state.pendingChanges.componentUpdates.present.filter((component) => {
+                return component.componentNew != action.payload.componentUpdate.componentOld
+                || component.componentOld != action.payload.componentUpdate.componentNew
+              }) : [action.payload.componentUpdate].concat(state.pendingChanges.componentUpdates.present),
             }),
           }),
         }

--- a/core/reducers/recipes.js
+++ b/core/reducers/recipes.js
@@ -1,4 +1,5 @@
 import {
+  UNDO, REDO,
   CREATING_RECIPE_SUCCEEDED,
   FETCHING_RECIPE_SUCCEEDED,
   FETCHING_RECIPES_SUCCEEDED,
@@ -8,89 +9,169 @@ import {
   DELETING_RECIPE_SUCCEEDED,
 } from '../actions/recipes';
 
-const recipes = (state = [], action) => {
+const recipesPresent = (state = [], action) => {
   switch (action.type) {
     case ADD_RECIPE_COMPONENT:
-      return [
-        ...state.map(recipe => {
-          if (recipe.id === action.payload.recipe.id) {
-            return Object.assign({}, recipe, recipe.components.append(action.payload.component) );
-          }
-          return recipe;
-        }),
-      ];
+      return Object.assign(
+        {}, state, {
+        past: state.past.concat([state.present]),
+        present: [
+          ...state.present.map(recipe => {
+            if (recipe.id === action.payload.recipe.id) {
+              return Object.assign({}, recipe, recipe.components.append(action.payload.component) );
+            }
+            return recipe;
+          }),
+        ]
+      });
     case REMOVE_RECIPE_COMPONENT:
-      return [
-        ...state.map(recipe => {
-          if (recipe.id === action.payload.recipe.id) {
-            return Object.assign(
+      return Object.assign(
+        {}, state, {
+        past: state.past.concat([state.present]),
+        present: [
+          ...state.present.map(recipe => {
+            if (recipe.id === action.payload.recipe.id) {
+              return Object.assign(
                 {},
                 recipe,
                 { components: recipe.components.filter(component => component.name !== action.payload.component.name) });
-          }
-          return recipe;
-        }),
-      ];
+            }
+            return recipe;
+          }),
+        ]
+      });
     case CREATING_RECIPE_SUCCEEDED:
-      return [
-        ...state.filter(recipe => recipe.id !== action.payload.recipe.id),
-        action.payload.recipe,
-      ];
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.filter(recipe => recipe.id !== action.payload.recipe.id),
+          action.payload.recipe,
+        ]
+      });
     // The following reducers filter the recipe out of the state and add the new version if
     // the recipe contains component data or is not found in the state
     case FETCHING_RECIPES_SUCCEEDED:
-      return action.payload.recipe.components !== undefined || !state.some(recipe => recipe.id === action.payload.recipe.id)
-        ? [...state.filter(recipe => recipe.id !== action.payload.recipe.id), action.payload.recipe]
-        : state;
+      return Object.assign(
+        {}, state, {
+        present: action.payload.recipe.components !== undefined
+          || !state.present.some(recipe => recipe.id === action.payload.recipe.id)
+          ? state.present.filter(recipe => recipe.id !== action.payload.recipe.id).concat(action.payload.recipe)
+          : state.present,
+      });
     case FETCHING_RECIPE_SUCCEEDED:
-      return [
-        ...state.filter(recipe => recipe.id !== action.payload.recipe.id),
-        action.payload.recipe,
-      ];
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.filter(recipe => recipe.id !== action.payload.recipe.id),
+          action.payload.recipe,
+        ]
+      });
     case FETCHING_RECIPE_CONTENTS_SUCCEEDED:
-      return [
-        ...state.filter(recipe => recipe.id !== action.payload.recipe.id),
-        action.payload.recipe,
-      ];
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.filter(recipe => recipe.id !== action.payload.recipe.id),
+          action.payload.recipe,
+        ]
+      });
     case SET_RECIPE:
-      return [
-        ...state.map(recipe => {
-          if (recipe.id === action.payload.recipe.id) {
-            return action.payload.recipe;
-          }
-          return recipe;
-        }),
-      ];
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.map(recipe => {
+            if (recipe.id === action.payload.recipe.id) {
+              return action.payload.recipe;
+            }
+            return recipe;
+          }),
+        ]
+      });
     case SET_RECIPE_COMPONENTS:
-      return [
-        ...state.map(recipe => {
-          if (recipe.id === action.payload.recipe.id) {
-            return Object.assign({}, recipe, { components: action.payload.components });
-          }
-          return recipe;
-        }),
-      ];
+      return Object.assign(
+        {}, state, {
+        past: state.past.concat([state.present]),
+        present: [
+          ...state.present.map(recipe => {
+            if (recipe.id === action.payload.recipe.id) {
+              return Object.assign({}, recipe, { components: action.payload.components });
+            }
+            return recipe;
+          }),
+        ]
+      });
     case SET_RECIPE_DEPENDENCIES:
-      return [
-        ...state.map(recipe => {
-          if (recipe.id === action.payload.recipe.id) {
-            return Object.assign({}, recipe, { dependencies: action.payload.dependencies });
-          }
-          return recipe;
-        }),
-      ];
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.map(recipe => {
+            if (recipe.id === action.payload.recipe.id) {
+              return Object.assign({}, recipe, { dependencies: action.payload.dependencies });
+            }
+            return recipe;
+          }),
+        ]
+      });
     case SET_RECIPE_DESCRIPTION:
-      return [
-        ...state.map(recipe => {
-          if (recipe.id === action.payload.recipe.id) {
-            return Object.assign({}, recipe, { description: action.payload.description });
-          }
-          return recipe;
-        }),
-      ];
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.map(recipe => {
+            if (recipe.id === action.payload.recipe.id) {
+              return Object.assign({}, recipe, { description: action.payload.description });
+            }
+            return recipe;
+          }),
+        ]
+      });
 
     case DELETING_RECIPE_SUCCEEDED:
-      return state.filter(recipe => recipe.id !== action.payload.recipeId);
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.filter(recipe => recipe.id !== action.payload.recipeId),
+        ],
+      });
+    default:
+      return state;
+  }
+};
+
+const recipes = (state = [], action) => {
+  switch (action.type) {
+    case UNDO:
+      return Object.assign(
+        {}, state, {
+        future: state.future.concat([state.present]),
+        present: state.past.pop(),
+      });
+    case REDO:
+      return Object.assign(
+        {}, state, {
+        past: state.past.concat([state.present]),
+        present: state.future.pop(),
+      });
+    case ADD_RECIPE_COMPONENT:
+      return recipesPresent(state, action);
+    case REMOVE_RECIPE_COMPONENT:
+      return recipesPresent(state, action);
+    case CREATING_RECIPE_SUCCEEDED:
+      return recipesPresent(state, action);
+    case FETCHING_RECIPES_SUCCEEDED:
+      return recipesPresent(state, action);
+    case FETCHING_RECIPE_SUCCEEDED:
+      return recipesPresent(state, action);
+    case FETCHING_RECIPE_CONTENTS_SUCCEEDED:
+      return recipesPresent(state, action);
+    case SET_RECIPE:
+      return recipesPresent(state, action);
+    case SET_RECIPE_COMPONENTS:
+      return recipesPresent(state, action);
+    case SET_RECIPE_DEPENDENCIES:
+      return recipesPresent(state, action);
+    case SET_RECIPE_DESCRIPTION:
+      return recipesPresent(state, action);
+    case DELETING_RECIPE_SUCCEEDED:
+      return recipesPresent(state, action);
     default:
       return state;
   }

--- a/core/reducers/recipes.js
+++ b/core/reducers/recipes.js
@@ -80,7 +80,7 @@ const recipes = (state = [], action) => {
             return Object.assign(
               {}, recipe, {
               past: [],
-              present: action.payload.recipe,
+              present: Object.assign({}, action.payload.recipe, { pendingChanges: [] }),
               future: [],
             });
           }

--- a/core/reducers/recipes.js
+++ b/core/reducers/recipes.js
@@ -4,7 +4,7 @@ import {
   FETCHING_RECIPE_SUCCEEDED,
   FETCHING_RECIPES_SUCCEEDED,
   FETCHING_RECIPE_CONTENTS_SUCCEEDED,
-  SET_RECIPE, SET_RECIPE_DESCRIPTION, SET_RECIPE_COMPONENTS, SET_RECIPE_DEPENDENCIES,
+  SET_RECIPE, SET_RECIPE_DESCRIPTION, SET_RECIPE_COMPONENTS, SET_RECIPE_DEPENDENCIES, SET_RECIPE_COMMENT,
   ADD_RECIPE_COMPONENT, REMOVE_RECIPE_COMPONENT,
   DELETING_RECIPE_SUCCEEDED,
 } from '../actions/recipes';
@@ -123,7 +123,18 @@ const recipesPresent = (state = [], action) => {
           }),
         ]
       });
-
+    case SET_RECIPE_COMMENT:
+      return Object.assign(
+        {}, state, {
+        present: [
+          ...state.present.map(recipe => {
+            if (recipe.id === action.payload.recipe.id) {
+              return Object.assign({}, recipe, { comment: action.payload.comment });
+            }
+            return recipe;
+          }),
+        ]
+      });
     case DELETING_RECIPE_SUCCEEDED:
       return Object.assign(
         {}, state, {
@@ -169,6 +180,8 @@ const recipes = (state = [], action) => {
     case SET_RECIPE_DEPENDENCIES:
       return recipesPresent(state, action);
     case SET_RECIPE_DESCRIPTION:
+      return recipesPresent(state, action);
+    case SET_RECIPE_COMMENT:
       return recipesPresent(state, action);
     case DELETING_RECIPE_SUCCEEDED:
       return recipesPresent(state, action);

--- a/core/reducers/recipes.js
+++ b/core/reducers/recipes.js
@@ -12,136 +12,154 @@ import {
 const recipesPresent = (state = [], action) => {
   switch (action.type) {
     case ADD_RECIPE_COMPONENT:
-      return Object.assign(
-        {}, state, {
-        past: state.past.concat([state.present]),
-        present: [
-          ...state.present.map(recipe => {
-            if (recipe.id === action.payload.recipe.id) {
-              return Object.assign({}, recipe, recipe.components.append(action.payload.component) );
-            }
-            return recipe;
-          }),
-        ]
-      });
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: recipe.present.components.append(action.payload.component),
+            });
+          }
+          return recipe;
+        }),
+      ];
     case REMOVE_RECIPE_COMPONENT:
-      return Object.assign(
-        {}, state, {
-        past: state.past.concat([state.present]),
-        present: [
-          ...state.present.map(recipe => {
-            if (recipe.id === action.payload.recipe.id) {
-              return Object.assign(
-                {},
-                recipe,
-                { components: recipe.components.filter(component => component.name !== action.payload.component.name) });
-            }
-            return recipe;
-          }),
-        ]
-      });
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: Object.assign(
+                {}, recipe.present, {
+                components: recipe.present.components.filter(component => component.name !== action.payload.component.name)
+              })
+            });
+          }
+          return recipe;
+        }),
+      ];
     case CREATING_RECIPE_SUCCEEDED:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.filter(recipe => recipe.id !== action.payload.recipe.id),
-          action.payload.recipe,
-        ]
-      });
+      return [
+        ...state.filter(recipe => recipe.present.id !== action.payload.recipe.id), {
+          past: [],
+          present: action.payload.recipe,
+          future: [],
+        }
+      ];
     // The following reducers filter the recipe out of the state and add the new version if
     // the recipe contains component data or is not found in the state
     case FETCHING_RECIPES_SUCCEEDED:
-      return Object.assign(
-        {}, state, {
-        present: action.payload.recipe.components !== undefined
-          || !state.present.some(recipe => recipe.id === action.payload.recipe.id)
-          ? state.present.filter(recipe => recipe.id !== action.payload.recipe.id).concat(action.payload.recipe)
-          : state.present,
-      });
-    case FETCHING_RECIPE_SUCCEEDED:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.filter(recipe => recipe.id !== action.payload.recipe.id),
-          action.payload.recipe,
-        ]
-      });
+      return action.payload.recipe.components !== undefined
+      || !state.some(recipe => recipe.present.id === action.payload.recipe.id)
+      ? [...state.filter(recipe => recipe.present.id !== action.payload.recipe.id), {
+          past: [],
+          present: action.payload.recipe,
+          future: [],
+        }]
+      : state;
     case FETCHING_RECIPE_CONTENTS_SUCCEEDED:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.filter(recipe => recipe.id !== action.payload.recipe.id),
-          action.payload.recipe,
-        ]
-      });
+      return [
+        ...state.filter(recipe => recipe.present.id !== action.payload.recipe.id), {
+          past: [],
+          present: action.payload.recipe,
+          future: [],
+        }
+      ];
     case SET_RECIPE:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.map(recipe => {
-            if (recipe.id === action.payload.recipe.id) {
-              return action.payload.recipe;
-            }
-            return recipe;
-          }),
-        ]
-      });
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: action.payload.recipe,
+            });
+          }
+          return recipe;
+        }),
+      ];
     case SET_RECIPE_COMPONENTS:
-      return Object.assign(
-        {}, state, {
-        past: state.past.concat([state.present]),
-        present: [
-          ...state.present.map(recipe => {
-            if (recipe.id === action.payload.recipe.id) {
-              return Object.assign({}, recipe, { components: action.payload.components });
-            }
-            return recipe;
-          }),
-        ]
-      });
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: Object.assign({}, recipe.present, { components: action.payload.components }),
+            });
+          }
+          return recipe;
+        }),
+      ];
     case SET_RECIPE_DEPENDENCIES:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.map(recipe => {
-            if (recipe.id === action.payload.recipe.id) {
-              return Object.assign({}, recipe, { dependencies: action.payload.dependencies });
-            }
-            return recipe;
-          }),
-        ]
-      });
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: Object.assign({}, recipe.present, { dependencies: action.payload.dependencies }),
+            });
+          }
+          return recipe;
+        }),
+      ];
     case SET_RECIPE_DESCRIPTION:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.map(recipe => {
-            if (recipe.id === action.payload.recipe.id) {
-              return Object.assign({}, recipe, { description: action.payload.description });
-            }
-            return recipe;
-          }),
-        ]
-      });
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: Object.assign({}, recipe.present, { description: action.payload.description }),
+            });
+          }
+          return recipe;
+        }),
+      ];
     case SET_RECIPE_COMMENT:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.map(recipe => {
-            if (recipe.id === action.payload.recipe.id) {
-              return Object.assign({}, recipe, { comment: action.payload.comment });
-            }
-            return recipe;
-          }),
-        ]
-      });
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: Object.assign({}, recipe.present, { comment: action.payload.comment }),
+            });
+          }
+          return recipe;
+        }),
+      ];
     case DELETING_RECIPE_SUCCEEDED:
-      return Object.assign(
-        {}, state, {
-        present: [
-          ...state.present.filter(recipe => recipe.id !== action.payload.recipeId),
-        ],
-      });
+      return state.filter(recipe => recipe.present.id !== action.payload.recipeId);
+    case UNDO:
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              present: recipe.past.pop(),
+              future: recipe.future.concat([recipe.present]),
+            });
+          }
+          return recipe;
+        }),
+      ];
+    case REDO:
+      return [
+        ...state.map(recipe => {
+          if (recipe.present.id === action.payload.recipe.id) {
+            return Object.assign(
+              {}, recipe, {
+              past: recipe.past.concat([recipe.present]),
+              present: recipe.future.pop(),
+            });
+          }
+          return recipe;
+        }),
+      ];
     default:
       return state;
   }

--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -3,7 +3,7 @@ import { fetchRecipeInputsApi } from '../apiCalls';
 import { FETCHING_INPUTS, fetchingInputsSucceeded } from '../actions/inputs';
 
 /* eslint require-yield: "warn" */ // FIXME: issue #151
-function* updateInputComponentData(inputs, componentData) {
+function updateInputComponentData(inputs, componentData) {
   let updatedInputs = inputs;
   if (componentData !== undefined && componentData.length > 0) {
     const parsedInputs = componentData.map(component => {

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -1,7 +1,27 @@
 import { createSelector } from 'reselect';
 
+const getPastLength = (state) => {
+  const pastLength = state.recipes.past.length;
+  return pastLength;
+};
+
+export const makeGetPastLength = () => createSelector(
+  [getPastLength],
+  (pastLength) => pastLength
+);
+
+const getFutureLength = (state) => {
+  const futureLength = state.recipes.future.length;
+  return futureLength;
+};
+
+export const makeGetFutureLength = () => createSelector(
+  [getFutureLength],
+  (futureLength) => futureLength
+);
+
 const getRecipeById = (state, recipeId) => {
-  const recipeById = state.recipes.find(recipe => recipe.id === recipeId);
+  const recipeById = state.recipes.present.find(recipe => recipe.id === recipeId);
   return recipeById;
 };
 
@@ -52,7 +72,7 @@ export const makeGetSortedDependencies = () => createSelector(
 );
 
 const getSortedRecipes = (state) => {
-  const sortedRecipes = state.recipes;
+  const sortedRecipes = state.recipes.present;
   const key = state.sort.recipes.key;
   const value = state.sort.recipes.value;
   sortedRecipes.sort((a, b) => {

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 
-const getPastLength = (state) => {
-  const pastLength = state.recipes.past.length;
+const getPastLength = (recipe) => {
+  const pastLength = recipe.past.length;
   return pastLength;
 };
 
@@ -10,8 +10,8 @@ export const makeGetPastLength = () => createSelector(
   (pastLength) => pastLength
 );
 
-const getFutureLength = (state) => {
-  const futureLength = state.recipes.future.length;
+const getFutureLength = (recipe) => {
+  const futureLength = recipe.future.length;
   return futureLength;
 };
 
@@ -21,7 +21,7 @@ export const makeGetFutureLength = () => createSelector(
 );
 
 const getRecipeById = (state, recipeId) => {
-  const recipeById = state.recipes.present.find(recipe => recipe.id === recipeId);
+  const recipeById = state.recipes.find(recipe => recipe.present.id === recipeId);
   return recipeById;
 };
 
@@ -72,7 +72,7 @@ export const makeGetSortedDependencies = () => createSelector(
 );
 
 const getSortedRecipes = (state) => {
-  const sortedRecipes = state.recipes.present;
+  const sortedRecipes = state.recipes;
   const key = state.sort.recipes.key;
   const value = state.sort.recipes.value;
   sortedRecipes.sort((a, b) => {

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -76,8 +76,8 @@ const getSortedRecipes = (state) => {
   const key = state.sort.recipes.key;
   const value = state.sort.recipes.value;
   sortedRecipes.sort((a, b) => {
-    if (a[key] > b[key]) return value === 'DESC' ? 1 : -1;
-    if (b[key] > a[key]) return value === 'DESC' ? -1 : 1;
+    if (a.present[key] > b.present[key]) return value === 'DESC' ? 1 : -1;
+    if (b.present[key] > a.present[key]) return value === 'DESC' ? -1 : 1;
     return 0;
   });
   return sortedRecipes;

--- a/core/store.js
+++ b/core/store.js
@@ -32,11 +32,7 @@ const initialState = {
         value: '',
     },
   },
-  recipes : {
-    past: [],
-    present: [],
-    future: [],
-  },
+  recipes : [],
   modals: {
     createComposition: {
       compositionTypes: [],

--- a/core/store.js
+++ b/core/store.js
@@ -88,6 +88,6 @@ const store = createStore(
 );
 sagaMiddleware.run(rootSaga);
 
-persistStore(store, { whitelist: ['recipePage', 'recipes'] });
+persistStore(store, { whitelist: ['recipePage'] });
 
 export default store;

--- a/core/store.js
+++ b/core/store.js
@@ -59,7 +59,11 @@ const initialState = {
       },
     },
     pendingChanges: {
-      componentUpdates: [],
+      componentUpdates: {
+        past: [],
+        present: [],
+        future: [],
+      },
     },
   },
   sort: {

--- a/core/store.js
+++ b/core/store.js
@@ -27,6 +27,15 @@ const initialState = {
       parent: '',
       status: '',
     },
+    inputFilters: {
+        field: 'name',
+        value: '',
+    },
+  },
+  recipes : {
+    past: [],
+    present: [],
+    future: [],
   },
   modals: {
     createComposition: {
@@ -48,6 +57,9 @@ const initialState = {
         modules: [],
         packages: [],
       },
+    },
+    pendingChanges: {
+      componentUpdates: [],
     },
   },
   sort: {
@@ -76,6 +88,6 @@ const store = createStore(
 );
 sagaMiddleware.run(rootSaga);
 
-persistStore(store, { whitelist: ['recipes', 'recipePage', 'inputs'] });
+persistStore(store, { whitelist: ['recipePage'] });
 
 export default store;

--- a/core/store.js
+++ b/core/store.js
@@ -88,6 +88,6 @@ const store = createStore(
 );
 sagaMiddleware.run(rootSaga);
 
-persistStore(store, { whitelist: ['recipePage'] });
+persistStore(store, { whitelist: ['recipePage', 'recipes'] });
 
 export default store;

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -624,9 +624,9 @@ const makeMapStateToProps = () => {
       const fetchedRecipe = getRecipeById(state, props.route.params.recipe.replace(/\s/g, '-'));
       return {
         rehydrated: state.rehydrated,
-        recipe: fetchedRecipe,
-        components: getSortedComponents(state, fetchedRecipe),
-        dependencies: getSortedDependencies(state, fetchedRecipe),
+        recipe: fetchedRecipe.present,
+        components: getSortedComponents(state, fetchedRecipe.present),
+        dependencies: getSortedDependencies(state, fetchedRecipe.present),
         recipePage: state.recipePage,
         exportModalVisible: state.modals.exportRecipe.visible,
         compositionTypes: state.modals.createComposition.compositionTypes,

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -412,7 +412,9 @@ class EditRecipePage extends React.Component {
 
   render() {
     if (!this.props.rehydrated) {
-      this.props.fetchingRecipeContents(this.props.route.params.recipe.replace(/\s/g, '-'));
+      if (this.props.recipe.id === undefined) {
+        this.props.fetchingRecipeContents(this.props.route.params.recipe.replace(/\s/g, '-'));
+      }
       return <div></div>;
     }
     if ((this.props.inputs.inputComponents === undefined || this.props.inputs.inputComponents.length === 0)

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -631,7 +631,7 @@ class EditRecipePage extends React.Component {
           : null}
         {modalActive === 'modalPendingChanges'
           ? <PendingChanges
-            recipe={recipe.name}
+            recipe={recipe}
             contents={dependencies}
             handleHideModal={this.handleHideModal}
           />

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -418,8 +418,11 @@ class EditRecipePage extends React.Component {
       return <div></div>;
     }
     if ((this.props.inputs.inputComponents === undefined || this.props.inputs.inputComponents.length === 0)
-      && this.props.components !== undefined) {
+      && this.props.recipe.components !== undefined) {
       this.props.fetchingInputs(this.props.inputs.inputFilters, 0, 50, this.props.recipe.components);
+    }
+    else if (this.props.recipe.components === undefined) {
+      this.props.fetchingInputs(this.props.inputs.inputFilters, 0, 50, []);
     }
     const recipeDisplayName = this.props.route.params.recipe;
     const {

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -407,15 +407,6 @@ class EditRecipePage extends React.Component {
       );
     }, 50);
   }
-  // undo() {
-  //   this.props.undo();
-  //   this.props.fetchingInputs(this.props.filter, 0, 50, this.props.recipe.components);
-  // }
-  //
-  // redo() {
-  //   this.props.redo();
-  //   this.props.fetchingInputs(this.props.filter, 0, 50, this.props.recipe.components);
-  // }
 
   render() {
     if (!this.props.rehydrated) {
@@ -446,7 +437,7 @@ class EditRecipePage extends React.Component {
             <li className="active"><strong>Edit Recipe</strong></li>
           </ol>
           <div className="cmpsr-header__actions">
-          {pastLength > 0 &&
+          {componentUpdates.length > 0 &&
             <ul className="list-inline">
             {componentUpdates.length !== 1 &&
               <li className="text-muted"> {componentUpdates.length} changes</li>
@@ -631,6 +622,7 @@ class EditRecipePage extends React.Component {
           : null}
         {modalActive === 'modalPendingChanges'
           ? <PendingChanges
+            handleSave={this.handleSave}
             recipe={recipe}
             contents={dependencies}
             handleHideModal={this.handleHideModal}

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -685,17 +685,17 @@ const makeMapStateToProps = () => {
       const fetchedRecipe = getRecipeById(state, props.route.params.recipe.replace(/\s/g, '-'));
       return {
         rehydrated: state.rehydrated,
-        recipe: fetchedRecipe,
-        components: getSortedComponents(state, fetchedRecipe),
-        dependencies: getSortedDependencies(state, fetchedRecipe),
+        recipe: fetchedRecipe.present,
+        components: getSortedComponents(state, fetchedRecipe.present),
+        dependencies: getSortedDependencies(state, fetchedRecipe.present),
         componentsSortKey: state.sort.components.key,
         componentsSortValue: state.sort.components.value,
         createComposition: state.modals.createComposition,
         inputs: state.inputs,
         selectedInput: state.inputs.selectedInput,
         modalActive: state.modals.modalActive,
-        pastLength: getPastLength(state),
-        futureLength: getFutureLength(state),
+        pastLength: getPastLength(fetchedRecipe),
+        futureLength: getFutureLength(fetchedRecipe),
         componentUpdates: state.modals.pendingChanges.componentUpdates.present,
       };
     }

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -429,7 +429,7 @@ class EditRecipePage extends React.Component {
     const {
       recipe, components, dependencies,
       inputs, createComposition, modalActive, componentsSortKey, componentsSortValue,
-      pastLength, futureLength,
+      pastLength, futureLength, componentUpdates,
     } = this.props;
 
     return (
@@ -448,8 +448,8 @@ class EditRecipePage extends React.Component {
           <div className="cmpsr-header__actions">
           {pastLength > 0 &&
             <ul className="list-inline">
-            {pastLength !== 1 &&
-              <li className="text-muted"> {pastLength} changes</li>
+            {componentUpdates.length !== 1 &&
+              <li className="text-muted"> {componentUpdates.length} changes</li>
             ||
               <li className="text-muted"> 1 change</li>
             }
@@ -703,6 +703,7 @@ const makeMapStateToProps = () => {
         modalActive: state.modals.modalActive,
         pastLength: getPastLength(state),
         futureLength: getFutureLength(state),
+        componentUpdates: state.modals.pendingChanges.componentUpdates.present,
       };
     }
     return {
@@ -718,6 +719,7 @@ const makeMapStateToProps = () => {
       modalActive: state.modals.modalActive,
       pastLength: 0,
       futureLength: 0,
+      componentUpdates: state.modals.pendingChanges.componentUpdates.present,
     };
   };
   return mapStateToProps;

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -677,6 +677,7 @@ EditRecipePage.propTypes = {
   appendModalPendingChangesComponentUpdates: PropTypes.func,
   pastLength: PropTypes.number,
   futureLength: PropTypes.number,
+  componentUpdates: PropTypes.array,
   undo: PropTypes.func,
   redo: PropTypes.func,
 };

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -411,7 +411,7 @@ class EditRecipePage extends React.Component {
   }
 
   render() {
-    if (!this.props.rehydrated) {
+    if (!this.props.rehydrated || this.props.recipe.id === undefined) {
       if (this.props.recipe.id === undefined) {
         this.props.fetchingRecipeContents(this.props.route.params.recipe.replace(/\s/g, '-'));
       }

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -153,7 +153,7 @@ class RecipesPage extends React.Component {
           handleShowModalExport={this.handleShowModalExport}
         />
       }
-        <CreateRecipe recipeNames={this.props.recipes.map(recipe => recipe.id)} />
+        <CreateRecipe recipeNames={recipes.map(recipe => recipe.id)} />
         {(exportRecipe !== undefined && exportRecipe.visible)
           ? <ExportRecipe
             recipe={exportRecipe.name}
@@ -205,6 +205,7 @@ const makeMapStateToProps = () => {
 
   return mapStateToProps;
 };
+
 
 const mapDispatchToProps = dispatch => ({
   fetchingModalExportRecipeContents: modalRecipeName => {

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -146,14 +146,14 @@ class RecipesPage extends React.Component {
       }
       {createComposition.compositionTypes !== undefined &&
         <RecipeListView
-          recipes={recipes}
+          recipes={recipes.map(recipe => recipe.present)}
           compositionTypes={createComposition.compositionTypes}
           handleDelete={this.handleDelete}
           setNotifications={this.setNotifications}
           handleShowModalExport={this.handleShowModalExport}
         />
       }
-        <CreateRecipe recipeNames={recipes.map(recipe => recipe.id)} />
+        <CreateRecipe recipeNames={recipes.map(recipe => recipe.present.id)} />
         {(exportRecipe !== undefined && exportRecipe.visible)
           ? <ExportRecipe
             recipe={exportRecipe.name}

--- a/test/end-to-end/pages/editRecipe.js
+++ b/test/end-to-end/pages/editRecipe.js
@@ -59,6 +59,8 @@ module.exports = class EditRecipePage extends MainPage {
     this.moreActionList = {
       Export: 'Export',
     };
+
+    this.componentListItemRootElementSelect = `${this.componentListItemRootElement} a`;
   }
 
   get url() {

--- a/test/end-to-end/test/test_editRecipe.js
+++ b/test/end-to-end/test/test_editRecipe.js
@@ -319,6 +319,8 @@ describe('Edit Recipe Page', () => {
 
         nightmare
           .wait(editRecipePage.componentListItemRootElement)
+          .wait(editRecipePage.componentListItemRootElementSelect)
+          .click(editRecipePage.componentListItemRootElementSelect)
           .wait(editRecipePage.btnSave)
           .click(editRecipePage.btnSave)
           .wait(toastNotifPage.iconCreating)

--- a/test/unit/index.norecipes.spec.js
+++ b/test/unit/index.norecipes.spec.js
@@ -8,7 +8,9 @@ describe('Home page', () => {
     compositionTypes: [{ name: 'qcow2', enabled: true }],
   };
   const mockState = {
-    recipes: [],
+    recipes: {
+      present: [],
+    },
     sort: { recipes: [] },
     modals: {
       createComposition: mockCreateComposition,

--- a/test/unit/index.norecipes.spec.js
+++ b/test/unit/index.norecipes.spec.js
@@ -8,9 +8,7 @@ describe('Home page', () => {
     compositionTypes: [{ name: 'qcow2', enabled: true }],
   };
   const mockState = {
-    recipes: {
-      present: [],
-    },
+    recipes: [],
     sort: { recipes: [] },
     modals: {
       createComposition: mockCreateComposition,


### PR DESCRIPTION

This PR meets the UI Acceptance Criteria of:
    
- When a change is made to a recipe, then the number of pending changes displayed next to the Save button is incremented.
- When no pending changes exist, then actions for Save, Discard, View and Comment are not available (buttons are disabled, pending changes text and link are not visible).
- Given one or more pending changes exist, when the user clicks the link "View and Comment", the pending changes are listed in the modal.
- When the user hits Save, then pending changes are committed to the recipe
- The modal dialog includes a comment field
- Undo and Redo actions

In regards to the failed test, I am uncertain why it is failing on travis. It passes locally.
