### PR TITLE
Add COPR build to cockpituous release script

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -23,3 +23,4 @@ release_source() {
 release_source
 job release-srpm
 job release-github
+job release-copr @weldr/welder-web


### PR DESCRIPTION
This will automatically upload and build new releases to our COPR
archive.

Blockers:
 - [x] Fix cockpituous' release-copr script: https://github.com/cockpit-project/cockpituous/pull/174
 - [x] Allow cockpituous to access @weldr COPR
 - [x] Allow cockpituous to access welder GitHub (requires 2FA for that user)