### PR TITLE
WIP: Run integration tests against lorax-composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
     - COMMAND=unit-test
     - COMMAND=end-to-end-test
     - COMMAND=cockpit-test
+    - COMMAND=cockpit-test-lorax
 script:
   - make "$COMMAND"
 after_success:

--- a/Dockerfile.cockpit
+++ b/Dockerfile.cockpit
@@ -8,5 +8,5 @@ RUN rm -rf /usr/share/cockpit/kubernetes/
 COPY welder-web*.rpm /tmp/
 RUN dnf -y install /tmp/welder-web*.rpm && rm -f /tmp/welder-web*.rpm
 
-CMD ["/usr/libexec/cockpit-ws", "--no-tls"]
+CMD sed -i "/welderApiPort=/ s_=.*;_='${PORT:-4000}';_" /usr/share/cockpit/welder/js/config.js && exec /usr/libexec/cockpit-ws --no-tls
 EXPOSE 9090

--- a/Dockerfile.lorax-composer
+++ b/Dockerfile.lorax-composer
@@ -1,0 +1,14 @@
+FROM centos:7
+LABEL maintainer='"Martin Pitt" <mpitt@redhat.com>'
+
+RUN yum install -y epel-release && \
+    curl https://copr.fedorainfracloud.org/coprs/g/weldr/lorax-composer/repo/epel-7/group_weldr-lorax-composer-epel-7.repo > \
+        /etc/yum.repos.d/lorax-composer.repo && \
+    yum install -y lorax-composer && \
+    yum clean all
+
+# lorax-composer is (unnecessarily) picky about permissions on its socket dir,
+# so we can't just export /run/weldr/
+VOLUME /recipes /run
+
+CMD [ "lorax-composer", "--group", "wheel", "/recipes" ]

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ cockpit-test: shared build-rpm
 	else \
 	    sudo docker build -f Dockerfile.cockpit -t welder/web-cockpit:latest .; \
 	fi;
+	# don't interfere with host-installed cockpit
+	sudo systemctl stop cockpit.socket cockpit.service || true
 
 	sudo docker run -d --name web --restart=always --network host welder/web-cockpit:latest
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,15 @@ metadata.db:
 	sudo docker cp import-metadata:/metadata.db .
 	sudo docker rm import-metadata
 
+lorax-composer-api:
+	sudo docker build -f Dockerfile.lorax-composer -t welder/lorax-composer-api .
+	sudo docker rm -f api || true
+	sudo docker run -d --name api --restart=always -v lorax-composer-volume:/recipes -v /run/weldr:/run welder/lorax-composer-api:latest
+
+bdcs-api:
+	sudo docker rm -f api || true
+	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest
+
 shared: metadata.db
 	if [ -n "$$TRAVIS" ]; then \
 	    sudo docker build -f Dockerfile.nodejs --cache-from welder/web-nodejs:latest -t welder/web-nodejs:latest . ; \
@@ -72,10 +81,8 @@ shared: metadata.db
 
 	sudo mkdir -p failed-image
 	sudo docker network inspect welder >/dev/null 2>&1 || sudo docker network create welder
-	sudo docker ps --quiet --all --filter 'ancestor=welder/bdcs-api-rs' | sudo xargs --no-run-if-empty docker rm -f
-	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest
 
-end-to-end-test: shared
+end-to-end-test: shared bdcs-api
 	if [ -n "$$TRAVIS" ]; then \
 	    sudo docker build --cache-from welder/web:latest -t welder/web:latest . ; \
 	else \
@@ -101,7 +108,7 @@ build-rpm:
 
 	sudo docker run --rm --name buildrpm -v `pwd`:/welder welder/buildrpm:latest
 
-cockpit-test: shared build-rpm
+cockpit-test-common: shared build-rpm
 	if [ -n "$$TRAVIS" ]; then \
 	    sudo docker build -f Dockerfile.cockpit --cache-from welder/web-cockpit:latest -t welder/web-cockpit:latest .; \
 	else \
@@ -109,16 +116,23 @@ cockpit-test: shared build-rpm
 	fi;
 	# don't interfere with host-installed cockpit
 	sudo systemctl stop cockpit.socket cockpit.service || true
+	# Clean generated intermidiate tar file and useless RPM file, it is inside docker image already
+	rm -f welder-web*.rpm welder-web.tar.gz
 
+cockpit-test: cockpit-test-common bdcs-api
 	sudo docker run -d --name web --restart=always --network host welder/web-cockpit:latest
-
-# Clean generated intermediate tar file and useless RPM file
-# RPM file is inside docker image already
-	rm -f welder-web*.rpm welder-web*.tar.gz
-
 	sudo docker run --rm --name welder_end_to_end --network host \
 	    -v `pwd`/failed-image:/tmp/failed-image \
 	    -e COCKPIT_TEST=1 \
+	    welder/web-e2e-tests:latest \
+	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test -- --verbose
+	sudo docker ps --quiet --all --filter 'ancestor=welder/web-cockpit' | sudo xargs --no-run-if-empty docker rm -f
+
+cockpit-test-lorax: cockpit-test-common lorax-composer-api
+	sudo docker run -d --name web --restart=always -v /run/weldr:/run/weldr -e PORT=/run/weldr/weldr/api.socket \
+	    --network host welder/web-cockpit:latest
+	sudo docker run --rm --name welder_end_to_end --network host -v /run/weldr:/run/weldr  \
+	    -e COCKPIT_TEST=1 -e API_URI='http://unix:/run/weldr/weldr/api.socket:' \
 	    welder/web-e2e-tests:latest \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test -- --verbose
 	sudo docker ps --quiet --all --filter 'ancestor=welder/web-cockpit' | sudo xargs --no-run-if-empty docker rm -f

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ shared: metadata.db
 	    sudo docker build -f ./test/end-to-end/Dockerfile -t welder/web-e2e-tests:latest ./test/end-to-end/ ; \
 	fi;
 
-	sudo mkdir failed-image
+	sudo mkdir -p failed-image
 	sudo docker network inspect welder >/dev/null 2>&1 || sudo docker network create welder
 	sudo docker ps --quiet --all --filter 'ancestor=welder/bdcs-api-rs' | sudo xargs --no-run-if-empty docker rm -f
 	sudo docker run -d --name api --restart=always -p 4000:4000 -v bdcs-recipes-volume:/bdcs-recipes -v `pwd`:/mddb --network welder --security-opt label=disable welder/bdcs-api-rs:latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ else
     NO_SCHEME=${API_URL##$SCHEME://}
     HOST=${NO_SCHEME%%:*}
     P1=${NO_SCHEME##*:}
-    PORT=${P1%%/}
+    [ -n "$PORT" ] || PORT=${P1%%/}
 
     if [ -z "$SCHEME" ] || [ -z "$HOST" ] || [ -z "$PORT" ]; then
         echo "ERROR PARSING API_URL=$API_URL";

--- a/test/end-to-end/entrypoint.sh
+++ b/test/end-to-end/entrypoint.sh
@@ -3,6 +3,10 @@
 # Rewrite config.json to use service name as hostname of API and Web
 cd /end2end/ || exit 1
 
+if [ -n "$API_URI" ]; then
+    sed -i "s,\"uri\": \"http://localhost:4000/\",\"uri\": \"$API_URI\"," config.json
+fi
+
 if [ "$COCKPIT_TEST" ]; then
     sed -i "s,\"root\": \"http://localhost:3000/\",\"root\": \"http://localhost:9090/welder\"," config.json
 fi


### PR DESCRIPTION
lorax-composer will be the designated backend for RHEL/CentOS 7, so
run integration tests against that. This communicates over an Unix
socket instead of a TCP one, so this needs some more configuration:

 * Add a new welder/lorax-composer-api container that installs the
   current lorax-composer COPR on CentOS 7.
 * Add a `PORT`/`API_URI` environment variable parameter to the
   web-cockpit and end-to-end containers for passing the port.
 * Move the api container creation out of the `shared` make target into
   two new lorax-composer-api and bdcs-api targets.
 * Split the cockpit test into two new `cockpit-test` and
   `cockpit-test-lorax` targets, and have them depend on the
   corresponding API.

Locally this works in general, it configures the ports and containers directly and most tests actually  succeed:
```
Test Suites: 2 failed, 3 passed, 5 total
Tests:       6 failed, 53 passed, 59 total
Snapshots:   0 total
Time:        385.223s
```
However, there are several timeouts. Some of  them might be cured by #188, but I figure the first timeout is because the first /projects/list call to lorax-composer takes very long due to having to read the yum db first. So this will require a longer timeout. Also, there might be some legitimate failures here if lorax-composer is lacking some API (or has bugs).

I want to see how this  fares on the CI infra, and get some initial feedback.

CC @bcl