### PR TITLE
Drop unsafe-inline from Cockpit Content-Security-Policy

### DIFF
--- a/components/CardView/CardView.js
+++ b/components/CardView/CardView.js
@@ -30,7 +30,7 @@ class CardView extends React.Component {
         {users.map((user, i) =>
           <div className="col-xs-12 col-sm-6 col-md-4 col-lg-3" key={i}>
             <div className="card-pf card-pf-view card-pf-view-select card-pf-view-single-select">
-              <div className="card-pf-body" style={{ height: '260px' }}>
+              <div className="card-pf-body">
                 <div className="card-pf-top-element">
                   <span className="fa fa-birthday-cake card-pf-icon-circle"></span>
                 </div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,5 +10,5 @@
             "order": 30
         }
     },
-    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-eval'"
 }


### PR DESCRIPTION
There are no inline HTML `on*=""` event handlers and no `<script>` tags.
Inline `style=` was only being used in CardView.js where it does not
actually make any visual difference, so just drop that.