### PR TITLE
Run end to end test on host network namespace, not on its own namespace.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,6 @@ before_install:
         else
             npm install
         fi
-install:
-  - |
-        if [ "$COMMAND" == "cockpit-test" ]; then
-            sed -i "s,var welderApiHost=.*,var welderApiHost=\"api\";," ./public/js/config.js
-        fi
 env:
   global:
     secure: "Q9X11ehcl4YE0ylxDGk8NgVeO7nIpqWiI9am2GA6JVXcxeYYcLf3NHGe1JiLwFQ/xSq4KJrY0IgpivkVrPwTOojpR/tRG5QNDR/IJzN/6PV0IAWkHjPDKZexCQmy4IoPFib/cWqxo46V/JZ+gzs/TJugkl5/QpTcGlCr+d7VkuA80Bj0nlQO5GevYVgYMCrN6u6cKNOWtNQ0gppxHrpsLo36MpHqHbNbv236GPGsV4K2qpiqvvO5ogD+LCv5xoKEZK0ext4FNrrZFq6XEYdy9uUaUbSFfoG+HXESXbIt0L7krQDT/PkKI0X4nM91eYl5mS63+HVue7vLiijS5h9+YCa8HblMIiAiyrR3lPPH0Hx4FVSrQfkvtoXMBs3nRt7keu2FG370a7WoaQ71Q2jHrI9cfYzRwa/Mok73eF/oeN32hPlPDD679hWOZYqbSksSTikCLIgwJpEgIfaHgEYXFmL2JFXk0HbgIciA+C9fE0rfaUbmARtWYq8c+b52aIxAHEV9zYy3JeARrYxk7s3jQgS/LZIw4rfso+bQIvEMUDWt8MnvKaecY1E7XjOpW1kuk8gVjZbHm6oHKl2IndZA9KNpXjT2ew8d3SB69l2lswUYu4mTdywNEUt6nIaQtROiiftUKYThAbibIEIrq7GxQSOYMUPbvUYsZO5rkVssJps="

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,9 @@ end-to-end-test: shared
 	fi;
 
 	sudo docker build -f Dockerfile.with-coverage -t welder/web-with-coverage:latest .
-	sudo docker run -d --name web --restart=always -p 80:3000 --network welder welder/web-with-coverage:latest
+	sudo docker run -d --name web -p 3000:3000 --restart=always --network welder welder/web-with-coverage:latest
 
-	sudo docker run --rm --name welder_end_to_end --network welder \
+	sudo docker run --rm --name welder_end_to_end --network host \
 	    -v `pwd`/.nyc_output/:/tmp/.nyc_output \
 	    welder/web-e2e-tests:latest \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test -- --verbose
@@ -98,13 +98,13 @@ cockpit-test: shared build-rpm
 	    sudo docker build -f Dockerfile.cockpit -t welder/web-cockpit:latest .; \
 	fi;
 
-	sudo docker run -d --name web --restart=always -p 9090:9090 --network welder welder/web-cockpit:latest
+	sudo docker run -d --name web --restart=always --network host welder/web-cockpit:latest
 
 # Clean generated intermidiate tar file and useless RPM file
 # RPM file is inside docker image already
 	rm -f welder-web*.rpm welder-web.tar.gz
 
-	sudo docker run --rm --name welder_end_to_end --network welder \
+	sudo docker run --rm --name welder_end_to_end --network host \
 	    -e COCKPIT_TEST=1 \
 	    welder/web-e2e-tests:latest \
 	    xvfb-run -a -s '-screen 0 1024x768x24' npm run test -- --verbose

--- a/test/end-to-end/entrypoint.sh
+++ b/test/end-to-end/entrypoint.sh
@@ -3,12 +3,8 @@
 # Rewrite config.json to use service name as hostname of API and Web
 cd /end2end/ || exit 1
 
-sed -i "s,\"uri\": \"http://localhost:4000/\",\"uri\": \"http://api:4000/\"," config.json
-
-if [ -z "$COCKPIT_TEST" ]; then
-    sed -i "s,\"root\": \"http://localhost:3000/\",\"root\": \"http://web:3000/\"," config.json
-else
-    sed -i "s,\"root\": \"http://localhost:3000/\",\"root\": \"http://web:9090/welder\"," config.json
+if [ "$COCKPIT_TEST" ]; then
+    sed -i "s,\"root\": \"http://localhost:3000/\",\"root\": \"http://localhost:9090/welder\"," config.json
 fi
 
 echo "Running with config.json settings:"


### PR DESCRIPTION
1. Run end to end and cockpit tests containers on localhost of host namespace.
2. For cockpit test, run all three containers on host namespace.
3. Remove some lines of sed codes because of two above changes.