### PR TITLE
Drop obsolete eslint override

### DIFF
--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -2,7 +2,6 @@ import { call, put, takeEvery } from 'redux-saga/effects';
 import { fetchRecipeInputsApi } from '../apiCalls';
 import { FETCHING_INPUTS, fetchingInputsSucceeded } from '../actions/inputs';
 
-/* eslint require-yield: "warn" */ // FIXME: issue #151
 function updateInputComponentData(inputs, componentData) {
   let updatedInputs = inputs;
   if (componentData !== undefined && componentData.length > 0) {


### PR DESCRIPTION
The function `updateInputComponentData()` was fixed recently [1] to be
synchronous instead of async, so it is correct now and the eslint
error is gone. Drop the annotation to avoid confusion and regression.

[1] https://github.com/weldr/welder-web/commit/50630524afbc1c03eb06204a44240edceea45498#diff-9e47aee6cedcc9f80cf6432dc6e63aff

----

This is cleanup from #151.