### PR TITLE
Simplified component state

### DIFF
--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -27,7 +27,7 @@ class BlueprintContents extends React.Component {
     return (
       <div>
         <Tabs
-          key={components.length + dependencies.length}
+          key={components.length}
           ref={c => {
             this.pfTabs = c;
           }}

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -92,8 +92,6 @@ class ComponentDetailsView extends React.Component {
   }
 
   initializeBootstrapElements() {
-    // Initialize Boostrap-select
-    $('.selectpicker').selectpicker();
     // Initialize Boostrap-tooltip
     $('[data-toggle="tooltip"]').tooltip();
   }
@@ -277,7 +275,12 @@ class ComponentDetailsView extends React.Component {
             </form>
           </div>}
         <div>
-          <Tabs key="pf-tabs" ref="pfTabs" classnames="nav nav-tabs nav-tabs-pf" tabChanged={e => this.handleTabChanged(e)}>
+          <Tabs
+            key={this.state.dependencies.length}
+            ref="pfTabs" 
+            classnames="nav nav-tabs nav-tabs-pf"
+            tabChanged={e => this.handleTabChanged(e)}
+          >
             <Tab tabTitle="Details" active={this.state.activeTab === 'Details'}>
               <h4 className="cmpsr-title">{this.state.componentData.summary}</h4>
               <p>{this.state.componentData.description}</p>

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -52,12 +52,12 @@ class ComponentDetailsView extends React.Component {
     const build = status === 'available' ? 'all' : '';
     // if the user clicks a component listed in the inputs and it's in the blueprint,
     // then use the version and release that's selected for the blueprint component
-    const selectedComponent = Object.assign({}, component);
-    if (selectedComponent.active === true && selectedComponent.inBlueprint === true) {
-      selectedComponent.version = component.version_selected;
-      selectedComponent.release = component.release_selected;
+    const activeComponent = Object.assign({}, component);
+    if (activeComponent.active === true && activeComponent.inBlueprint === true) {
+      activeComponent.version = component.version_selected;
+      activeComponent.release = component.release_selected;
     }
-    Promise.all([MetadataApi.getMetadataComponent(selectedComponent, build)])
+    Promise.all([MetadataApi.getMetadataComponent(activeComponent, build)])
       .then(data => {
         this.setState({ componentData: data[0][0] });
         this.setState({ dependencies: data[0][0].dependencies });
@@ -185,7 +185,7 @@ class ComponentDetailsView extends React.Component {
                   <button
                     className="btn btn-primary add"
                     type="button"
-                    onClick={e => this.props.handleAddComponent(e, 'details', this.state.componentData, this.state.dependencies)}
+                    onClick={e => this.props.handleAddComponent(e, 'details', this.state.componentData)}
                   >
                     Add
                   </button>

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -54,13 +54,14 @@ class ComponentDetailsView extends React.Component {
     // then use the version and release that's selected for the blueprint component
     const activeComponent = Object.assign({}, component);
     if (activeComponent.active === true && activeComponent.inBlueprint === true) {
-      activeComponent.version = component.version_selected;
-      activeComponent.release = component.release_selected;
+      activeComponent.version = component.versionSelected;
+      activeComponent.release = component.releaseSelected;
     }
     Promise.all([MetadataApi.getMetadataComponent(activeComponent, build)])
       .then(data => {
         this.setState({ componentData: data[0][0] });
-        this.setState({ dependencies: data[0][0].dependencies });
+        const filteredDependencies = data[0][0].dependencies.filter(dependency => dependency.name !== data[0][0].name);
+        this.setState({ dependencies: filteredDependencies });
         if (this.props.status === 'editSelected') {
           this.handleEdit();
         }
@@ -277,7 +278,7 @@ class ComponentDetailsView extends React.Component {
         <div>
           <Tabs
             key={this.state.dependencies.length}
-            ref="pfTabs" 
+            ref="pfTabs"
             classnames="nav nav-tabs nav-tabs-pf"
             tabChanged={e => this.handleTabChanged(e)}
           >

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -133,7 +133,7 @@ class ComponentInputs extends React.Component {
                       data-original-title={`Add Component<br />
                             Version&nbsp;<strong>${component.version}</strong>
                             Release&nbsp;<strong>${component.release}</strong>`}
-                      onClick={e => this.props.handleAddComponent(e, 'input', component, [])}
+                      onClick={e => this.props.handleAddComponent(e, 'input', component)}
                     >
                       <span className="fa fa-plus" />
                     </a>}

--- a/components/ListView/ListItemComponents.js
+++ b/components/ListView/ListItemComponents.js
@@ -33,8 +33,8 @@ class ListItemComponents extends React.Component {
     const p = new Promise((resolve, reject) => {
       Promise.all([MetadataApi.getData(constants.get_modules_info + component.name)])
         .then(data => {
-          const dependencies = data[0].modules[0].dependencies;
-          this.setState({ dependencies });
+          const filteredDependencies = data[0].modules[0].dependencies.filter(dependency => dependency.name !== component.name);
+          this.setState({ dependencies: filteredDependencies });
           resolve();
         })
         .catch(e => {

--- a/core/actions/blueprintPage.js
+++ b/core/actions/blueprintPage.js
@@ -22,25 +22,25 @@ export const setActiveTab = (activeTab) => ({
   },
 });
 
-export const SET_SELECTED_COMPONENT = 'SET_SELECTED_COMPONENT';
-export const setSelectedComponent = (component) => ({
-  type: SET_SELECTED_COMPONENT,
+export const SET_ACTIVE_COMPONENT = 'SET_ACTIVE_COMPONENT';
+export const setActiveComponent = (component) => ({
+  type: SET_ACTIVE_COMPONENT,
   payload: {
     component,
   },
 });
 
-export const SET_SELECTED_COMPONENT_PARENT = 'SET_SELECTED_COMPONENT_PARENT';
-export const setSelectedComponentParent = (componentParent) => ({
-  type: SET_SELECTED_COMPONENT_PARENT,
+export const SET_ACTIVE_COMPONENT_PARENT = 'SET_ACTIVE_COMPONENT_PARENT';
+export const setActiveComponentParent = (componentParent) => ({
+  type: SET_ACTIVE_COMPONENT_PARENT,
   payload: {
     componentParent,
   },
 });
 
-export const SET_SELECTED_COMPONENT_STATUS = 'SET_SELECTED_COMPONENT_STATUS';
-export const setSelectedComponentStatus = (componentStatus) => ({
-  type: SET_SELECTED_COMPONENT_STATUS,
+export const SET_ACTIVE_COMPONENT_STATUS = 'SET_ACTIVE_COMPONENT_STATUS';
+export const setActiveComponentStatus = (componentStatus) => ({
+  type: SET_ACTIVE_COMPONENT_STATUS,
   payload: {
     componentStatus,
   },

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -55,37 +55,6 @@ export const setBlueprint = (blueprint) => ({
   },
 });
 
-export const SET_BLUEPRINT_DESCRIPTION = 'SET_BLUEPRINT_DESCRIPTION';
-export const setBlueprintDescription = (blueprint, description) => ({
-  type: SET_BLUEPRINT_DESCRIPTION,
-  payload: {
-    blueprint,
-    description,
-  },
-});
-
-export const REMOVE_BLUEPRINT_COMPONENT = 'REMOVE_BLUEPRINT_COMPONENT';
-export const removeBlueprintComponent = (blueprint, component, pendingChange) => ({
-  type: REMOVE_BLUEPRINT_COMPONENT,
-  payload: {
-    blueprint,
-    component,
-    pendingChange,
-  },
-});
-
-export const SET_BLUEPRINT_COMPONENTS = 'SET_BLUEPRINT_COMPONENTS';
-export const setBlueprintComponents = (blueprint, components, dependencies, packages, pendingChange) => ({
-  type: SET_BLUEPRINT_COMPONENTS,
-  payload: {
-    blueprint,
-    components,
-    dependencies,
-    packages,
-    pendingChange,
-  },
-});
-
 export const SET_BLUEPRINT_COMMENT = 'SET_BLUEPRINT_COMMENT';
 export const setBlueprintComment = (blueprint, comment) => ({
   type: SET_BLUEPRINT_COMMENT,
@@ -95,6 +64,54 @@ export const setBlueprintComment = (blueprint, comment) => ({
   },
 });
 
+export const SET_BLUEPRINT_DESCRIPTION = 'SET_BLUEPRINT_DESCRIPTION';
+export const setBlueprintDescription = (blueprint, description) => ({
+  type: SET_BLUEPRINT_DESCRIPTION,
+  payload: {
+    blueprint,
+    description,
+  },
+});
+
+export const ADD_BLUEPRINT_COMPONENT = 'ADD_BLUEPRINT_COMPONENT';
+export const addBlueprintComponent = (blueprint, component) => ({
+  type: ADD_BLUEPRINT_COMPONENT,
+  payload: {
+    blueprint,
+    component,
+  },
+});
+
+export const ADD_BLUEPRINT_COMPONENT_SUCCEEDED = 'ADD_BLUEPRINT_COMPONENT_SUCCEEDED';
+export const addBlueprintComponentSucceeded = (blueprintId, components, packages, pendingChange) => ({
+  type: ADD_BLUEPRINT_COMPONENT_SUCCEEDED,
+  payload: {
+    blueprintId,
+    components,
+    packages,
+    pendingChange,
+  },
+});
+
+export const REMOVE_BLUEPRINT_COMPONENT = 'REMOVE_BLUEPRINT_COMPONENT';
+export const removeBlueprintComponent = (blueprint, component) => ({
+  type: REMOVE_BLUEPRINT_COMPONENT,
+  payload: {
+    blueprint,
+    component,
+  },
+});
+
+export const REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED = 'REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED';
+export const removeBlueprintComponentSucceeded = (blueprintId, components, packages, pendingChange) => ({
+  type: REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
+  payload: {
+    blueprintId,
+    components,
+    packages,
+    pendingChange,
+  },
+});
 
 export const DELETING_BLUEPRINT = 'DELETING_BLUEPRINT';
 export const deletingBlueprint = (blueprintId) => ({

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -113,3 +113,26 @@ export function fetchDiffWorkspaceApi(blueprintId) {
   });
   return p;
 }
+
+export function depsolveComponentsApi(packages) {
+  const p = new Promise((resolve, reject) => {
+    const packageNames = packages.map(item => item.name);
+    let dependencies = [];
+    if (packageNames.length > 0) {
+      utils.apiFetch(constants.get_projects_deps + packageNames)
+        .then(depData => {
+          // bdcs-api v0.3.0 includes module (component) and dependency NEVRAs
+          // tagging all dependencies a "RPM" for now
+          dependencies = BlueprintApi.setType(depData.projects, depData.projects, 'RPM');
+          resolve(dependencies);
+        })
+        .catch(e => {
+          console.log(`getBlueprint: Error getting component and dependency metadata: ${e}`);
+          reject();
+        });
+    } else {
+      resolve(dependencies);
+    }
+  });
+  return p;
+}

--- a/core/reducers/blueprintPage.js
+++ b/core/reducers/blueprintPage.js
@@ -1,6 +1,6 @@
 import {
   SET_EDIT_DESCRIPTION_VISIBLE, SET_EDIT_DESCRIPTION_VALUE,
-  SET_SELECTED_COMPONENT, SET_SELECTED_COMPONENT_PARENT, SET_SELECTED_COMPONENT_STATUS,
+  SET_ACTIVE_COMPONENT, SET_ACTIVE_COMPONENT_PARENT, SET_ACTIVE_COMPONENT_STATUS,
   SET_ACTIVE_TAB,
 } from '../actions/blueprintPage';
 
@@ -12,15 +12,15 @@ const blueprintPage = (state = [], action) => {
     case SET_EDIT_DESCRIPTION_VALUE:
       return Object.assign({}, state,
                            { editDescriptionValue: action.payload.value });
-    case SET_SELECTED_COMPONENT:
+    case SET_ACTIVE_COMPONENT:
       return Object.assign({}, state,
-                           { selectedComponent: action.payload.component });
-    case SET_SELECTED_COMPONENT_PARENT:
+                           { activeComponent: action.payload.component });
+    case SET_ACTIVE_COMPONENT_PARENT:
       return Object.assign({}, state,
-                           { selectedComponentParent: action.payload.componentParent });
-    case SET_SELECTED_COMPONENT_STATUS:
+                           { activeComponentParent: action.payload.componentParent });
+    case SET_ACTIVE_COMPONENT_STATUS:
       return Object.assign({}, state,
-                           { selectedComponentStatus: action.payload.componentStatus });
+                           { activeComponentStatus: action.payload.componentStatus });
     case SET_ACTIVE_TAB:
       return Object.assign({}, state,
                            { activeTab: action.payload.activeTab });

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -3,37 +3,13 @@ import {
   CREATING_BLUEPRINT_SUCCEEDED,
   FETCHING_BLUEPRINTS_SUCCEEDED,
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
-  SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION, SET_BLUEPRINT_COMPONENTS, SET_BLUEPRINT_COMMENT,
-  REMOVE_BLUEPRINT_COMPONENT,
+  ADD_BLUEPRINT_COMPONENT_SUCCEEDED, REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
+  SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION, SET_BLUEPRINT_COMMENT,
   DELETING_BLUEPRINT_SUCCEEDED,
 } from '../actions/blueprints';
 
 const blueprints = (state = [], action) => {
   switch (action.type) {
-    case REMOVE_BLUEPRINT_COMPONENT:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprint.id) {
-            return Object.assign(
-              {}, blueprint, {
-              past: blueprint.past.concat([blueprint.present]),
-              present: Object.assign(
-                {}, blueprint.present, {
-                components: blueprint.present.components.filter(component => component.name !== action.payload.component.name),
-                packages: blueprint.present.packages.filter(component => component.name !== action.payload.component.name),
-                localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
-                  return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
-                   || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
-                }) ? blueprint.present.localPendingChanges.filter((component) => {
-                  return component.componentNew != action.payload.pendingChange.componentOld
-                  || component.componentOld != action.payload.pendingChange.componentNew
-                }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
-              }),
-            });
-          }
-          return blueprint;
-        }),
-      ];
     case CREATING_BLUEPRINT_SUCCEEDED:
       return [
         ...state.filter(blueprint => blueprint.present.id !== action.payload.blueprint.id), {
@@ -67,6 +43,52 @@ const blueprints = (state = [], action) => {
           future: [],
         }
       ];
+    case ADD_BLUEPRINT_COMPONENT_SUCCEEDED:
+      return [
+        ...state.map(blueprint => {
+          if (blueprint.present.id === action.payload.blueprintId) {
+            return Object.assign(
+              {}, blueprint, {
+              past: blueprint.past.concat([blueprint.present]),
+              present: Object.assign({}, blueprint.present, {
+                components: action.payload.components,
+                packages: action.payload.packages,
+                localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
+                  return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
+                  || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
+                }) ? blueprint.present.localPendingChanges.filter((component) => {
+                  return component.componentNew != action.payload.pendingChange.componentOld
+                  || component.componentOld != action.payload.pendingChange.componentNew
+                }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
+              }),
+            });
+          }
+          return blueprint;
+        }),
+      ];
+    case REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED:
+      return [
+        ...state.map(blueprint => {
+          if (blueprint.present.id === action.payload.blueprintId) {
+            return Object.assign(
+              {}, blueprint, {
+              past: blueprint.past.concat([blueprint.present]),
+              present: Object.assign({}, blueprint.present, {
+                components: action.payload.components,
+                packages: action.payload.packages,
+                localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
+                  return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
+                   || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
+                }) ? blueprint.present.localPendingChanges.filter((component) => {
+                  return component.componentNew != action.payload.pendingChange.componentOld
+                  || component.componentOld != action.payload.pendingChange.componentNew
+                }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
+              }),
+            });
+          }
+          return blueprint;
+        }),
+      ];
     case SET_BLUEPRINT:
       return [
         ...state.map(blueprint => {
@@ -84,25 +106,13 @@ const blueprints = (state = [], action) => {
           return blueprint;
         }),
       ];
-    case SET_BLUEPRINT_COMPONENTS:
+    case SET_BLUEPRINT_COMMENT:
       return [
         ...state.map(blueprint => {
           if (blueprint.present.id === action.payload.blueprint.id) {
             return Object.assign(
               {}, blueprint, {
-              past: blueprint.past.concat([blueprint.present]),
-              present: Object.assign({}, blueprint.present, {
-                components: action.payload.components,
-                dependencies: action.payload.dependencies,
-                packages: action.payload.packages,
-                localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
-                  return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
-                  || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
-                }) ? blueprint.present.localPendingChanges.filter((component) => {
-                  return component.componentNew != action.payload.pendingChange.componentOld
-                  || component.componentOld != action.payload.pendingChange.componentNew
-                }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
-              }),
+              present: Object.assign({}, blueprint.present, { comment: action.payload.comment }),
             });
           }
           return blueprint;
@@ -116,18 +126,6 @@ const blueprints = (state = [], action) => {
               {}, blueprint, {
               past: blueprint.past.concat([blueprint.present]),
               present: Object.assign({}, blueprint.present, { description: action.payload.description }),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case SET_BLUEPRINT_COMMENT:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprint.id) {
-            return Object.assign(
-              {}, blueprint, {
-              present: Object.assign({}, blueprint.present, { comment: action.payload.comment }),
             });
           }
           return blueprint;

--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -12,17 +12,17 @@ function updateInputComponentData(inputs, selectedComponents, dependencies) {
       selectedComponents.map(component => {
         if (component.name === input.name) {
           input.inBlueprint = true; // eslint-disable-line no-param-reassign
-          input.user_selected = true; // eslint-disable-line no-param-reassign
-          input.version_selected = component.version; // eslint-disable-line no-param-reassign
-          input.release_selected = component.release; // eslint-disable-line no-param-reassign
+          input.userSelected = true; // eslint-disable-line no-param-reassign
+          input.versionSelected = component.version; // eslint-disable-line no-param-reassign
+          input.releaseSelected = component.release; // eslint-disable-line no-param-reassign
         }
       });
       dependencies.map(dependency => {
         if (dependency.name === input.name) {
           input.inBlueprint = true; // eslint-disable-line no-param-reassign
-          input.user_selected = false; // eslint-disable-line no-param-reassign
-          input.version_selected = dependency.version; // eslint-disable-line no-param-reassign
-          input.release_selected = dependency.release; // eslint-disable-line no-param-reassign
+          input.userSelected = false; // eslint-disable-line no-param-reassign
+          input.versionSelected = dependency.version; // eslint-disable-line no-param-reassign
+          input.releaseSelected = dependency.release; // eslint-disable-line no-param-reassign
         }
       });
     });

--- a/core/sagas/modals.js
+++ b/core/sagas/modals.js
@@ -9,7 +9,6 @@ import {
 function* fetchModalBlueprintContents(action) {
   try {
     const { blueprintName } = action.payload;
-    console.log('in saga');
     const response = yield call(fetchBlueprintContentsApi, blueprintName);
     yield put(setModalExportBlueprintContents(response.components));
   } catch (error) {

--- a/core/sagas/modals.js
+++ b/core/sagas/modals.js
@@ -9,8 +9,9 @@ import {
 function* fetchModalBlueprintContents(action) {
   try {
     const { blueprintName } = action.payload;
+    console.log('in saga');
     const response = yield call(fetchBlueprintContentsApi, blueprintName);
-    yield put(setModalExportBlueprintContents(response.dependencies));
+    yield put(setModalExportBlueprintContents(response.components));
   } catch (error) {
     console.log('Error in loadModalBlueprintSaga');
   }

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -39,6 +39,10 @@ const getSortedSelectedComponents = (state, blueprint) => {
   }
 
   const sortedSelectedComponents = components.filter(component => selectedComponentNames.includes(component.name));
+  sortedSelectedComponents.map(component => {
+    component.inBlueprint = true; // eslint-disable-line no-param-reassign
+    component.user_selected = true;
+  });
   const key = state.sort.components.key;
   const value = state.sort.components.value;
   sortedSelectedComponents.sort((a, b) => {
@@ -62,7 +66,9 @@ const getSortedDependencies = (state, blueprint) => {
   }
 
   const sortedDependencies = dependencies.filter(dependency => !selectedComponentNames.includes(dependency.name));
-
+  sortedDependencies.map(dependency => {
+    dependency.inBlueprint = true; // eslint-disable-line no-param-reassign
+  });
   const key = state.sort.dependencies.key;
   const value = state.sort.dependencies.value;
   sortedDependencies.sort((a, b) => {

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -41,7 +41,7 @@ const getSortedSelectedComponents = (state, blueprint) => {
   const sortedSelectedComponents = components.filter(component => selectedComponentNames.includes(component.name));
   sortedSelectedComponents.map(component => {
     component.inBlueprint = true; // eslint-disable-line no-param-reassign
-    component.user_selected = true;
+    component.userSelected = true;
   });
   const key = state.sort.components.key;
   const value = state.sort.components.value;

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -30,32 +30,39 @@ export const makeGetBlueprintById = () => createSelector(
   (blueprint) => blueprint
 );
 
-const getSortedComponents = (state, blueprint) => {
-  // TODO; sort
-  const sortedComponents = blueprint.components;
-  if (sortedComponents === undefined) {
+const getSortedSelectedComponents = (state, blueprint) => {
+  const selectedComponentNames = blueprint.packages.map(item => item.name);
+
+  const components = blueprint.components;
+  if (components === undefined) {
     return [];
   }
+
+  const sortedSelectedComponents = components.filter(component => selectedComponentNames.includes(component.name));
   const key = state.sort.components.key;
   const value = state.sort.components.value;
-  sortedComponents.sort((a, b) => {
+  sortedSelectedComponents.sort((a, b) => {
     if (a[key] > b[key]) return value === 'DESC' ? 1 : -1;
     if (b[key] > a[key]) return value === 'DESC' ? -1 : 1;
     return 0;
   });
-  return sortedComponents;
+  return sortedSelectedComponents;
 };
 
-export const makeGetSortedComponents = () => createSelector(
-  [getSortedComponents],
-  (components) => components
+export const makeGetSortedSelectedComponents = () => createSelector(
+  [getSortedSelectedComponents],
+  (selectedComponents) => selectedComponents
 );
 
 const getSortedDependencies = (state, blueprint) => {
-  const sortedDependencies = blueprint.dependencies;
-  if (sortedDependencies === undefined) {
+  const selectedComponentNames = blueprint.packages.map(item => item.name);
+  const dependencies = blueprint.components;
+  if (dependencies === undefined) {
     return [];
   }
+
+  const sortedDependencies = dependencies.filter(dependency => !selectedComponentNames.includes(dependency.name));
+
   const key = state.sort.dependencies.key;
   const value = state.sort.dependencies.value;
   sortedDependencies.sort((a, b) => {

--- a/core/store.js
+++ b/core/store.js
@@ -15,9 +15,9 @@ const initialState = {
   blueprintPage: {
     activeTab: 'Details',
     editDescriptionVisible: 'false',
-    selectedComponent: '',
-    selectedComponentParent: '',
-    selectedComponentStatus: 'view',
+    activeComponent: '',
+    activeComponentParent: '',
+    activeComponentStatus: 'view',
   },
   inputs: {
     selectedInputPage: 0,

--- a/data/BlueprintApi.js
+++ b/data/BlueprintApi.js
@@ -101,7 +101,7 @@ class BlueprintApi {
     components = this.setType(components, data.recipe.packages, 'RPM');
     components.map(i => {
       i.inBlueprint = true; // eslint-disable-line no-param-reassign
-      i.user_selected = true; // eslint-disable-line no-param-reassign
+      i.userSelected = true; // eslint-disable-line no-param-reassign
       return i;
     });
     return components;

--- a/data/MetadataApi.js
+++ b/data/MetadataApi.js
@@ -65,7 +65,7 @@ class MetadataApi {
 
         const componentData = data[1].modules[0];
         componentData.inBlueprint = component.inBlueprint;
-        componentData.user_selected = component.user_selected;
+        componentData.userSelected = component.userSelected;
         componentData.ui_type = component.ui_type;
 
         // The component's depsolved version may be in .dependencies

--- a/data/NotificationsApi.js
+++ b/data/NotificationsApi.js
@@ -65,11 +65,11 @@ class NotificationsApi {
         };
         break;
       }
-      case 'saving': {
+      case 'committing': {
         notification = {
           type: 'process',
-          label: 'saving',
-          message: <span><strong>{blueprint}:</strong> Saving blueprint.</span>,
+          label: 'committing',
+          message: <span><strong>{blueprint}:</strong> Committing blueprint.</span>,
           dismiss: true,
         };
         break;

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -14,11 +14,10 @@ import EmptyState from '../../components/EmptyState/EmptyState';
 import Pagination from '../../components/Pagination/Pagination';
 import Toolbar from '../../components/Toolbar/Toolbar';
 import BlueprintApi from '../../data/BlueprintApi';
-import MetadataApi from '../../data/MetadataApi';
 import NotificationsApi from '../../data/NotificationsApi';
 import { connect } from 'react-redux';
 import {
-  fetchingBlueprintContents, setBlueprint, setBlueprintComponents, savingBlueprint,
+  fetchingBlueprintContents, setBlueprint, addBlueprintComponent, committingBlueprint,
   removeBlueprintComponent, undo, redo, commitToWorkspace, deleteHistory,
 } from '../../core/actions/blueprints';
 import {
@@ -30,7 +29,7 @@ import {
   componentsSortSetKey, componentsSortSetValue, dependenciesSortSetKey, dependenciesSortSetValue,
 } from '../../core/actions/sort';
 import {
-  makeGetBlueprintById, makeGetSortedComponents, makeGetSortedDependencies, makeGetFutureLength, makeGetPastLength
+  makeGetBlueprintById, makeGetSortedSelectedComponents, makeGetSortedDependencies, makeGetFutureLength, makeGetPastLength
 } from '../../core/selectors';
 
 class EditBlueprintPage extends React.Component {
@@ -81,7 +80,7 @@ class EditBlueprintPage extends React.Component {
         field: 'name',
         value: event.target.value,
       };
-      this.props.fetchingInputs(filter, 0, this.props.inputs.pageSize, this.props.blueprint.components);
+      this.props.fetchingInputs(filter, 0, this.props.inputs.pageSize, this.props.selectedComponents);
       this.props.setSelectedInputPage(0);
       // TODO handle the case where no results are returned
       $('#cmpsr-blueprint-input-filter').blur();
@@ -94,7 +93,7 @@ class EditBlueprintPage extends React.Component {
     // where componentData represents either a single blueprint component
     // or the entire set of blueprint components
     if (componentData === undefined) {
-      componentData = this.props.blueprint.components; // eslint-disable-line no-param-reassign
+      componentData = this.props.selectedComponents; // eslint-disable-line no-param-reassign
     }
     let updatedInputs = inputs;
     if (componentData.length > 0) {
@@ -149,7 +148,7 @@ class EditBlueprintPage extends React.Component {
     const filter = this.props.inputs.inputFilters;
     // check if filters are set to determine current input set
     if (this.props.inputs.inputComponents.slice(0)[page].length === 0) {
-      this.props.fetchingInputs(filter, page, this.props.inputs.pageSize, this.props.blueprint.components);
+      this.props.fetchingInputs(filter, page, this.props.inputs.pageSize, this.props.selectedComponents);
     }
   }
 
@@ -160,9 +159,9 @@ class EditBlueprintPage extends React.Component {
   handleCommit () {
     // clear existing notifications
     NotificationsApi.closeNotification(undefined, 'committed');
-    NotificationsApi.closeNotification(undefined, 'saving');
-    // display the saving notification
-    NotificationsApi.displayNotification(this.props.blueprint.name, 'saving');
+    NotificationsApi.closeNotification(undefined, 'committing');
+    // display the committing notification
+    NotificationsApi.displayNotification(this.props.blueprint.name, 'committing');
     this.setNotifications();
     // post blueprint (includes 'committed' notification)
     Promise.all([BlueprintApi.handleCommitBlueprint(this.props.blueprint)])
@@ -182,33 +181,7 @@ class EditBlueprintPage extends React.Component {
       .catch(e => console.log(`Error in blueprint commit: ${e}`));
   }
 
-  addBlueprintComponent(componentData) {
-    // component data is [[{component}, [{dependency},{}]]]
-    const blueprintComponents = this.props.blueprint.components.slice(0);
-    const updatedBlueprintComponents = blueprintComponents.concat(componentData[0][0]);
-    const blueprintDependencies = this.props.blueprint.dependencies;
-    const updatedBlueprintDependencies = blueprintDependencies.concat(componentData[0][0].dependencies);
-    const updatedBlueprintPackages = updatedBlueprintComponents.map(component => Object.assign({}, {}, {
-      name: component.name,
-      version: component.version
-    }));
-    const pendingChange = {
-      componentOld: null,
-      componentNew: componentData[0][0].name + '-' +componentData[0][0].version + '-' + componentData[0][0].release
-    }
-
-    this.props.setBlueprintComponents(
-      this.props.blueprint,
-      updatedBlueprintComponents,
-      updatedBlueprintDependencies,
-      updatedBlueprintPackages,
-      pendingChange
-    );
-
-    BlueprintApi.updateBlueprint(componentData[0][0], 'add');
-  }
-
-  handleAddComponent(event, source, component, dependencies) {
+  handleAddComponent(event, source, component) {
     // the user clicked Add in the sidebar, e.g. source === "input"
     // or the user clicked Add in the details view
     component.inBlueprint = true; // eslint-disable-line no-param-reassign
@@ -216,19 +189,9 @@ class EditBlueprintPage extends React.Component {
     if (component !== undefined) {
       if (source === 'input') {
         $(event.currentTarget).tooltip('hide');
-        // get metadata for default build
-        Promise.all([
-          MetadataApi.getMetadataComponent(component, ''),
-        ]).then((data) => {
-          this.addBlueprintComponent(data);
-          this.props.commitToWorkspace(this.props.blueprint.id);
-        }).catch(e => console.log(`handleAddComponent: Error getting component metadata: ${e}`));
-      } else {
-        // if source is the details view, then metadata is already known and passed with component
-        const data = [[component, dependencies]];
-        this.addBlueprintComponent(data);
-        this.props.commitToWorkspace(this.props.blueprint.id);
       }
+      // if source is the details view, then metadata is already known and passed with component
+      this.props.addBlueprintComponent(this.props.blueprint, component);
     }
 
     // update input component data to match the blueprint component data
@@ -243,11 +206,9 @@ class EditBlueprintPage extends React.Component {
   }
 
   handleUpdateComponent(event, component) {
-    // the user clicked Edit in the details view and committed updates to the component version
+    // the user clicked Edit in the details view and saved updates to the component version
     // find component in blueprint components
-    // let selectedComponent = this.props.blueprint.components.filter((obj) => (obj.name === component.name));
-    // // update blueprint component with committed updates
-    // selectedComponent = Object.assign(selectedComponent, component);
+    // update blueprint component with saved updates
     this.hideComponentDetails();
     // update input component with committed Updates
     this.updateInputComponentsOnChange(component);
@@ -268,15 +229,9 @@ class EditBlueprintPage extends React.Component {
     // update input component data
     this.updateInputComponentsOnChange(component, 'remove');
     // update the list of blueprint components to not include the removed component
-    const pendingChange = {
-      componentOld: component.name + '-' + component.version + '-' + component.release,
-      componentNew: null,
-    };
-    this.props.removeBlueprintComponent(this.props.blueprint, component, pendingChange);
+    this.props.removeBlueprintComponent(this.props.blueprint, component);
     event.preventDefault();
     event.stopPropagation();
-
-    this.props.commitToWorkspace(this.props.blueprint.id);
   }
 
   updateInputComponentsOnChange(component, remove) {
@@ -333,7 +288,7 @@ class EditBlueprintPage extends React.Component {
         inputs[page][index].active = true;
       }
       this.props.setInputComponents(inputs);
-      // set selectedComponentStatus
+      // set activeComponentStatus
       if (mode === 'edit') {
         // if I clicked Edit in list item kebab
         this.props.setSelectedInputStatus('editSelected');
@@ -430,7 +385,7 @@ class EditBlueprintPage extends React.Component {
         this.props.inputs.inputFilters,
         this.props.inputs.selectedInputPage,
         this.props.inputs.pageSize,
-        this.props.blueprint.components
+        this.props.selectedComponents,
       );
     }, 50);
   }
@@ -450,7 +405,7 @@ class EditBlueprintPage extends React.Component {
     }
     const blueprintDisplayName = this.props.route.params.blueprint;
     const {
-      blueprint, components, dependencies,
+      blueprint, selectedComponents, dependencies,
       inputs, createImage, modalActive, componentsSortKey, componentsSortValue,
       pastLength, futureLength,
     } = this.props;
@@ -511,7 +466,7 @@ class EditBlueprintPage extends React.Component {
               }
               <li className="list__subgroup-item--first">
                 <button
-                  className={`btn btn-default ${components.length ? '' : 'disabled'}`}
+                  className={`btn btn-default ${selectedComponents.length ? '' : 'disabled'}`}
                   id="cmpsr-btn-crt-image"
                   data-toggle="modal"
                   data-target="#cmpsr-modal-crt-image"
@@ -533,7 +488,7 @@ class EditBlueprintPage extends React.Component {
                     <span className="fa fa-ellipsis-v" />
                   </button>
                   <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-                    {components.length &&
+                    {selectedComponents.length &&
                       <li><a href="#" onClick={e => this.handleShowModal(e, 'modalExportBlueprint')}>Export</a></li>
                     ||
                       <li className="disabled"><a>Export</a></li>
@@ -572,13 +527,13 @@ class EditBlueprintPage extends React.Component {
               futureLength={futureLength}
             />
           }
-            {((components === undefined || components.length === 0) &&
+            {((selectedComponents === undefined || selectedComponents.length === 0) &&
               <EmptyState
                 title={'Add Blueprint Components'}
                 message={'Browse or search for components, then add them to the blueprint.'}
               />) ||
               <BlueprintContents
-                components={components}
+                components={selectedComponents}
                 dependencies={dependencies}
                 handleRemoveComponent={this.handleRemoveComponent}
                 handleComponentDetails={this.handleComponentDetails}
@@ -696,7 +651,7 @@ class EditBlueprintPage extends React.Component {
         {modalActive === 'modalExportBlueprint'
           ? <ExportBlueprint
             blueprint={blueprint.name}
-            contents={dependencies}
+            contents={blueprint.components}
             handleHideModal={this.handleHideModal}
           />
           : null}
@@ -723,7 +678,7 @@ EditBlueprintPage.propTypes = {
   selectedInput: PropTypes.object,
   fetchingBlueprintContents: PropTypes.func,
   setBlueprint: PropTypes.func,
-  savingBlueprint: PropTypes.func,
+  committingBlueprint: PropTypes.func,
   removeBlueprintComponent: PropTypes.func,
   fetchingInputs: PropTypes.func,
   setInputComponents: PropTypes.func,
@@ -732,11 +687,11 @@ EditBlueprintPage.propTypes = {
   setSelectedInputStatus: PropTypes.func,
   setSelectedInputParent: PropTypes.func,
   deleteFilter: PropTypes.func,
-  setBlueprintComponents: PropTypes.func,
+  addBlueprintComponent: PropTypes.func,
   setModalActive: PropTypes.func,
   dependenciesSortSetValue: PropTypes.func,
   componentsSortSetValue: PropTypes.func,
-  components: PropTypes.array,
+  selectedComponents: PropTypes.array,
   dependencies: PropTypes.array,
   componentsSortKey: PropTypes.string,
   componentsSortValue: PropTypes.string,
@@ -750,7 +705,7 @@ EditBlueprintPage.propTypes = {
 
 const makeMapStateToProps = () => {
   const getBlueprintById = makeGetBlueprintById();
-  const getSortedComponents = makeGetSortedComponents();
+  const getSortedSelectedComponents = makeGetSortedSelectedComponents();
   const getSortedDependencies = makeGetSortedDependencies();
   const getPastLength = makeGetPastLength();
   const getFutureLength = makeGetFutureLength();
@@ -760,7 +715,7 @@ const makeMapStateToProps = () => {
       return {
         rehydrated: state.rehydrated,
         blueprint: fetchedBlueprint.present,
-        components: getSortedComponents(state, fetchedBlueprint.present),
+        selectedComponents: getSortedSelectedComponents(state, fetchedBlueprint.present),
         dependencies: getSortedDependencies(state, fetchedBlueprint.present),
         componentsSortKey: state.sort.components.key,
         componentsSortValue: state.sort.components.value,
@@ -775,7 +730,7 @@ const makeMapStateToProps = () => {
     return {
       rehydrated: state.rehydrated,
       blueprint: {},
-      components: [],
+      selectedComponents: [],
       dependencies: [],
       componentsSortKey: state.sort.components.key,
       componentsSortValue: state.sort.components.value,
@@ -806,8 +761,11 @@ const mapDispatchToProps = (dispatch) => ({
   setBlueprint: blueprint => {
     dispatch(setBlueprint(blueprint));
   },
-  setBlueprintComponents: (blueprint, components, dependencies, packages, pendingChange) => {
-    dispatch(setBlueprintComponents(blueprint, components, dependencies, packages, pendingChange));
+  addBlueprintComponent: (blueprint, component) => {
+    dispatch(addBlueprintComponent(blueprint, component));
+  },
+  removeBlueprintComponent: (blueprint, component) => {
+    dispatch(removeBlueprintComponent(blueprint, component));
   },
   setSelectedInput: (selectedInput) => {
     dispatch(setSelectedInput(selectedInput));
@@ -821,11 +779,8 @@ const mapDispatchToProps = (dispatch) => ({
   deleteFilter: () => {
     dispatch(deleteFilter());
   },
-  savingBlueprint: (blueprint) => {
-    dispatch(savingBlueprint(blueprint));
-  },
-  removeBlueprintComponent: (blueprint, component, pendingChange) => {
-    dispatch(removeBlueprintComponent(blueprint, component, pendingChange));
+  committingBlueprint: (blueprint) => {
+    dispatch(committingBlueprint(blueprint));
   },
   setModalActive: (modalActive) => {
     dispatch(setModalActive(modalActive));

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -101,9 +101,9 @@ class EditBlueprintPage extends React.Component {
         const index = inputs[page].map(input => input.name).indexOf(component.name);
         if (index >= 0) {
           inputs[page][index].inBlueprint = true; // eslint-disable-line no-param-reassign
-          inputs[page][index].user_selected = true; // eslint-disable-line no-param-reassign
-          inputs[page][index].version_selected = component.version; // eslint-disable-line no-param-reassign
-          inputs[page][index].release_selected = component.release; // eslint-disable-line no-param-reassign
+          inputs[page][index].userSelected = true; // eslint-disable-line no-param-reassign
+          inputs[page][index].versionSelected = component.version; // eslint-disable-line no-param-reassign
+          inputs[page][index].releaseSelected = component.release; // eslint-disable-line no-param-reassign
         }
         return inputs;
       });
@@ -185,7 +185,7 @@ class EditBlueprintPage extends React.Component {
     // the user clicked Add in the sidebar, e.g. source === "input"
     // or the user clicked Add in the details view
     component.inBlueprint = true; // eslint-disable-line no-param-reassign
-    component.user_selected = true; // eslint-disable-line no-param-reassign
+    component.userSelected = true; // eslint-disable-line no-param-reassign
     if (component !== undefined) {
       if (source === 'input') {
         $(event.currentTarget).tooltip('hide');
@@ -263,9 +263,9 @@ class EditBlueprintPage extends React.Component {
     // of inputs, then update metadata for the input component
     if (index >= 0) {
       inputs[page][index].inBlueprint = false; // eslint-disable-line no-param-reassign
-      inputs[page][index].user_selected = false; // eslint-disable-line no-param-reassign
-      delete inputs[page][index].version_selected; // eslint-disable-line no-param-reassign
-      delete inputs[page][index].release_selected; // eslint-disable-line no-param-reassign
+      inputs[page][index].userSelected = false; // eslint-disable-line no-param-reassign
+      delete inputs[page][index].versionSelected; // eslint-disable-line no-param-reassign
+      delete inputs[page][index].releaseSelected; // eslint-disable-line no-param-reassign
     }
 
     return inputs;
@@ -295,7 +295,7 @@ class EditBlueprintPage extends React.Component {
       } else if (parent === undefined || parent === '') {
         // if parent is not defined (i.e. I clicked a component in the input list
         // or component list, or I clicked the first component in the breadcrumb)
-        if (component.user_selected === true) {
+        if (component.userSelected === true) {
           // and component is selected by the user to be in the blueprint,
           // then set state to selected
           this.props.setSelectedInputStatus('selected');

--- a/test/end-to-end/pages/toastNotif.js
+++ b/test/end-to-end/pages/toastNotif.js
@@ -25,8 +25,8 @@ module.exports = class TostaNotifPage extends MainPage {
     // Notification label
     this.labelStatus = '#cmpsr-toast-0 span + span';
 
-    // Blueprint saving and committed status label
-    this.varStatusSaving = `${this.varBlueprintName} Saving blueprint.`;
+    // Blueprint committing and committed status label
+    this.varStatusCommitting = `${this.varBlueprintName} Committing blueprint.`;
     this.varStatusCommitted = `${this.varBlueprintName} Blueprint changes are committed.`;
 
     // Cancel link

--- a/test/end-to-end/pages/viewBlueprint.js
+++ b/test/end-to-end/pages/viewBlueprint.js
@@ -23,7 +23,7 @@ module.exports = class ViewBlueprintPage extends MainPage {
     this.detailsContentRootElement = `${this.tabRootElement} pf-tab[tabtitle="Details"]`;
 
     // Components tab content root element
-    this.componentsContentRootElement = `${this.tabRootElement} pf-tab[tabtitle="Components"]`;
+    this.componentsContentRootElement = `${this.tabRootElement} pf-tab[tabtitle="Selected Components"]`;
 
     // Images tab content root element
     this.imagesContentRootElement = `${this.tabRootElement} pf-tab[tabtitle="Images"]`;

--- a/test/end-to-end/test/test_editBlueprint.js
+++ b/test/end-to-end/test/test_editBlueprint.js
@@ -245,7 +245,6 @@ describe('Edit Blueprint Page', () => {
           const depList = packs.map(
             pack => pack.dependencies.map(module => `${module.name}-${module.version}-${module.release}`));
           const depCompSet = new Set(depList.reduce((acc, val) => [...acc, ...val]));
-
           // Highlight the expected result
           const expectedNumber = `${[...depCompSet].length} ${exportBlueprintPage.varTotalComponents}`;
           const zeroComponent = exportBlueprintPage.varEmptyTotalComponents;


### PR DESCRIPTION
As a developer, there should be minimal duplicate data in the state. For recipes, we currently have components, dependencies, and packages which all contain similar data. This will be simplified to just components and packages. We then filter our selected components and dependencies from the lists of packages and components.
