### PR TITLE
Fix clearing input filter on editRecipePage

### DIFF
--- a/core/actions/inputs.js
+++ b/core/actions/inputs.js
@@ -28,14 +28,6 @@ export const setInputComponents = (inputComponents) => ({
   },
 });
 
-export const SET_FILTERED_INPUT_INPUTS = 'SET_FILTERED_INPUT_INPUTS';
-export const setFilteredInputInputs = (filteredInputInputs) => ({
-  type: SET_FILTERED_INPUT_INPUTS,
-  payload: {
-    filteredInputInputs,
-  },
-});
-
 export const SET_SELECTED_INPUT_PAGE = 'SET_SELECTED_INPUT_PAGE';
 export const setSelectedInputPage = (selectedInputPage) => ({
   type: SET_SELECTED_INPUT_PAGE,

--- a/core/reducers/inputs.js
+++ b/core/reducers/inputs.js
@@ -2,7 +2,7 @@ import {
   FETCHING_INPUTS_SUCCEEDED,
   SET_SELECTED_INPUT_PAGE,
   SET_SELECTED_INPUT, SET_SELECTED_INPUT_STATUS, SET_SELECTED_INPUT_PARENT,
-  SET_INPUT_COMPONENTS, SET_FILTERED_INPUT_COMPONENTS,
+  SET_INPUT_COMPONENTS,
   DELETE_FILTER,
 } from '../actions/inputs';
 
@@ -25,11 +25,7 @@ const inputs = (state = [], action) => {
                   Math.ceil((action.payload.inputs[1] / action.payload.pageSize) - 1)).fill([])),
               totalInputs: action.payload.inputs[1],
               pageSize: action.payload.pageSize,
-          });
-    case SET_FILTERED_INPUT_COMPONENTS:
-      return Object.assign(
-          {}, state,
-          { filteredInputComponents: action.payload.filteredInputComponents }
+          }
       );
     case SET_SELECTED_INPUT_PAGE:
       return Object.assign(
@@ -55,8 +51,8 @@ const inputs = (state = [], action) => {
       return Object.assign(
           {}, state,
           {
-              filteredInputComponents: [[]],
-              totalFilteredInputs: 0,
+              inputComponents: undefined,
+              totalInputs: 0,
               selectedInputPage: 0,
               inputFilters: {
                   field: 'name',

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -22,7 +22,7 @@ import {
   removeBlueprintComponent, undo, redo, commitToWorkspace, deleteHistory,
 } from '../../core/actions/blueprints';
 import {
-  fetchingInputs, setInputComponents, setFilteredInputComponents, setSelectedInputPage,
+  fetchingInputs, setInputComponents, setSelectedInputPage,
   setSelectedInput, setSelectedInputStatus, setSelectedInputParent, deleteFilter,
 } from '../../core/actions/inputs';
 import { setModalActive } from '../../core/actions/modals';
@@ -65,6 +65,10 @@ class EditBlueprintPage extends React.Component {
 
   componentDidMount() {
     document.title = 'Blueprint';
+  }
+
+  componentWillUnmount() {
+    this.props.deleteFilter();
   }
 
   setNotifications() {
@@ -110,7 +114,12 @@ class EditBlueprintPage extends React.Component {
   }
 
   handleClearFilters(event) {
+    const filter = {
+      field: 'name',
+      value: '',
+    };
     this.props.deleteFilter();
+    this.props.fetchingInputs(filter, 0, this.props.inputs.pageSize, this.props.blueprint.components);
     $('#cmpsr-blueprint-input-filter').val('');
     event.preventDefault();
     event.stopPropagation();
@@ -718,7 +727,6 @@ EditBlueprintPage.propTypes = {
   removeBlueprintComponent: PropTypes.func,
   fetchingInputs: PropTypes.func,
   setInputComponents: PropTypes.func,
-  setFilteredInputComponents: PropTypes.func,
   setSelectedInputPage: PropTypes.func,
   setSelectedInput: PropTypes.func,
   setSelectedInputStatus: PropTypes.func,
@@ -791,9 +799,6 @@ const mapDispatchToProps = (dispatch) => ({
   },
   setInputComponents: (inputComponents) => {
     dispatch(setInputComponents(inputComponents));
-  },
-  setFilteredInputComponents: (inputFilterComponents) => {
-    dispatch(setFilteredInputComponents(inputFilterComponents));
   },
   setSelectedInputPage: (selectedInputPage) => {
     dispatch(setSelectedInputPage(selectedInputPage));


### PR DESCRIPTION
On the editRecipePage, when filtering inputs, one can now clear the filter by clicking the X icon or Clear All Filters link. Also, when navigating away from the editRecipePage, the filter resets. This covers issue #139 