### PR TITLE
Bind-mount .nyc_output/ to /tmp/.nyc_output inside docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ end-to-end-test: shared
 	sudo docker run -d --name web --restart=always -p 80:3000 --network welder welder/web-with-coverage:latest
 
 	sudo docker run --rm --name welder_end_to_end --network welder \
-	    -v `pwd`/.nyc_output/:/tmp \
+	    -v `pwd`/.nyc_output/:/tmp/.nyc_output \
 	    welder/web-e2e-tests:latest \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test -- --verbose
 	sudo docker ps --quiet --all --filter 'ancestor=welder/web-with-coverage' | sudo xargs --no-run-if-empty docker rm -f

--- a/test/end-to-end/Dockerfile
+++ b/test/end-to-end/Dockerfile
@@ -2,6 +2,9 @@
 FROM welder/web-nodejs:latest
 MAINTAINER Xiaofeng Wang <xiaofwan@redhat.com>
 
+# to avoid the JS code doing checks we create this here
+RUN mkdir -p /tmp/.nyc_output
+
 # Install xvfb to simulate framebuffer for nightmare.js
 # Install electorn dependency
 RUN dnf --setopt=deltarpm=0 --verbose install -y xorg-x11-server-Xvfb which libXScrnSaver \

--- a/test/end-to-end/utils/coverage.js
+++ b/test/end-to-end/utils/coverage.js
@@ -16,7 +16,7 @@ module.exports = {
         const hash = require('crypto').createHmac('sha256', '')
           .update(strCoverage)
           .digest('hex');
-        const fileName = `/tmp/coverage-${hash}.json`;
+        const fileName = `/tmp/.nyc_output/coverage-${hash}.json`;
         require('fs').writeFileSync(fileName, strCoverage);
 
         done();


### PR DESCRIPTION
this leaves a functional /tmp in the container and solves issues
with mktemp (called from xvfb-run), possibly triggered by SELinux