### PR TITLE
add image builder icon for Cockpit nav

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,8 @@
     "dashboard": {
         "index": {
             "label": "Image Builder",
-            "order": 30
+            "order": 30,
+            "icon": "pficon-build"
         }
     },
     "content-security-policy": "default-src 'self' 'unsafe-eval'"


### PR DESCRIPTION
Adds the patternfly icon pficon-build to display as the icon in the Cockpit navigation.

An example of the icon can be seen on the [PatternFly icon page](http://www.patternfly.org/styles/icons/)

![image](https://user-images.githubusercontent.com/21063328/38747506-12ee45b8-3f19-11e8-80d3-5c9e2899b386.png)
