### PR TITLE
Load Pending Changes from Workspace

### DIFF
--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -133,7 +133,7 @@ class PendingChanges extends React.Component {
                     } {this.props.recipe.workspacePendingChanges.deletedChanges.length !== 0 &&
                       <li className="list-group-item">
                         <div className="row">
-                          <div className="col-sm-3">Deleted</div>
+                          <div className="col-sm-3">Removed</div>
                           <div className="col-sm-9">
                             <ul className="list-unstyled">
                               {this.props.recipe.workspacePendingChanges.deletedChanges.map((componentUpdated, index) => (

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -88,7 +88,7 @@ class PendingChanges extends React.Component {
                 </div>
                 <strong>Pending Changes</strong><span className="text-muted"> (most recent first)</span>
                 <ul className="list-group">
-                  {this.props.recipe.pendingChanges.map((componentUpdated, index) => (
+                  {this.props.recipe.localPendingChanges.map((componentUpdated, index) => (
                     <li className="list-group-item" key={index}>
                       {componentUpdated.componentNew && componentUpdated.componentOld &&
                         <div className="row">
@@ -110,6 +110,45 @@ class PendingChanges extends React.Component {
                     </li>
                   ))}
                 </ul>
+                {(this.props.recipe.workspacePendingChanges.addedChanges.length !== 0 ||
+                 this.props.recipe.workspacePendingChanges.deletedChanges.length !== 0) &&
+                  <div>
+                    <strong>Changes made in a previous session (i)</strong>
+                    <ul className="list-group">
+                    {this.props.recipe.workspacePendingChanges.addedChanges.length !== 0 &&
+                      <li className="list-group-item">
+                        <div className="row">
+                          <div className="col-sm-3">Added</div>
+                          <div className="col-sm-9">
+                            <ul className="list-unstyled">
+                              {this.props.recipe.workspacePendingChanges.addedChanges.map((componentUpdated, index) => (
+                                <li key={index}>
+                                  <strong>{componentUpdated.new.Package.name}-{componentUpdated.new.Package.version}</strong>
+                                </li>
+                                ))}
+                            </ul>
+                          </div>
+                        </div>
+                      </li>
+                    } {this.props.recipe.workspacePendingChanges.deletedChanges.length !== 0 &&
+                      <li className="list-group-item">
+                        <div className="row">
+                          <div className="col-sm-3">Deleted</div>
+                          <div className="col-sm-9">
+                            <ul className="list-unstyled">
+                              {this.props.recipe.workspacePendingChanges.deletedChanges.map((componentUpdated, index) => (
+                                <li key={index}>
+                                  <strong>{componentUpdated.old.Package.name}-{componentUpdated.old.Package.version}</strong>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        </div>
+                      </li>
+                    }
+                    </ul>
+                  </div>
+                }
               </form>
             </div>
             <div className="modal-footer">

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -75,7 +75,6 @@ const Toolbar = props => (
         <button
           className="btn btn-link disabled"
           type="button"
-          onClick={() => {props.undo(props.recipeId); props.handleHistory();}}
         >
           <span className="fa fa-undo" aria-hidden="true" />
         </button>
@@ -88,7 +87,6 @@ const Toolbar = props => (
         <button
           className="btn btn-link disabled"
           type="button"
-          onClick={() => {props.redo(props.recipeId); props.handleHistory();}}
         >
           <span className="fa fa-repeat" aria-hidden="true" />
         </button>

--- a/core/actions/recipes.js
+++ b/core/actions/recipes.js
@@ -1,11 +1,3 @@
-export const FETCHING_RECIPE = 'FETCHING_RECIPE';
-export const fetchingRecipe = (recipeId) => ({
-  type: FETCHING_RECIPE,
-  payload: {
-    recipeId,
-  },
-});
-
 export const CREATING_RECIPE = 'CREATING_RECIPE';
 export const creatingRecipe = (events, recipe) => ({
   type: CREATING_RECIPE,
@@ -23,24 +15,17 @@ export const creatingRecipeSucceeded = (recipe) => ({
   },
 });
 
-export const FETCHING_RECIPE_SUCCEEDED = 'FETCHING_RECIPE_SUCCEEDED';
-export const fetchingRecipeSucceeded = (recipe) => ({
-  type: FETCHING_RECIPE_SUCCEEDED,
-  payload: {
-    recipe,
-  },
-});
-
 export const FETCHING_RECIPES = 'FETCHING_RECIPES';
 export const fetchingRecipes = () => ({
   type: FETCHING_RECIPES,
 });
 
 export const FETCHING_RECIPES_SUCCEEDED = 'FETCHING_RECIPES_SUCCEEDED';
-export const fetchingRecipesSucceeded = (recipe) => ({
+export const fetchingRecipesSucceeded = (recipe, pendingChanges) => ({
   type: FETCHING_RECIPES_SUCCEEDED,
   payload: {
     recipe,
+    pendingChanges,
   },
 });
 
@@ -53,10 +38,12 @@ export const fetchingRecipeContents = (recipeId) => ({
 });
 
 export const FETCHING_RECIPE_CONTENTS_SUCCEEDED = 'FETCHING_RECIPE_CONTENTS_SUCCEEDED';
-export const fetchingRecipeContentsSucceeded = (recipe) => ({
+export const fetchingRecipeContentsSucceeded = (recipePast, recipePresent, pendingChanges) => ({
   type: FETCHING_RECIPE_CONTENTS_SUCCEEDED,
   payload: {
-    recipe,
+    recipePast,
+    recipePresent,
+    pendingChanges,
   },
 });
 
@@ -74,15 +61,6 @@ export const setRecipeDescription = (recipe, description) => ({
   payload: {
     recipe,
     description,
-  },
-});
-
-export const ADD_RECIPE_COMPONENT = 'ADD_RECIPE_COMPONENT';
-export const addRecipeComponent = (recipe, component) => ({
-  type: ADD_RECIPE_COMPONENT,
-  payload: {
-    recipe,
-    component,
   },
 });
 
@@ -152,6 +130,22 @@ export const undo = (recipeId) => ({
 export const REDO = 'REDO';
 export const redo = (recipeId) => ({
   type: REDO,
+  payload: {
+    recipeId,
+  },
+});
+
+export const DELETE_HISTORY = 'DELETE_HISTORY';
+export const deleteHistory = (recipeId) => ({
+  type: DELETE_HISTORY,
+  payload: {
+    recipeId,
+  },
+});
+
+export const SAVE_TO_WORKSPACE = 'SAVE_TO_WORKSPACE';
+export const saveToWorkspace = (recipeId) => ({
+  type: SAVE_TO_WORKSPACE,
   payload: {
     recipeId,
   },

--- a/core/actions/recipes.js
+++ b/core/actions/recipes.js
@@ -75,12 +75,13 @@ export const removeRecipeComponent = (recipe, component, pendingChange) => ({
 });
 
 export const SET_RECIPE_COMPONENTS = 'SET_RECIPE_COMPONENTS';
-export const setRecipeComponents = (recipe, components, dependencies, pendingChange) => ({
+export const setRecipeComponents = (recipe, components, dependencies, packages, pendingChange) => ({
   type: SET_RECIPE_COMPONENTS,
   payload: {
     recipe,
     components,
     dependencies,
+    packages,
     pendingChange,
   },
 });

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -18,6 +18,16 @@ export function fetchRecipeContentsApi(recipeName) {
   return recipeContents;
 }
 
+export function fetchWorkspaceRecipeContentsApi(recipeRaw) {
+  const recipeContents = Promise.all([RecipeApi.getRecipeWorkspace(recipeRaw)])
+    .then(data => {
+      const recipe = data[0];
+      return recipe;
+    })
+    .catch(err => console.log(`Error in fetchModalRecipeContents promise: ${err}`));
+  return recipeContents;
+}
+
 export function fetchRecipeInputsApi(filter, selectedInputPage, pageSize) {
   const page = selectedInputPage * pageSize;
   const p = new Promise((resolve, reject) => {
@@ -54,7 +64,7 @@ export function fetchRecipeInfoApi(recipeName) {
   const recipeFetch = utils.apiFetch(constants.get_recipes_info + recipeName)
     .then(recipedata => {
       if (recipedata.recipes.length > 0) {
-        const recipe = recipedata.recipes[0];
+        let recipe = recipedata.recipes[0];
         recipe.id = recipeName;
         return recipe;
       }
@@ -78,4 +88,28 @@ export function deleteRecipeApi(recipe) {
   const deletedRecipe = Promise.all([RecipeApi.deleteRecipe(recipe)])
     .then(() => recipe);
   return deletedRecipe;
+}
+
+export function saveToWorkspaceApi(recipe) {
+  return utils.apiFetch(constants.post_recipes_workspace, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(recipe),
+  }, true);
+}
+
+export function fetchDiffWorkspaceApi(recipeId) {
+  const p = new Promise((resolve, reject) => {
+    utils.apiFetch('/api/v0/recipes/diff/' + recipeId + '/NEWEST/WORKSPACE')
+    .then(data => {
+      resolve(data);
+    })
+    .catch(e => {
+      console.log(`Error fetching diff: ${e}`);
+      reject();
+    });
+  });
+  return p;
 }

--- a/core/constants.js
+++ b/core/constants.js
@@ -9,9 +9,11 @@ const constants = {
   get_recipes_deps: '/api/v0/recipes/depsolve/',
   get_modules_list: '/api/v0/modules/list',
   get_projects_info: '/api/v0/projects/info/',
+  get_projects_deps: '/api/v0/projects/depsolve/',
   get_modules_info: '/api/v0/modules/info/',
   get_compose_types: '/api/v0/compose/types',
   post_recipes_new: '/api/v0/recipes/new',
+  post_recipes_workspace: '/api/v0/recipes/workspace',
   delete_recipe: '/api/v0/recipes/delete/',
 
 };

--- a/core/reducers/recipes.js
+++ b/core/reducers/recipes.js
@@ -38,7 +38,10 @@ const recipes = (state = [], action) => {
       return [
         ...state.filter(recipe => recipe.present.id !== action.payload.recipe.id), {
           past: [],
-          present: Object.assign({}, action.payload.recipe, { localPendingChanges: [], workspacePendingChanges: [] }),
+          present: Object.assign({}, action.payload.recipe,  {
+            localPendingChanges: [],
+            workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+          }),
           future: [],
         }
       ];
@@ -49,7 +52,10 @@ const recipes = (state = [], action) => {
       || !state.some(recipe => recipe.present.id === action.payload.recipe.id)
       ? [...state.filter(recipe => recipe.present.id !== action.payload.recipe.id), {
           past: [],
-          present: Object.assign({}, action.payload.recipe, { localPendingChanges: [], workspacePendingChanges: [] }),
+          present: Object.assign({}, action.payload.recipe, {
+            localPendingChanges: [],
+            workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+          }),
           future: [],
         }]
       : state;
@@ -68,7 +74,10 @@ const recipes = (state = [], action) => {
             return Object.assign(
               {}, recipe, {
               past: [],
-              present: Object.assign({}, action.payload.recipe, { localPendingChanges: [], workspacePendingChanges: [] }),
+              present: Object.assign({}, action.payload.recipe, {
+                localPendingChanges: [],
+                workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+              }),
               future: [],
             });
           }
@@ -85,6 +94,7 @@ const recipes = (state = [], action) => {
               present: Object.assign({}, recipe.present, {
                 components: action.payload.components,
                 dependencies: action.payload.dependencies,
+                packages: action.payload.packages,
                 localPendingChanges: recipe.present.localPendingChanges.some((component) => {
                   return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
                   || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
@@ -157,7 +167,10 @@ const recipes = (state = [], action) => {
           if (recipe.present.id === action.payload.recipeId) {
             return Object.assign(
               {}, recipe, {
-              present: Object.assign({}, recipe.past.shift(), { localPendingChanges: [], workspacePendingChanges: [] }),
+              present: Object.assign({}, recipe.past.shift(),  {
+                localPendingChanges: [],
+                workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+              }),
               past: [],
               future: [],
             });

--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -1,6 +1,10 @@
-import { call, put, takeEvery } from 'redux-saga/effects';
+import { take, call, put, takeEvery } from 'redux-saga/effects';
 import { fetchRecipeInputsApi } from '../apiCalls';
 import { FETCHING_INPUTS, fetchingInputsSucceeded } from '../actions/inputs';
+import {
+  FETCHING_RECIPE_CONTENTS_SUCCEEDED,
+} from '../actions/recipes';
+
 
 function updateInputComponentData(inputs, componentData) {
   let updatedInputs = inputs;
@@ -23,8 +27,14 @@ function updateInputComponentData(inputs, componentData) {
 function* fetchInputs(action) {
   try {
     const { filter, selectedInputPage, pageSize, componentData } = action.payload;
+    let components = componentData;
+    if (componentData === undefined) {
+      const recipeResponse = yield take(FETCHING_RECIPE_CONTENTS_SUCCEEDED);
+      const { recipePresent } = recipeResponse.payload;
+      components = recipePresent.components;
+    }
     const response = yield call(fetchRecipeInputsApi, `/*${filter.value}*`, selectedInputPage, pageSize);
-    const updatedResponse = yield call(updateInputComponentData, response, componentData);
+    const updatedResponse = yield call(updateInputComponentData, response, components);
     yield put(fetchingInputsSucceeded(filter, selectedInputPage, pageSize, updatedResponse));
   } catch (error) {
     console.log('Error in fetchInputsSaga');

--- a/core/sagas/recipes.js
+++ b/core/sagas/recipes.js
@@ -51,7 +51,7 @@ function* fetchRecipeContents(action) {
       const workspaceRecipe = yield call(fetchRecipeInfoApi, recipeId);
       const workspaceDepsolved = yield call(fetchWorkspaceRecipeContentsApi, workspaceRecipe);
       recipePast = [Object.assign(
-        {}, recipeResponse, { localPendingChanges: [], workspacePendingChanges: [] }
+        {}, recipeResponse, { localPendingChanges: [], workspacePendingChanges: {addedChanges: [], deletedChanges: []} }
       )];
       recipePresent = Object.assign(
         {}, workspaceDepsolved, { localPendingChanges: [], workspacePendingChanges: workspacePendingChanges }

--- a/data/RecipeApi.js
+++ b/data/RecipeApi.js
@@ -75,49 +75,29 @@ class RecipeApi {
     const p = new Promise((resolve, reject) => {
       const recipe = recipeRaw;
       const componentNames = recipeRaw.packages.map(item => item.name);
-      // utils.apiFetch(constants.get_projects_deps + packageNames)
       if (componentNames.length > 0) {
         utils.apiFetch(constants.get_projects_info + componentNames)
-          .then(data => {
+          .then(compData => {
             // bdcs-api v0.3.0 includes module (component) and dependency NEVRAs
             // tagging all dependencies a "RPM" for now
-            const dependencies = data.projects ?
-                this.makeRecipeDependencies(data.projects, 'RPM') :
-                [];
-            let components = data.projects;
+            let components = compData.projects;
             components = this.setType(components, recipeRaw.modules, 'Module');
-            components = this.setType(components, data.projects, 'RPM');
-            components.map(i => {
-              i.inRecipe = true; // eslint-disable-line no-param-reassign
-              i.user_selected = true; // eslint-disable-line no-param-reassign
-              return i;
+            components = this.setType(components, compData.projects, 'RPM');
+            components.map(component => {
+              component.inRecipe = true; // eslint-disable-line no-param-reassign
+              component.user_selected = true; // eslint-disable-line no-param-reassign
+              component.version = component.builds[0].source.version; // eslint-disable-line no-param-reassign
+              component.release = component.builds[0].release; // eslint-disable-line no-param-reassign
             });
-            // Tag objects as Module if modules and RPM if packages, for now
-            if (dependencies.length === 0) {
-                // get metadata for the components only
-              Promise.all([
-                MetadataApi.getData(constants.get_projects_info + componentNames),
-              ]).then((compData) => {
-                recipe.components = MetadataApi.updateComponentMetadata(components, compData[0]);
-                recipe.dependencies = [];
-                this.recipe = recipe;
-                resolve(recipe);
-              }).catch(e => console.log(`getRecipe: Error getting component metadata: ${e}`));
-            } else {
-                // get metadata for the components
-                // get metadata for the dependencies
-                // get dependencies for dependencies
-              const dependencyNames = MetadataApi.getNames(dependencies);
-              Promise.all([
-                MetadataApi.getData(constants.get_projects_info + componentNames),
-                MetadataApi.getData(constants.get_projects_info + dependencyNames),
-              ]).then((compData) => {
-                recipe.components = MetadataApi.updateComponentMetadata(components, compData[0]);
-                recipe.dependencies = MetadataApi.updateComponentMetadata(dependencies, compData[1]);
+            utils.apiFetch(constants.get_projects_deps + componentNames)
+              .then(depData => {
+                let dependencies = depData.projects;
+                dependencies = this.setType(dependencies, depData.projects, 'RPM');
+                recipe.components = components
+                recipe.dependencies = dependencies;
                 this.recipe = recipe;
                 resolve(recipe);
               }).catch(e => console.log(`getRecipe: Error getting component and dependency metadata: ${e}`));
-            }
           })
           .catch(e => {
             console.log('catch');

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -96,10 +96,6 @@ class RecipePage extends React.Component {
     this.props.setEditDescriptionVisible(false);
     this.props.setModalExportRecipeVisible(false);
   }
-  // Get the recipe details, and its dependencies
-  // Object layout is:
-  // {recipes: [{recipe: RECIPE, modules: MODULES}, ...]}
-  // Where MODULES is a modules/info/ object {name: "", projects: [{...
 
   componentDidMount() {
     document.title = 'Recipe';

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -90,7 +90,7 @@ class RecipePage extends React.Component {
   }
 
   componentWillMount() {
-    if (this.props.rehydrated) {
+    if (this.props.rehydrated && this.props.recipe.components === undefined) {
       this.props.fetchingRecipeContents(this.props.route.params.recipe.replace(/\s/g, '-'));
     }
     this.props.setEditDescriptionVisible(false);

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -6,7 +6,7 @@ import CreateRecipe from '../../components/Modal/CreateRecipe';
 import ExportRecipe from '../../components/Modal/ExportRecipe';
 import EmptyState from '../../components/EmptyState/EmptyState';
 import { connect } from 'react-redux';
-import { fetchingRecipes, deletingRecipe } from '../../core/actions/recipes';
+import { deletingRecipe } from '../../core/actions/recipes';
 import {
   setModalExportRecipeName, setModalExportRecipeContents, setModalExportRecipeVisible, fetchingModalExportRecipeContents,
 } from '../../core/actions/modals';
@@ -167,7 +167,6 @@ class RecipesPage extends React.Component {
 }
 
 RecipesPage.propTypes = {
-  fetchingRecipes: PropTypes.func,
   deletingRecipe: PropTypes.func,
   setModalExportRecipeVisible: PropTypes.func,
   setModalExportRecipeName: PropTypes.func,
@@ -210,9 +209,6 @@ const makeMapStateToProps = () => {
 const mapDispatchToProps = dispatch => ({
   fetchingModalExportRecipeContents: modalRecipeName => {
     dispatch(fetchingModalExportRecipeContents(modalRecipeName));
-  },
-  fetchingRecipes: () => {
-    dispatch(fetchingRecipes());
   },
   setModalExportRecipeName: modalRecipeName => {
     dispatch(setModalExportRecipeName(modalRecipeName));


### PR DESCRIPTION
A user should now be able to view a list of pending changes with those from the current session listed in the order they were made (newest first) and the unsaved updates from prior sessions shown separately. The user can discard these pending changes and can undo/redo both local and workspace changes. This PR does not include the discard changes modal, the pending changes modal info tooltip, nor an alert when undoing workspace changes. Also, when loading components from the workspace the only dependencies loaded are the components themselves.