### PR TITLE
 Update layout of page-level actions on Edit Recipe page

### DIFF
--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -97,7 +97,7 @@ const Toolbar = props => (
 );
 
 Toolbar.propTypes = {
-  handleShowModal: PropTypes.func,
+  handleHistory: PropTypes.func,
 };
 
 export default Toolbar;

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -92,57 +92,6 @@ const Toolbar = props => (
         </button>
       }
       </div>
-      <div className="toolbar-pf-action-right">
-        <div className="form-group">
-          <button
-            className="btn btn-default"
-            id="cmpsr-btn-crt-compos"
-            data-toggle="modal"
-            data-target="#cmpsr-modal-crt-compos"
-            type="button"
-          >
-            Create Composition
-          </button>
-          <div className="dropdown btn-group  dropdown-kebab-pf">
-            <button
-              className="btn btn-link dropdown-toggle"
-              type="button"
-              id="dropdownKebab"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
-            >
-              <span className="fa fa-ellipsis-v" />
-            </button>
-            <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-              <li><a href="#" onClick={e => props.handleShowModal(e, 'modalExportRecipe')}>Export</a></li>
-              <li role="separator" className="divider" />
-              <li><a>Update Selected Components</a></li>
-              <li><a>Remove Selected Components</a></li>
-            </ul>
-          </div>
-        </div>
-        <div className="form-group toolbar-pf-find">
-          <button className="btn btn-link btn-find" type="button">
-            <span className="fa fa-search" />
-          </button>
-          <div className="find-pf-dropdown-container">
-            <input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
-            <div className="find-pf-buttons">
-              <span className="find-pf-nums">1 of 3</span>
-              <button className="btn btn-link" type="button">
-                <span className="fa fa-angle-up" />
-              </button>
-              <button className="btn btn-link" type="button">
-                <span className="fa fa-angle-down" />
-              </button>
-              <button className="btn btn-link btn-find-close" type="button">
-                <span className="pficon pficon-close" />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
     </form>
   </div>
 );

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -175,8 +175,7 @@ class RecipePage extends React.Component {
               </li>
               <li>
                 <button
-                  className="btn btn-default"
-                  id="cmpsr-btn-crt-compos"
+                  className={`btn btn-default ${components.length ? '' : 'disabled'}`}                  id="cmpsr-btn-crt-compos"
                   data-toggle="modal"
                   data-target="#cmpsr-modal-crt-compos"
                   type="button"
@@ -197,7 +196,11 @@ class RecipePage extends React.Component {
                     <span className="fa fa-ellipsis-v" />
                   </button>
                   <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                    <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
+                    {components.length &&
+                      <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
+                    ||
+                      <li className="disabled"><a>Export</a></li>
+                    }
                   </ul>
                 </div>
               </li>

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -464,35 +464,77 @@ class EditRecipePage extends React.Component {
             <li className="active"><strong>Edit Recipe</strong></li>
           </ol>
           <div className="cmpsr-header__actions">
-          {numPendingChanges > 0 &&
             <ul className="list-inline">
-            {numPendingChanges !== 1 &&
-              <li className="text-muted"> {numPendingChanges} changes</li>
-            ||
-              <li className="text-muted"> 1 change</li>
-            }
+              {numPendingChanges > 0 &&
               <li>
-                <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>View and Comment</a>
+                <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>
+                  {numPendingChanges !== 1 &&
+                    <span>{numPendingChanges} Pending Changes</span>
+                  ||
+                    <span>1 Pending Change</span>
+                  }
+                </a>
               </li>
-              <li>
-                <button className="btn btn-primary" type="button" onClick={this.handleSave}>Save</button>
-              </li>
-              <li>
-                <button className="btn btn-default" type="button" onClick={this.handleDiscardChanges}>
-                  Discard Changes
+              }
+              {numPendingChanges > 0 &&
+                <li>
+                  <button className="btn btn-primary" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>
+                    Save
+                  </button>
+                </li>
+              ||
+                <li>
+                  <button className="btn btn-primary disabled" type="button">Save</button>
+                </li>
+              }
+              {numPendingChanges > 0 &&
+                <li>
+                  <button className="btn btn-default" type="button" onClick={this.handleDiscardChanges}>
+                    Discard Changes
+                  </button>
+                </li>
+              ||
+                <li>
+                  <button className="btn btn-default disabled" type="button">
+                    Discard Changes
+                  </button>
+                </li>
+              }
+              <li className="list__subgroup-item--first">
+                <button
+                  className={`btn btn-default ${components.length ? '' : 'disabled'}`}
+                  id="cmpsr-btn-crt-compos"
+                  data-toggle="modal"
+                  data-target="#cmpsr-modal-crt-compos"
+                  type="button"
+                >
+                  Create Composition
                 </button>
               </li>
-            </ul>
-          ||
-            <ul className="list-inline">
               <li>
-                <button className="btn btn-primary disabled" type="button">Save</button>
-              </li>
-              <li>
-                <button className="btn btn-default disabled" type="button">Discard Changes</button>
+                <div className="dropdown dropdown-kebab-pf">
+                  <button
+                    className="btn btn-link dropdown-toggle"
+                    type="button"
+                    id="dropdownKebab"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
+                    <span className="fa fa-ellipsis-v" />
+                  </button>
+                  <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
+                    {components.length &&
+                      <li><a href="#" onClick={e => this.handleShowModal(e, 'modalExportRecipe')}>Export</a></li>
+                    ||
+                      <li className="disabled"><a>Export</a></li>
+                    }
+                  </ul>
+                </div>
               </li>
             </ul>
-          }
+
+
           </div>
           <div className="cmpsr-title">
             <h1 className="cmpsr-title__item">{recipeDisplayName}</h1>

--- a/pages/recipeEdit/index.js
+++ b/pages/recipeEdit/index.js
@@ -466,15 +466,15 @@ class EditRecipePage extends React.Component {
           <div className="cmpsr-header__actions">
             <ul className="list-inline">
               {numPendingChanges > 0 &&
-              <li>
-                <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>
-                  {numPendingChanges !== 1 &&
-                    <span>{numPendingChanges} Pending Changes</span>
-                  ||
-                    <span>1 Pending Change</span>
-                  }
-                </a>
-              </li>
+                <li>
+                  <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>
+                    {numPendingChanges !== 1 &&
+                      <span>{numPendingChanges} Pending Changes</span>
+                    ||
+                      <span>1 Pending Change</span>
+                    }
+                  </a>
+                </li>
               }
               {numPendingChanges > 0 &&
                 <li>

--- a/public/custom.css
+++ b/public/custom.css
@@ -141,6 +141,11 @@ textarea.form-control[readonly] {
 .cmpsr-header__actions .list-inline > li:first-child {
   padding-left: 0;
 }
+.list-inline .list__subgroup-item--first {
+  border-left: 1px solid #e5e5e5;
+  padding-left: 10px;
+  margin-left: 5px;
+}
 .cmpsr-title {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -355,3 +360,9 @@ textarea.form-control[readonly] {
  .nav-tabs .badge {
    display: inline;
  }
+
+/* disabled state */
+/* disable pointer events for both <a> and <button> */
+.btn.disabled, fieldset[disabled] .btn {
+    pointer-events: none;
+}

--- a/test/end-to-end/pages/changesPendingSave.js
+++ b/test/end-to-end/pages/changesPendingSave.js
@@ -1,0 +1,45 @@
+// Changes Pending Save page object
+const MainPage = require('./main');
+
+module.exports = class changesPendingSave extends MainPage {
+  constructor() {
+    super('Changes Pending Save');
+
+// ---- Root element selector ---- //
+    // Root Element for this Dialog Page
+    this.rootElement = 'div[id="cmpsr-modal-pending-changes"] .modal-dialog .modal-content';
+
+    // Header
+    this.headerElement = `${this.rootElement} .modal-header`;
+
+    // Body
+    this.bodyElement = `${this.rootElement} .modal-body`;
+
+    // Footer
+    this.footerElement = `${this.rootElement} .modal-footer`;
+
+// ---- Page element selector ---- //
+    // Page Title
+    this.varPageTitle = 'Changes Pending Save';
+    this.labelPageTitle = `${this.headerElement} h4[class="modal-title"]`;
+
+    // X Close Button
+    this.btnXClose = `${this.headerElement} span[class="pficon pficon-close"]`;
+
+    // Recipe Name label
+    this.labelRecipeName = `${this.bodyElement} p[class="form-control-static"]`;
+
+    // Comment text area
+    this.textAreaComment = `${this.bodyElement} textarea[id="textInput2-modal-markup"]`;
+
+    // Pending changes action
+    this.labelPendingChangesAction = `${this.bodyElement} ul li div div[class="col-sm-3"]`;
+
+    // Pending changes component
+    this.labelPendingChangesComponent = `${this.bodyElement} ul li div div strong`;
+
+    // Save and Close button
+    this.btnSave = `${this.footerElement} button[class="btn btn-primary"]`;
+    this.btnClose = `${this.footerElement} button[class="btn btn-default" data-dismiss="modal"]`;
+  }
+};

--- a/test/end-to-end/pages/editRecipe.js
+++ b/test/end-to-end/pages/editRecipe.js
@@ -19,9 +19,6 @@ module.exports = class EditRecipePage extends MainPage {
     // Recipe inputs root element
     this.recipeInputRootElement = '.cmpsr-panel__body--sidebar';
 
-    // Recipe list edit root element
-    this.recipeListEditRootElement = '.cmpsr-panel__body--main';
-
     // Component list item root element
     this.componentListItemRootElement = `${this.recipeInputRootElement} .cmpsr-list-pf__compacted .list-pf-item`;
 // ---- Page element selector ---- //
@@ -41,13 +38,13 @@ module.exports = class EditRecipePage extends MainPage {
 
     // Create Composition button
     this.varCreateCompos = 'Create Composition';
-    this.btnCreateCompos = `${this.recipeListEditRootElement} button[data-target="#cmpsr-modal-crt-compos"]`;
+    this.btnCreateCompos = `${this.editActionBarRootElement} button[data-target="#cmpsr-modal-crt-compos"]`;
 
     // More action button
-    this.btnMore = `${this.recipeListEditRootElement} button[id="dropdownKebab"]`;
+    this.btnMore = `${this.editActionBarRootElement} button[id="dropdownKebab"]`;
 
     // Export action
-    this.menuActionExport = `${this.recipeListEditRootElement} ul[aria-labelledby="dropdownKebab"] li:nth-child(1) a`;
+    this.menuActionExport = `${this.editActionBarRootElement} ul[aria-labelledby="dropdownKebab"] li:nth-child(1) a`;
 
     // Save button
     this.btnSave = `${this.editActionBarRootElement} ul li button[class="btn btn-primary"]`;

--- a/test/end-to-end/pages/viewRecipe.js
+++ b/test/end-to-end/pages/viewRecipe.js
@@ -71,7 +71,6 @@ module.exports = class ViewRecipePage extends MainPage {
     // Selected Components content
     this.contentSelectedComponents = `${this.componentsContentRootElement} pf-tabs pf-tab
                                       div[class="list-pf cmpsr-list-pf list-pf-stacked cmpsr-recipe__components"]`;
-   }
   }
 
   get url() {

--- a/test/end-to-end/pages/viewRecipe.js
+++ b/test/end-to-end/pages/viewRecipe.js
@@ -19,14 +19,14 @@ module.exports = class ViewRecipePage extends MainPage {
     // Tab list root element
     this.tabListRootElement = `${this.tabRootElement} ul[role="tablist"]`;
 
-    // Detail tab page root element
-    this.detailTabRootElement = `${this.tabRootElement} pf-tab[tabtitle="Details"]`;
+    // Details tab content root element
+    this.detailsContentRootElement = `${this.tabRootElement} pf-tab[tabtitle="Details"]`;
 
-    // Components tab page root element
-    this.componentsTabRootElement = `${this.tabRootElement} pf-tab[tabtitle="Components"]`;
+    // Components tab content root element
+    this.componentsContentRootElement = `${this.tabRootElement} pf-tab[tabtitle="Components"]`;
 
-    // Compositions tab page root element
-    this.compositionsTabRootElement = `${this.tabRootElement} pf-tab[tabtitle="Compositions"]`;
+    // Compositions tab content root element
+    this.compositionsContentRootElement = `${this.tabRootElement} pf-tab[tabtitle="Compositions"]`;
 
 // ---- Page element selector ---- //
     // Nav-bar: Recipe Name label
@@ -52,6 +52,26 @@ module.exports = class ViewRecipePage extends MainPage {
     this.toolBarMoreActionList = {
       Export: 'Export',
     };
+
+    // Detail tab element
+    this.detailTabElement = `${this.tabListRootElement} li:nth-child(1) a`;
+
+    // Components tab page element
+    this.componentsTabElement = `${this.tabListRootElement} li:nth-child(2) a`;
+
+    // Compositions tab page element
+    this.compositionsTabElement = `${this.tabListRootElement} li:nth-child(3) a`;
+
+    // Selected Components tab under Components tab
+    this.tabSelectedComponents = `${this.componentsContentRootElement} pf-tabs ul[role="tablist"] li:nth-child(1) a`;
+
+    // Dependencies tab under Components tab
+    this.tabDependencies = `${this.componentsContentRootElement} pf-tabs ul[role="tablist"] li:nth-child(2) a`;
+
+    // Selected Components content
+    this.contentSelectedComponents = `${this.componentsContentRootElement} pf-tabs pf-tab
+                                      div[class="list-pf cmpsr-list-pf list-pf-stacked cmpsr-recipe__components"]`;
+   }
   }
 
   get url() {

--- a/test/end-to-end/test/test_editRecipe.js
+++ b/test/end-to-end/test/test_editRecipe.js
@@ -4,6 +4,7 @@ const EditRecipePage = require('../pages/editRecipe');
 const CreateComposPage = require('../pages/createCompos');
 const ToastNotifPage = require('../pages/toastNotif');
 const ExportRecipePage = require('../pages/exportRecipe');
+const ChangesPendingSavePage = require('../pages/changesPendingSave');
 const apiCall = require('../utils/apiCall');
 const helper = require('../utils/helper');
 const pageConfig = require('../config');
@@ -13,7 +14,7 @@ const coverage = require('../utils/coverage.js').coverage;
 describe('Edit Recipe Page', () => {
   let nightmare;
   // Set case running timeout
-  const timeout = 15000;
+  const timeout = 75000;
 
   // Check BDCS API and Web service first
   beforeAll(apiCall.serviceCheck);
@@ -318,6 +319,7 @@ describe('Edit Recipe Page', () => {
     describe('Save Recipe Test #acceptance', () => {
       test('should have toast notification pop up when Save button clicked @edit-recipe-page', (done) => {
         const toastNotifPage = new ToastNotifPage(pageConfig.recipe.simple.name);
+        const changesPendingSavePage = new ChangesPendingSavePage();
 
         // Highlight the expected result
         const expected = toastNotifPage.varStatusSaved;
@@ -328,6 +330,8 @@ describe('Edit Recipe Page', () => {
           .click(editRecipePage.componentListItemRootElementSelect)
           .wait(editRecipePage.btnSave)
           .click(editRecipePage.btnSave)
+          .wait(changesPendingSavePage.btnSave)
+          .click(changesPendingSavePage.btnSave)
           .wait(toastNotifPage.iconCreating)
           .wait((page) => {
             const recipeName = document.querySelector(page.labelRecipeName).innerText;

--- a/test/end-to-end/test/test_editRecipe.js
+++ b/test/end-to-end/test/test_editRecipe.js
@@ -14,7 +14,7 @@ const coverage = require('../utils/coverage.js').coverage;
 describe('Edit Recipe Page', () => {
   let nightmare;
   // Set case running timeout
-  const timeout = 75000;
+  const timeout = 15000;
 
   // Check BDCS API and Web service first
   beforeAll(apiCall.serviceCheck);

--- a/test/end-to-end/test/test_viewRecipe.js
+++ b/test/end-to-end/test/test_viewRecipe.js
@@ -178,6 +178,11 @@ describe('View Recipe Page', () => {
         const expected = exportRecipePage.varExportTitle;
 
         nightmare
+          .wait(viewRecipePage.componentsTabElement)
+          .click(viewRecipePage.componentsTabElement)
+          .wait(viewRecipePage.tabSelectedComponents)
+          .click(viewRecipePage.tabSelectedComponents)
+          .wait(viewRecipePage.contentSelectedComponents)
           .wait(btnMoreAction)
           .click(btnMoreAction)
           .wait(menuActionExport)
@@ -208,6 +213,11 @@ describe('View Recipe Page', () => {
           const expectedContent = [...depCompSet].sort().join('\n');
 
           nightmare
+            .wait(viewRecipePage.componentsTabElement)
+            .click(viewRecipePage.componentsTabElement)
+            .wait(viewRecipePage.tabSelectedComponents)
+            .click(viewRecipePage.tabSelectedComponents)
+            .wait(viewRecipePage.contentSelectedComponents)
             .wait(btnMoreAction)
             .click(btnMoreAction)
             .wait(menuActionExport)
@@ -240,6 +250,11 @@ describe('View Recipe Page', () => {
         let expected = '';
 
         nightmare
+          .wait(viewRecipePage.componentsTabElement)
+          .click(viewRecipePage.componentsTabElement)
+          .wait(viewRecipePage.tabSelectedComponents)
+          .click(viewRecipePage.tabSelectedComponents)
+          .wait(viewRecipePage.contentSelectedComponents)
           .wait(btnMoreAction)
           .click(btnMoreAction)
           .wait(menuActionExport)


### PR DESCRIPTION
Updates include:

- Remove Create Composition and Export actions from toolbar and move to top of page, next to Save and Discard.
- Remove non-functional non-mvp actions from toolbar.
- Relabel the link that opens the Pending Changes modal.
- Update Save button to also open the Pending Changes modal.
- Set disable state for page-level actions where needed.

Note: Additional changes are needed that were not made in this PR. The label "Save" should change to "Commit" wherever it is used (i.e. page-level actions, toast notifications, Pending Changes modal), but these changes will be made later when other updates to the Pending Changes modal are completed. 