### PR TITLE
Include modal confirmation for Delete Blueprint

### DIFF
--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -98,7 +98,7 @@ class BlueprintListView extends React.Component {
                     aria-labelledby="dropdownKebabRight9"
                   >
                     <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e, blueprint.name)}>Export</a></li>
-                    <li><a href="#" onClick={(e) => this.props.handleDelete(e, blueprint.id)}>Archive</a></li>
+                    <li><a href="#" onClick={(e) => this.props.handleShowModalDelete(e, blueprint)}>Delete</a></li>
                   </ul>
                 </div>
               </div>
@@ -208,7 +208,7 @@ class BlueprintListView extends React.Component {
 }
 
 BlueprintListView.propTypes = {
-  handleDelete: PropTypes.func,
+  handleShowModalDelete: PropTypes.func,
   blueprints: PropTypes.array,
   setNotifications: PropTypes.func,
   handleShowModalExport: PropTypes.func,

--- a/components/Modal/DeleteBlueprint.js
+++ b/components/Modal/DeleteBlueprint.js
@@ -1,0 +1,66 @@
+/* global $ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class DeleteBlueprint extends React.Component {
+
+  componentDidMount() {
+    $(this.modal).modal('show');
+    $(this.modal).on('hidden.bs.modal', this.props.handleHideModal);
+  }
+
+  render() {
+    return (
+      <div
+        className="modal fade"
+        id="cmpsr-modal-delete"
+        ref={(c) => { this.modal = c; }}
+        tabIndex="-1"
+        role="dialog"
+        aria-labelledby="myModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <button
+                type="button"
+                className="close"
+                data-dismiss="modal"
+              >
+                <span className="pficon pficon-close"></span>
+              </button>
+              <h4 className="modal-title" id="myModalLabel">Delete Blueprint</h4>
+            </div>
+            <div className="modal-body">
+              <p>Are you sure you want to delete the blueprint <strong>{this.props.blueprint.name}</strong>?</p>
+            </div>
+            <div className="modal-footer">
+              <p className="pull-left">This action cannot be undone.</p>
+              <button
+                type="button"
+                className="btn btn-default"
+                data-dismiss="modal"
+              >Cancel</button>
+              <button
+                type="button"
+                className="btn btn-danger"
+                data-dismiss="modal"
+                onClick={(e) => this.props.handleDelete(e, this.props.blueprint.id)}
+              >Delete</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+DeleteBlueprint.propTypes = {
+  blueprint: PropTypes.object,
+  handleHideModal: PropTypes.func,
+  handleDelete: PropTypes.func,
+};
+
+export default DeleteBlueprint;

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -108,6 +108,36 @@ export function fetchingModalExportBlueprintContents(blueprintName) {
   };
 }
 
+export const SET_MODAL_DELETE_BLUEPRINT_NAME = 'SET_MODAL_DELETE_BLUEPRINT_NAME';
+export function setModalDeleteBlueprintName(blueprintName) {
+  return {
+    type: SET_MODAL_DELETE_BLUEPRINT_NAME,
+    payload: {
+      blueprintName,
+    },
+  };
+}
+
+export const SET_MODAL_DELETE_BLUEPRINT_ID = 'SET_MODAL_DELETE_BLUEPRINT_ID';
+export function setModalDeleteBlueprintId(blueprintId) {
+  return {
+    type: SET_MODAL_DELETE_BLUEPRINT_ID,
+    payload: {
+      blueprintId,
+    },
+  };
+}
+
+export const SET_MODAL_DELETE_BLUEPRINT_VISIBLE = 'SET_MODAL_DELETE_BLUEPRINT_VISIBLE';
+export function setModalDeleteBlueprintVisible(visible) {
+  return {
+    type: SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
+    payload: {
+      visible,
+    },
+  };
+}
+
 export const APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES = 'APPEND_MODAL_PENDING_CHANGES_COMPONENT_UPDATES';
 export function appendModalPendingChangesComponentUpdates(componentUpdate) {
   return {

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -1,6 +1,7 @@
 import {
   SET_MODAL_ACTIVE,
   SET_MODAL_EXPORT_BLUEPRINT_NAME, SET_MODAL_EXPORT_BLUEPRINT_CONTENTS, SET_MODAL_EXPORT_BLUEPRINT_VISIBLE,
+  SET_MODAL_DELETE_BLUEPRINT_NAME, SET_MODAL_DELETE_BLUEPRINT_ID, SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
   SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE, SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE,
   SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE, SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS, SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT,
   FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS,
@@ -28,7 +29,7 @@ const modalCreateBlueprint = (state = [], action) => {
             createBlueprint: Object.assign(
               {}, state.createBlueprint, {
                 errorDuplicateVisible: action.payload.errorDuplicateVisible
-              }) 
+              })
           }
       );
     case SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE:
@@ -57,6 +58,28 @@ const modalCreateImage = (state = [], action) => {
       return Object.assign(
           {}, state,
           { createImage: Object.assign({}, state.createImage, { imageTypes: action.payload.imageTypes }) }
+      );
+    default:
+      return state;
+  }
+};
+
+const modalDeleteBlueprint = (state = [], action) => {
+  switch (action.type) {
+    case SET_MODAL_DELETE_BLUEPRINT_NAME:
+      return Object.assign(
+          {}, state,
+          { deleteBlueprint: Object.assign({}, state.deleteBlueprint, { name: action.payload.blueprintName }) }
+      );
+    case SET_MODAL_DELETE_BLUEPRINT_ID:
+      return Object.assign(
+          {}, state,
+          { deleteBlueprint: Object.assign({}, state.deleteBlueprint, { id: action.payload.blueprintId }) }
+      );
+    case SET_MODAL_DELETE_BLUEPRINT_VISIBLE:
+      return Object.assign(
+          {}, state,
+          { deleteBlueprint: Object.assign({}, state.deleteBlueprint, { visible: action.payload.visible }) }
       );
     default:
       return state;
@@ -100,6 +123,12 @@ const modals = (state = [], action) => {
       return modalCreateBlueprint(state, action);
     case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
       return modalCreateBlueprint(state, action);
+    case SET_MODAL_DELETE_BLUEPRINT_NAME:
+      return modalDeleteBlueprint(state, action);
+    case SET_MODAL_DELETE_BLUEPRINT_ID:
+      return modalDeleteBlueprint(state, action);
+    case SET_MODAL_DELETE_BLUEPRINT_VISIBLE:
+      return modalDeleteBlueprint(state, action);
     case FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS:
       return modalCreateImage(state, action);
     case SET_MODAL_EXPORT_BLUEPRINT_NAME:

--- a/core/store.js
+++ b/core/store.js
@@ -42,6 +42,11 @@ const initialState = {
       contents: [],
       visible: false,
     },
+    deleteBlueprint: {
+      name: '',
+      id: '',
+      visible: false,
+    },
     createBlueprint: {
       showErrorName: false,
       showErrorDuplicate: false,

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -4,6 +4,7 @@ import Layout from '../../components/Layout';
 import BlueprintListView from '../../components/ListView/BlueprintListView';
 import CreateBlueprint from '../../components/Modal/CreateBlueprint';
 import ExportBlueprint from '../../components/Modal/ExportBlueprint';
+import DeleteBlueprint from '../../components/Modal/DeleteBlueprint';
 import EmptyState from '../../components/EmptyState/EmptyState';
 import { connect } from 'react-redux';
 import { deletingBlueprint } from '../../core/actions/blueprints';
@@ -12,6 +13,9 @@ import {
   setModalExportBlueprintContents,
   setModalExportBlueprintVisible,
   fetchingModalExportBlueprintContents,
+  setModalDeleteBlueprintName,
+  setModalDeleteBlueprintId,
+  setModalDeleteBlueprintVisible,
 } from '../../core/actions/modals';
 import { blueprintsSortSetKey, blueprintsSortSetValue } from '../../core/actions/sort';
 import { makeGetSortedBlueprints } from '../../core/selectors';
@@ -21,6 +25,8 @@ class BlueprintsPage extends React.Component {
     super();
     this.setNotifications = this.setNotifications.bind(this);
     this.handleDelete = this.handleDelete.bind(this);
+    this.handleHideModalDelete = this.handleHideModalDelete.bind(this);
+    this.handleShowModalDelete = this.handleShowModalDelete.bind(this);
     this.handleHideModalExport = this.handleHideModalExport.bind(this);
     this.handleShowModalExport = this.handleShowModalExport.bind(this);
   }
@@ -65,8 +71,22 @@ class BlueprintsPage extends React.Component {
     e.stopPropagation();
   }
 
+  handleHideModalDelete() {
+    this.props.setModalDeleteBlueprintVisible(false);
+    this.props.setModalDeleteBlueprintId('');
+    this.props.setModalDeleteBlueprintName('');
+  }
+
+  handleShowModalDelete(e, blueprint) {
+    this.props.setModalDeleteBlueprintId(blueprint.id);
+    this.props.setModalDeleteBlueprintName(blueprint.name);
+    this.props.setModalDeleteBlueprintVisible(true);
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
   render() {
-    const { blueprints, exportBlueprint, createImage, blueprintSortKey, blueprintSortValue } = this.props;
+    const { blueprints, exportBlueprint, deleteBlueprint, createImage, blueprintSortKey, blueprintSortValue } = this.props;
     return (
       <Layout className="container-fluid" ref="layout">
         <div className="row toolbar-pf">
@@ -151,9 +171,9 @@ class BlueprintsPage extends React.Component {
         <BlueprintListView
           blueprints={blueprints.map(blueprint => blueprint.present)}
           imageTypes={createImage.imageTypes}
-          handleDelete={this.handleDelete}
           setNotifications={this.setNotifications}
           handleShowModalExport={this.handleShowModalExport}
+          handleShowModalDelete={this.handleShowModalDelete}
         />
       }
         <CreateBlueprint blueprintNames={blueprints.map(blueprint => blueprint.present.id)} />
@@ -164,6 +184,13 @@ class BlueprintsPage extends React.Component {
             handleHideModal={this.handleHideModalExport}
           />
           : null}
+        {(deleteBlueprint !== undefined && deleteBlueprint.visible)
+          ? <DeleteBlueprint
+            blueprint={deleteBlueprint}
+            handleDelete={this.handleDelete}
+            handleHideModal={this.handleHideModalDelete}
+          />
+          : null}
       </Layout>
     );
   }
@@ -171,12 +198,16 @@ class BlueprintsPage extends React.Component {
 
 BlueprintsPage.propTypes = {
   deletingBlueprint: PropTypes.func,
+  setModalDeleteBlueprintVisible: PropTypes.func,
+  setModalDeleteBlueprintName: PropTypes.func,
+  setModalDeleteBlueprintId: PropTypes.func,
   setModalExportBlueprintVisible: PropTypes.func,
   setModalExportBlueprintName: PropTypes.func,
   setModalExportBlueprintContents: PropTypes.func,
   fetchingModalExportBlueprintContents: PropTypes.func,
   blueprints: PropTypes.array,
   exportBlueprint: PropTypes.object,
+  deleteBlueprint: PropTypes.object,
   createImage: PropTypes.object,
   blueprintSortKey: PropTypes.string,
   blueprintSortValue: PropTypes.string,
@@ -190,6 +221,7 @@ const makeMapStateToProps = () => {
     if (getSortedBlueprints(state) !== undefined) {
       return {
         exportBlueprint: state.modals.exportBlueprint,
+        deleteBlueprint: state.modals.deleteBlueprint,
         createImage: state.modals.createImage,
         blueprints: getSortedBlueprints(state),
         blueprintSortKey: state.sort.blueprints.key,
@@ -198,6 +230,7 @@ const makeMapStateToProps = () => {
     }
     return {
       exportBlueprint: state.modals.exportBlueprint,
+      deleteBlueprint: state.modals.deleteBlueprint,
       createImage: state.modals.createImage,
       blueprints: {},
       blueprintSortKey: state.sort.blueprints.key,
@@ -221,6 +254,15 @@ const mapDispatchToProps = dispatch => ({
   },
   setModalExportBlueprintVisible: modalVisible => {
     dispatch(setModalExportBlueprintVisible(modalVisible));
+  },
+  setModalDeleteBlueprintName: modalBlueprintName => {
+    dispatch(setModalDeleteBlueprintName(modalBlueprintName));
+  },
+  setModalDeleteBlueprintId: modalBlueprintId => {
+    dispatch(setModalDeleteBlueprintId(modalBlueprintId));
+  },
+  setModalDeleteBlueprintVisible: modalVisible => {
+    dispatch(setModalDeleteBlueprintVisible(modalVisible));
   },
   deletingBlueprint: blueprint => {
     dispatch(deletingBlueprint(blueprint));

--- a/test/end-to-end/pages/blueprints.js
+++ b/test/end-to-end/pages/blueprints.js
@@ -18,7 +18,7 @@ module.exports = class BlueprintsPage extends MainPage {
     // More Action dropdown menu list
     this.moreActionList = {
       Export: 'Export',
-      Archive: 'Archive',
+      Delete: 'Delete',
     };
   }
 


### PR DESCRIPTION
This PR includes the following changes:

* Changes the text "Archive" to "Delete" for the action that deletes a blueprint
* Includes a Delete Blueprint modal that displays when the user clicks Delete for a blueprint in the list of blueprints. Previously, this action immediately made the api call to delete the recipe. Now this action is associated with the red button on the modal.