### PR TITLE
Don't ignore failed serviceCheck in tests

### DIFF
--- a/test/end-to-end/test/test_createRecipe.js
+++ b/test/end-to-end/test/test_createRecipe.js
@@ -15,9 +15,7 @@ describe('Create Recipe Page', () => {
   const timeout = 15000;
 
   // Check BDCS API and Web service first
-  beforeAll((done) => {
-    apiCall.serviceCheck(done);
-  });
+  beforeAll(apiCall.serviceCheck);
 
   const recipesPage = new RecipesPage();
   const createRecipePage = new CreateRecipePage(pageConfig.recipe.simple.name

--- a/test/end-to-end/test/test_editRecipe.js
+++ b/test/end-to-end/test/test_editRecipe.js
@@ -15,9 +15,7 @@ describe('Edit Recipe Page', () => {
   const timeout = 15000;
 
   // Check BDCS API and Web service first
-  beforeAll((done) => {
-    apiCall.serviceCheck(done);
-  });
+  beforeAll(apiCall.serviceCheck);
 
   const editRecipePage = new EditRecipePage(pageConfig.recipe.simple.name);
 

--- a/test/end-to-end/test/test_importSanity.js
+++ b/test/end-to-end/test/test_importSanity.js
@@ -23,10 +23,8 @@ describe('Imported Content Sanity Testing', () => {
     });
   });
 
-  beforeAll((done) => {
-    // Check BDCS API and Web service first
-    apiCall.serviceCheck(done);
-  });
+  // Check BDCS API and Web service first
+  beforeAll(apiCall.serviceCheck);
 
   beforeAll((done) => {
     // Create a new recipe before the first test run in this suite

--- a/test/end-to-end/test/test_recipes.js
+++ b/test/end-to-end/test/test_recipes.js
@@ -16,9 +16,7 @@ describe('Recipes Page', () => {
   const timeout = 15000;
 
   // Check BDCS API and Web service first
-  beforeAll((done) => {
-    apiCall.serviceCheck(done);
-  });
+  beforeAll(apiCall.serviceCheck);
 
   const recipesPage = new RecipesPage();
 

--- a/test/end-to-end/test/test_viewRecipe.js
+++ b/test/end-to-end/test/test_viewRecipe.js
@@ -15,9 +15,7 @@ describe('View Recipe Page', () => {
   const timeout = 15000;
 
   // Check BDCS API and Web service first
-  beforeAll((done) => {
-    apiCall.serviceCheck(done);
-  });
+  beforeAll(apiCall.serviceCheck);
 
   const viewRecipePage = new ViewRecipePage(pageConfig.recipe.simple.name);
 

--- a/test/end-to-end/utils/apiCall.js
+++ b/test/end-to-end/utils/apiCall.js
@@ -4,7 +4,7 @@ const pageConfig = require('../config');
 
 module.exports = {
   // BDCS API + Web service checking
-  serviceCheck: (done) => {
+  serviceCheck: () => {
     const bdcsOptions = {
       method: 'GET',
       uri: `${pageConfig.api.uri}${pageConfig.api.test}`,
@@ -14,37 +14,7 @@ module.exports = {
       uri: pageConfig.root,
     };
 
-    request(bdcsOptions)
-      .then(() => {
-        request(webOptions)
-          .then(() => { done(); })
-          .catch((error) => { done(error); });
-      })
-      .catch((error) => { done(error); });
-  },
-
-  // BDCS API checking
-  apiCheck: (done) => {
-    const options = {
-      method: 'GET',
-      uri: `${pageConfig.api.uri}${pageConfig.api.test}`,
-    };
-
-    request(options)
-      .then(() => { done(); })
-      .catch((error) => { done(error); });
-  },
-
-  // Web service checking
-  webCheck: (done) => {
-    const options = {
-      method: 'GET',
-      uri: pageConfig.root,
-    };
-
-    request(options)
-      .then(() => { done(); })
-      .catch((error) => { done(error); });
+    return Promise.all([request(bdcsOptions), request(webOptions)]);
   },
 
   // Create a new recipe


### PR DESCRIPTION
The integration test's `serviceCheck()` previously caught errors (if the
checked services like bdcs and welder-web are not running) and just
called the `done()` callback, but that does not care about the returned
value - in particular if that is an exception. This causes unhelpful
test failure output and makes the entire `serviceCheck()` call rather useless.

Instead, directly return the two involved promises instead of using a
`done` callback, to let jest deal with it properly (see
http://facebook.github.io/jest/docs/en/setup-teardown.html)

Drop the unused `webCheck()` and `apiCheck()` methods.