### PR TITLE
Prepare for automatic releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# generate version number from the latest git tag; if the topmost commit is
+# tagged (at release time), just use that; if there are commits after that,
+# append a ".x" suffix to indicate that's a development snapshot
+# if there is no tag (yet), use 0 as version
+RELEASEVER=$(shell (git describe --exclude '*jenkins*' || echo 0) | sed 's/-[0-9]\+-g.*/.x/')
+
 all:
 	NODE_ENV=$(NODE_ENV) npm run build
 
@@ -15,13 +21,14 @@ dist-gzip: all
 	# remove evil file name that breaks rpmbuild (https://github.com/patternfly/patternfly/issues/917)
 	find _install -name 'Logo_Horizontal_Reversed.svg alias' -delete
 	cp welder-web.spec _install/
-	tar -C _install/ -czf welder-web.tar.gz .
+	tar -C _install/ -czf welder-web-$(RELEASEVER).tar.gz .
 	rm -rf _install
 
 srpm: dist-gzip
 	rpmbuild -bs \
 	  --define "_sourcedir `pwd`" \
 	  --define "_srcrpmdir `pwd`" \
+	  --define "releasever $(RELEASEVER)" \
 	  welder-web.spec
 
 rpm: dist-gzip
@@ -34,6 +41,7 @@ rpm: dist-gzip
 	  --define "_srcrpmdir `pwd`" \
 	  --define "_rpmdir `pwd`/output" \
 	  --define "_buildrootdir `pwd`/build" \
+	  --define "releasever $(RELEASEVER)" \
 	  welder-web.spec
 	find `pwd`/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
 	rm -r "`pwd`/rpmbuild"
@@ -100,9 +108,9 @@ cockpit-test: shared build-rpm
 
 	sudo docker run -d --name web --restart=always -p 9090:9090 --network welder welder/web-cockpit:latest
 
-# Clean generated intermidiate tar file and useless RPM file
+# Clean generated intermediate tar file and useless RPM file
 # RPM file is inside docker image already
-	rm -f welder-web*.rpm welder-web.tar.gz
+	rm -f welder-web*.rpm welder-web*.tar.gz
 
 	sudo docker run --rm --name welder_end_to_end --network welder \
 	    -e COCKPIT_TEST=1 \

--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -1,0 +1,25 @@
+# This is a script run to release welder-web through Cockpituous:
+# https://github.com/cockpit-project/cockpituous
+
+# Anything that start with 'job' may run in a way that it SIGSTOP's
+# itself when preliminary preparition and then gets a SIGCONT in
+# order to complete its work
+
+RELEASE_SOURCE="_release/source"
+RELEASE_SPEC="welder-web.spec"
+RELEASE_SRPM="_release/srpm"
+
+release_source() {
+# cockpituous' release-source is aimed at ./autogen.sh/autotools style
+# projects, so just build our own here
+    npm prune
+    npm install
+    make dist-gzip
+    mkdir -p "$RELEASE_SOURCE"
+    # this script gets sourced, normal shell globbing does not work
+    find -name welder-web-*.tar.gz -exec mv '{}' "$RELEASE_SOURCE/" \;
+}
+
+release_source
+job release-srpm
+job release-github

--- a/welder-web.spec
+++ b/welder-web.spec
@@ -1,10 +1,14 @@
+%if "%{!?releasever:1}"
+%define releasever 0
+%endif
+
 Name: welder-web
-Version: 0
-Release: 0
+Version: %{releasever}
+Release: 1%{?dist}
 Summary: Welder UI
 License: MIT
 
-Source: welder-web.tar.gz
+Source: welder-web-%{version}.tar.gz
 BuildArch: noarch
 
 %define debug_package %{nil}
@@ -23,3 +27,5 @@ find %{buildroot} -type f >> files.list
 sed -i "s|%{buildroot}||" *.list
 
 %files -f files.list
+
+%changelog


### PR DESCRIPTION
As discussed on the mailing list, I am working on automating welder-web releases with [cockpituous](https://github.com/cockpit-project/cockpituous). This fixes the tarball and spec file to actually get an idea of releases and versions, and provides an initial cockpituous release script.

I tested this on my own welder-web fork on https://github.com/martinpitt/welder-web, and ran:

in my welder-web branch:

    git tag -s 0.0.1 -m "$(printf '0.0.1\n\n- test release\n')"
    git push --tags martin

in an empty temporary directory:

    ~/upstream/cockpituous/release/release-runner -r https://github.com/martinpitt/welder-web utils/cockpituous-release

The latter command would be done by a bot from a cockpituous container eventually, but this makes it easy to test locally.

This produced a first release: https://github.com/martinpitt/welder-web/releases, with correct release notes (from the tag) attached) and the produced tarball. It also produced a correct srpm with adjusted %changelog and Version:. This does not currently  get uploaded anywhere, but that (COPR) will be next step after this.

As I will keep removing and re-adding the tag/release for testing, here is a screenshot:

![release](https://user-images.githubusercontent.com/200109/35110382-f2ecf99a-fc78-11e7-9522-4091e782403a.png)
