### PR TITLE
Import minimal metadata.db instead of downloading it

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,0 +1,7 @@
+FROM fedora:26
+MAINTAINER Alexander Todorov <atodorov@redhat.com>
+
+RUN dnf -y install sqlite ostree sudo gobject-introspection
+
+COPY ./import-metadata.sh /tmp/
+CMD ["/tmp/import-metadata.sh"]

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ unit-test:
 	npm run test:cov
 
 metadata.db:
-	wget --progress=dot:giga https://s3.amazonaws.com/weldr/metadata.db
+	sudo docker build -f Dockerfile.metadata -t welder/import-metadata .
+	sudo docker run --name import-metadata welder/import-metadata:latest
+	sudo docker cp import-metadata:/metadata.db .
+	sudo docker rm import-metadata
 
 shared: metadata.db
 	if [ -n "$$TRAVIS" ]; then \

--- a/import-metadata.sh
+++ b/import-metadata.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+# NOTE: execute from the root directory of the project
+
+# create the MDDB database if it doesn't exist
+# ARG1 - OPTIONAL - a content store directory for exports
+
+IMPORT="./bdcs-import"
+SCHEMA="./schema.sql"
+METADATA="metadata.db"
+DNF="/usr/bin/dnf"
+
+[ -f "$DNF" ] || DNF="/usr/bin/yum"
+
+if [ -z "$1" ]; then
+    IMPORT_REPO=`mktemp -d /tmp/bdcs-import.repo.XXXXXX`
+    REMOVE_IMPORT_REPO=1
+else
+    IMPORT_REPO="$1"
+    REMOVE_IMPORT_REPO=0
+fi
+
+[ -f "$IMPORT" ] || curl -o "$IMPORT" https://s3.amazonaws.com/weldr/bdcs-import && chmod a+x "$IMPORT"
+[ -f "$SCHEMA" ] || curl -o "$SCHEMA" https://raw.githubusercontent.com/weldr/bdcs/master/schema.sql
+sqlite3 "$METADATA" < "$SCHEMA"
+
+DNF_ROOT=`mktemp -d /tmp/dnf.root.XXXXXX`
+DNF_DOWNLOAD=`mktemp -d /tmp/dnf.download.XXXXXX`
+
+# download all the RPMs
+sudo $DNF install -y --nogpgcheck --releasever=26 \
+                 --downloadonly --downloaddir=$DNF_DOWNLOAD \
+                 --installroot=$DNF_ROOT httpd
+
+# then import all RPMs
+for F in $DNF_DOWNLOAD/*.rpm; do
+    $IMPORT $METADATA $IMPORT_REPO file://$F
+done
+
+# cleanup temporary directories and files
+sudo rm -rf $DNF_ROOT $DNF_DOWNLOAD $IMPORT $SCHEMA
+[ "$REMOVE_IMPORT_REPO" == 1 ] && rm -rf $IMPORT_REPO


### PR DESCRIPTION
we want to get rid of the humongous CentOS 7 metadata.db and use
a small file for testing. Here metadata.db isn't really used for
anything and is only a requirement so we can run the api
container.