### PR TITLE
Replace eval(coverage.js) in tests with proper import

### DIFF
--- a/test/end-to-end/README.md
+++ b/test/end-to-end/README.md
@@ -147,14 +147,6 @@ There are several things to be noted when writing and executing the tests:
 3. `utils/coverage.js` must be executed inside the last `.then()` method in the
    Nightmare sequence. This is usually after the last expectation (assertion);
 4. `utils/coverage.js` takes care to call `.end()` and close the electron process;
-5. We're using `eval()` to *include* the contents of `utils/coverage.js` inside the
-   last `.then()` method because attempts to execute the same code as a method of
-   a helper module have failed. You will likely get something like
-   `nightmare is not defined` or
-   `Unhandled promise rejection (rejection id: 1): cov_23rlop1885 is not defined`;
-6. `eval()` **must be** called from the global scope, it can't be made into a
-   helper function. Thus the syntax is abit ugly but at least it is a one liner;
-
 
 ## Test Result
 

--- a/test/end-to-end/test/test_createRecipe.js
+++ b/test/end-to-end/test/test_createRecipe.js
@@ -7,6 +7,7 @@ const apiCall = require('../utils/apiCall');
 const helper = require('../utils/helper');
 const pageConfig = require('../config');
 const fs = require('fs');
+const coverage = require('../utils/coverage.js').coverage;
 
 
 describe('Create Recipe Page', () => {
@@ -56,7 +57,7 @@ describe('Create Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expectedHelpBlockMsg);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should show alert message by clicking Enter key when create recipe without name @create-recipe-page', (done) => {
@@ -84,7 +85,7 @@ describe('Create Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expectedHelpBlockMsg);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should show alert message by changing focus to description input @create-recipe-page', (done) => {
@@ -104,7 +105,7 @@ describe('Create Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -130,7 +131,7 @@ describe('Create Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(true);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });

--- a/test/end-to-end/test/test_editRecipe.js
+++ b/test/end-to-end/test/test_editRecipe.js
@@ -8,6 +8,7 @@ const apiCall = require('../utils/apiCall');
 const helper = require('../utils/helper');
 const pageConfig = require('../config');
 const fs = require('fs');
+const coverage = require('../utils/coverage.js').coverage;
 
 describe('Edit Recipe Page', () => {
   let nightmare;
@@ -62,7 +63,7 @@ describe('Edit Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expectedViewRecipeLinke);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -79,7 +80,7 @@ describe('Edit Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should have Create Composition button @edit-recipe-page', (done) => {
@@ -94,7 +95,7 @@ describe('Edit Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -120,7 +121,7 @@ describe('Edit Recipe Page', () => {
             .then((element) => {
               expect(element).toBe(expected);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
         test('should have toast notification pop up when new composition added @edit-recipe-page', (done) => {
@@ -161,7 +162,7 @@ describe('Edit Recipe Page', () => {
             .then((element) => {
               expect(element).toBe(expectedComplete);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
       });
@@ -186,7 +187,7 @@ describe('Edit Recipe Page', () => {
             , menuActionExport)
           .then((element) => {
             expect(element).toBe(expected);
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -207,7 +208,7 @@ describe('Edit Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -242,7 +243,7 @@ describe('Edit Recipe Page', () => {
             .then((element) => {
               expect(element).toBe(expectedContent);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }
 
@@ -307,7 +308,7 @@ describe('Edit Recipe Page', () => {
             // remove the last "\n" from paste result with trim()
             expect(element.trim()).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -338,7 +339,7 @@ describe('Edit Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });

--- a/test/end-to-end/test/test_importSanity.js
+++ b/test/end-to-end/test/test_importSanity.js
@@ -6,6 +6,7 @@ const pageConfig = require('../config');
 const helper = require('../utils/helper');
 const sqlite3 = require('sqlite3').verbose();
 const fs = require('fs');
+const coverage = require('../utils/coverage.js').coverage;
 
 describe('Imported Content Sanity Testing', () => {
   let nightmare;
@@ -59,7 +60,7 @@ describe('Imported Content Sanity Testing', () => {
           expect(element).toBe(expectedText);
 
           // note eval() can't be called from within another function
-          eval(fs.readFileSync('utils/coverage.js').toString());
+          coverage(nightmare, done);
         });
     });
   }, timeout);

--- a/test/end-to-end/test/test_recipes.js
+++ b/test/end-to-end/test/test_recipes.js
@@ -9,6 +9,7 @@ const apiCall = require('../utils/apiCall');
 const helper = require('../utils/helper');
 const pageConfig = require('../config');
 const fs = require('fs');
+const coverage = require('../utils/coverage.js').coverage;
 
 describe('Recipes Page', () => {
   let nightmare;
@@ -39,7 +40,7 @@ describe('Recipes Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -58,7 +59,7 @@ describe('Recipes Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should pop up Create Recipe window when click Create Recipe button @recipes-page', (done) => {
@@ -79,7 +80,7 @@ describe('Recipes Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -114,7 +115,7 @@ describe('Recipes Page', () => {
             .then((element) => {
               expect(element).toBe(expected);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
         test('should have correct recipe description on list after new recipe added @recipes-page', (done) => {
@@ -128,7 +129,7 @@ describe('Recipes Page', () => {
             .then((element) => {
               expect(element).toContain(expected);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
       });
@@ -157,7 +158,7 @@ describe('Recipes Page', () => {
               .then((element) => {
                 expect(element).toBe(expected);
 
-                eval(fs.readFileSync('utils/coverage.js').toString());
+                coverage(nightmare, done);
               });
           }, timeout);
           test('should have toast notification pop up when new composition added @recipes-page', (done) => {
@@ -197,7 +198,7 @@ describe('Recipes Page', () => {
               .then((element) => {
                 expect(element).toBe(expectedComplete);
 
-                eval(fs.readFileSync('utils/coverage.js').toString());
+                coverage(nightmare, done);
               });
           }, timeout);
         });
@@ -222,7 +223,7 @@ describe('Recipes Page', () => {
             .then((element) => {
               expect(element).toBe(expected);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
         test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -242,7 +243,7 @@ describe('Recipes Page', () => {
             .then((element) => {
               expect(element).toBe(expected);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
         test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -277,7 +278,7 @@ describe('Recipes Page', () => {
               .then((element) => {
                 expect(element).toBe(expectedContent);
 
-                eval(fs.readFileSync('utils/coverage.js').toString());
+                coverage(nightmare, done);
               });
           }
 
@@ -341,7 +342,7 @@ describe('Recipes Page', () => {
               // remove the last "\n" from paste result with trim()
               expect(element.trim()).toBe(expected);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
       });

--- a/test/end-to-end/test/test_viewRecipe.js
+++ b/test/end-to-end/test/test_viewRecipe.js
@@ -8,6 +8,7 @@ const apiCall = require('../utils/apiCall');
 const helper = require('../utils/helper');
 const pageConfig = require('../config');
 const fs = require('fs');
+const coverage = require('../utils/coverage.js').coverage;
 
 describe('View Recipe Page', () => {
   let nightmare;
@@ -53,7 +54,7 @@ describe('View Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -69,7 +70,7 @@ describe('View Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should have Create Composition button @view-recipe-page', (done) => {
@@ -83,7 +84,7 @@ describe('View Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });
@@ -106,7 +107,7 @@ describe('View Recipe Page', () => {
             .then((element) => {
               expect(element).toBe(expected);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
         test('should have toast notification pop up when new composition added @view-recipe-page', (done) => {
@@ -146,7 +147,7 @@ describe('View Recipe Page', () => {
             .then((element) => {
               expect(element).toBe(expectedComplete);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }, timeout);
       });
@@ -171,7 +172,7 @@ describe('View Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should pop up Export Recipe window by clicking "Export"', (done) => {
@@ -191,7 +192,7 @@ describe('View Recipe Page', () => {
           .then((element) => {
             expect(element).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
       test('should show the correct dependence packages and total numbers of dependencies', (done) => {
@@ -226,7 +227,7 @@ describe('View Recipe Page', () => {
             .then((element) => {
               expect(element).toBe(expectedContent);
 
-              eval(fs.readFileSync('utils/coverage.js').toString());
+              coverage(nightmare, done);
             });
         }
 
@@ -290,7 +291,7 @@ describe('View Recipe Page', () => {
             // remove the last "\n" from paste result with trim()
             expect(element.trim()).toBe(expected);
 
-            eval(fs.readFileSync('utils/coverage.js').toString());
+            coverage(nightmare, done);
           });
       }, timeout);
     });

--- a/test/end-to-end/utils/coverage.js
+++ b/test/end-to-end/utils/coverage.js
@@ -6,23 +6,27 @@
 
 // collects coverage from the tested page,
 // calls nightmare.end() and calls done()
-// executed via eval() as a last step of every test!
-nightmare
-  .evaluate(() => {
-    if (window.location.href.includes('9090')) {
-      return window.top.document.querySelector('.container-frame').contentWindow.__coverage__;
-    }
-    return window.__coverage__;
-  })
-  .end()
-  .then((cov) => {
-    const strCoverage = JSON.stringify(cov);
-    const hash = require('crypto').createHmac('sha256', '')
-      .update(strCoverage)
-      .digest('hex');
-    const fileName = `/tmp/coverage-${hash}.json`;
-    require('fs').writeFileSync(fileName, strCoverage);
+module.exports = {
+  coverage: (nightmare, done) => {
+    nightmare
+      .evaluate(() => {
+        if (window.location.href.includes('9090')) {
+          return window.top.document.querySelector('.container-frame').contentWindow.__coverage__;
+        }
+        return window.__coverage__;
+      })
+      .end()
+      .then((cov) => {
+        const strCoverage = JSON.stringify(cov);
+        const hash = require('crypto').createHmac('sha256', '')
+          .update(strCoverage)
+          .digest('hex');
+        const fileName = `/tmp/coverage-${hash}.json`;
+        require('fs').writeFileSync(fileName, strCoverage);
 
-    done();
-  })
-.catch(err => console.log(err));
+        done();
+      })
+    .catch(err => console.log(err));
+  },
+
+};


### PR DESCRIPTION
Slurping in utils/coverage.js via a manual file read and `eval()` is a
big and unnecessary hack. Turn it into a proper function instead.