### PR TITLE
Rename Cockpit dashboard title

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
 
     "dashboard": {
         "index": {
-            "label": "Welder",
+            "label": "Image Builder",
             "order": 30
         }
     },


### PR DESCRIPTION
Cockpit uses menu items which are a functional description
("Networking", "Containers", "Logs", or "Dashboard"), not product names
("Network Manager", "Docker", or "systemd"). Consequently, name the
Cockpit dashboard "Image Builder" instead of "Welder".