### PR TITLE
tests: Fix metadata.db download regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,13 @@ stylelint:
 unit-test:
 	npm run test:cov
 
-shared:
+metadata.db:
+	wget --progress=dot:giga https://s3.amazonaws.com/weldr/metadata.db
+
+shared: metadata.db
 	sudo docker build -f Dockerfile.nodejs --cache-from welder/web-nodejs:latest -t welder/web-nodejs:latest .
 	sudo docker build -f ./test/end-to-end/Dockerfile --cache-from welder/web-e2e-tests:latest -t welder/web-e2e-tests:latest ./test/end-to-end/
 	sudo docker network inspect welder >/dev/null 2>&1 || sudo docker network create welder
-	wget --progress=dot:giga https://s3.amazonaws.com/weldr/metadata.db
 	sudo docker ps --quiet --all --filter 'ancestor=welder/bdcs-api-rs' | sudo xargs --no-run-if-empty docker rm -f
 	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest
 


### PR DESCRIPTION
Commit 147cf6e62 moved the metadata.db from a Makefile dependency to an
unconditional command in the `shared` target. As the latter is phony,
this leads to unnecessarily downloading the metadata for every test run.
Revert that bit.

CC: @henrywang, can you please review/land?