### PR TITLE
Fix timeout issue when running end to end test in local environment.

### DIFF
--- a/test/end-to-end/utils/coverage.js
+++ b/test/end-to-end/utils/coverage.js
@@ -12,13 +12,17 @@ module.exports = {
       .evaluate(() => window.__coverage__)
       .end()
       .then((cov) => {
-        const strCoverage = JSON.stringify(cov);
-        const hash = require('crypto').createHmac('sha256', '')
-          .update(strCoverage)
-          .digest('hex');
-        const fileName = `/tmp/.nyc_output/coverage-${hash}.json`;
-        require('fs').writeFileSync(fileName, strCoverage);
-
+        if (cov) {
+          const fs = require('fs');
+          const strCoverage = JSON.stringify(cov);
+          const hash = require('crypto').createHmac('sha256', '')
+            .update(strCoverage)
+            .digest('hex');
+          const covOutDir = '/tmp/.nyc_output/';
+          if (!fs.existsSync(covOutDir)) fs.mkdirSync(covOutDir);
+          const fileName = `${covOutDir}coverage-${hash}.json`;
+          fs.writeFileSync(fileName, strCoverage);
+        }
         done();
       })
     .catch(err => console.log(err));


### PR DESCRIPTION
This issue is caused by saving code coverage result file to a
non-exist folder(/tmp/.nay_output).

To fix this issue, two check points were added.
1. The code coverage result file will not be genreated and saved
if code coverage is not enabeled.
2. If there is no /tmp/.nay_output folder in current system, create
one.