### PR TITLE
Switch to using the blueprints API instead of recipes.

### DIFF
--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -56,15 +56,15 @@ export function fetchBlueprintInputsApi(filter, selectedInputPage, pageSize) {
 
 export function fetchBlueprintNamesApi() {
   const blueprintNames = utils.apiFetch(constants.get_blueprints_list)
-    .then(response => response.recipes);
+    .then(response => response.blueprints);
   return blueprintNames;
 }
 
 export function fetchBlueprintInfoApi(blueprintName) {
   const blueprintFetch = utils.apiFetch(constants.get_blueprints_info + blueprintName)
     .then(blueprintdata => {
-      if (blueprintdata.recipes.length > 0) {
-        let blueprint = blueprintdata.recipes[0];
+      if (blueprintdata.blueprints.length > 0) {
+        let blueprint = blueprintdata.blueprints[0];
         blueprint.id = blueprintName;
         return blueprint;
       }
@@ -102,7 +102,7 @@ export function commitToWorkspaceApi(blueprint) {
 
 export function fetchDiffWorkspaceApi(blueprintId) {
   const p = new Promise((resolve, reject) => {
-    utils.apiFetch('/api/v0/recipes/diff/' + blueprintId + '/NEWEST/WORKSPACE')
+    utils.apiFetch('/api/v0/blueprints/diff/' + blueprintId + '/NEWEST/WORKSPACE')
     .then(data => {
       resolve(data);
     })

--- a/core/constants.js
+++ b/core/constants.js
@@ -4,17 +4,17 @@
 
 const constants = {
   // BDCS API paths
-  get_blueprints_list: '/api/v0/recipes/list',
-  get_blueprints_info: '/api/v0/recipes/info/',
-  get_blueprints_deps: '/api/v0/recipes/depsolve/',
+  get_blueprints_list: '/api/v0/blueprints/list',
+  get_blueprints_info: '/api/v0/blueprints/info/',
+  get_blueprints_deps: '/api/v0/blueprints/depsolve/',
   get_modules_list: '/api/v0/modules/list',
   get_projects_info: '/api/v0/projects/info/',
   get_projects_deps: '/api/v0/projects/depsolve/',
   get_modules_info: '/api/v0/modules/info/',
   get_image_types: '/api/v0/compose/types',
-  post_blueprints_new: '/api/v0/recipes/new',
-  post_blueprints_workspace: '/api/v0/recipes/workspace',
-  delete_blueprint: '/api/v0/recipes/delete/',
+  post_blueprints_new: '/api/v0/blueprints/new',
+  post_blueprints_workspace: '/api/v0/blueprints/workspace',
+  delete_blueprint: '/api/v0/blueprints/delete/',
 
 };
 

--- a/data/BlueprintApi.js
+++ b/data/BlueprintApi.js
@@ -22,12 +22,12 @@ class BlueprintApi {
             .then(data => {
               // bdcs-api v0.3.0 includes module (component) and component NEVRAs
               // tagging all components a "RPM" for now
-              const components = data.recipes[0].dependencies ?
-                  this.makeBlueprintComponents(data.recipes[0].dependencies, 'RPM') :
+              const components = data.blueprints[0].dependencies ?
+                  this.makeBlueprintComponents(data.blueprints[0].dependencies, 'RPM') :
                   [];
               // Tag objects as Module if modules and RPM if packages, for now
-              const selectedComponents = this.makeBlueprintSelectedComponents(data.recipes[0]);
-              const blueprint = data.recipes[0].recipe;
+              const selectedComponents = this.makeBlueprintSelectedComponents(data.blueprints[0]);
+              const blueprint = data.blueprints[0].blueprint;
               if (selectedComponents.length > 0) {
                 const selectedComponentNames = MetadataApi.getNames(selectedComponents);
                 if (components.length === 0) {
@@ -97,8 +97,8 @@ class BlueprintApi {
   // set additional metadata for each of the components
   makeBlueprintSelectedComponents(data) {
     let components = data.modules;
-    components = this.setType(components, data.recipe.modules, 'Module');
-    components = this.setType(components, data.recipe.packages, 'RPM');
+    components = this.setType(components, data.blueprint.modules, 'Module');
+    components = this.setType(components, data.blueprint.packages, 'RPM');
     components.map(i => {
       i.inBlueprint = true; // eslint-disable-line no-param-reassign
       i.userSelected = true; // eslint-disable-line no-param-reassign
@@ -233,7 +233,7 @@ class BlueprintApi {
     const p = new Promise((resolve, reject) => {
       utils.apiFetch(constants.get_blueprints_deps + this.blueprint.name.replace(/\s/g, '-'))
       .then(data => {
-        const blueprint = data.recipes[0].recipe;
+        const blueprint = data.blueprints[0].blueprint;
         this.blueprint.version = blueprint.version;
         resolve(blueprint);
       })

--- a/test/end-to-end/config.json
+++ b/test/end-to-end/config.json
@@ -3,8 +3,8 @@
     "api": {
         "uri": "http://localhost:4000/",
         "test": "api/v0/test",
-        "newBlueprint": "api/v0/recipes/new",
-        "deleteBlueprint": "api/v0/recipes/delete/",
+        "newBlueprint": "api/v0/blueprints/new",
+        "deleteBlueprint": "api/v0/blueprints/delete/",
         "moduleInfo": "api/v0/modules/info/",
         "moduleListTotalPackages": "api/v0/modules/list?limit=0&offset=0"
     },


### PR DESCRIPTION
This requires an API server that has also made the change.

Merging this needs to be coordinated with the related PRs from lorax-composer, bdcs-api, and bdcs-cli.