### PR TITLE
Internationalize welder-web using react-intl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 node_modules
 public/index.html
 public/dist

--- a/components/CardView/CardView.js
+++ b/components/CardView/CardView.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 class CardView extends React.Component {
@@ -49,7 +50,15 @@ class CardView extends React.Component {
                   </div>
                 </div>
                 <p className="card-pf-info text-center">
-                  <strong>Created On</strong> 2015-03-01 02:00 AM <br /> Never Expires
+                  <FormattedMessage
+                    defaultMessage="{createdOnMsg} {createdOnDate, date, 'YYYY-MM-dd'} {createdOnDate, time, 'hh:mm a'}"
+                    values={{
+                      createOnMsg: <strong><FormattedMessage defaultMessage="Created On" /></strong>,
+                      createdOnDate: new Date(2015, 2, 1, 2, 0)
+                    }}
+                  />
+                  <br />
+                  <FormattedMessage defaultMessage="Never Expires" />
                 </p>
               </div>
               <div className="card-pf-view-checkbox">

--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -1,6 +1,19 @@
 import React from 'react';
+import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 
-function Header() {
+const messages = defineMessages({
+  helpTitle: {
+    defaultMessage: "Help"
+  },
+  noNewNotifications: {
+    defaultMessage: "No new notifications"
+  },
+  username: {
+    defaultMessage: "Username"
+  }
+});
+
+function Header(props) {
   return (
     <nav className="navbar navbar-pf-vertical">
       <div className="navbar-header">
@@ -15,7 +28,7 @@ function Header() {
               className="nav-item-iconic"
               id="notifications"
             >
-              <span className="fa fa-bell-o" title="No new notifications"></span>
+              <span className="fa fa-bell-o" title={props.intl.formatMessage(messages.noNewNotifications)}></span>
             </a>
           </li>
           <li className="dropdown">
@@ -26,12 +39,12 @@ function Header() {
               aria-haspopup="true"
               aria-expanded="true"
             >
-              <span title="Help" className="fa pficon-help"></span>
+              <span title={props.intl.formatMessage(messages.helpTitle)} className="fa pficon-help"></span>
               <span className="caret"></span>
             </a>
             <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
-              <li><a >Help</a></li>
-              <li><a >About</a></li>
+              <li><a ><FormattedMessage defaultMessage="Help" /></a></li>
+              <li><a ><FormattedMessage defaultMessage="About" /></a></li>
             </ul>
           </li>
           <li className="dropdown">
@@ -42,12 +55,12 @@ function Header() {
               aria-haspopup="true"
               aria-expanded="true"
             >
-              <span title="Username" className="fa pficon-user"></span>
+              <span title={props.intl.formatMessage(messages.username)} className="fa pficon-user"></span>
               <span className="caret"></span>
             </a>
             <ul className="dropdown-menu" aria-labelledby="dropdownMenu2">
-              <li><a >Preferences</a></li>
-              <li><a >Logout</a></li>
+              <li><a ><FormattedMessage defaultMessage="Preferences" /></a></li>
+              <li><a ><FormattedMessage defaultMessage="Logout" /></a></li>
             </ul>
           </li>
         </ul>
@@ -56,4 +69,8 @@ function Header() {
   );
 }
 
-export default Header;
+Header.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(Header);

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -1,12 +1,19 @@
 /* global $ */
 
 import React from 'react';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import Link from '../Link';
 import history from '../../core/history';
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "Pf*" }]*/
 // without these imports the entire app will produce an error when loaded
 import PfBreakpoints from './PfBreakpoints';
 import PfVerticalNavigation from './PfVerticalNavigation';
+
+const messages = defineMessages({
+  blueprints: {
+    defaultMessage: "BluePrints"
+  }
+});
 
 class Navigation extends React.Component {
 
@@ -21,6 +28,7 @@ class Navigation extends React.Component {
 
   render() {
     const location = history.getCurrentLocation();
+    const { formatMessage } = this.props.intl;
     return (
       <div className="nav-pf-vertical">
         <ul className="list-group">
@@ -29,11 +37,11 @@ class Navigation extends React.Component {
               <span
                 className="fa fa-shield"
                 data-toggle="tooltip"
-                title="Blueprints"
+                title={formatMessage(messages.blueprints)}
                 onClick={(e) => this.handleNavClick(e)}
               >
               </span>
-              <span className="list-group-item-value">Blueprints</span>
+              <span className="list-group-item-value">{formatMessage(messages.blueprints)}</span>
             </Link>
           </li>
         </ul>
@@ -43,4 +51,8 @@ class Navigation extends React.Component {
 
 }
 
-export default Navigation;
+Navigation.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(Navigation);

--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -1,10 +1,20 @@
 import React from 'react';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import Tabs from '../../components/Tabs/Tabs';
 import Tab from '../../components/Tabs/Tab';
 import ListView from '../../components/ListView/ListView';
 import ListItemComponents from '../../components/ListView/ListItemComponents';
 import DependencyListView from '../../components/ListView/DependencyListView';
+
+const messages = defineMessages({
+  dependencies: {
+    defaultMessage: "Dependencies {count}"
+  },
+  selected: {
+    defaultMessage: "Selected Components {count}"
+  }
+});
 
 class BlueprintContents extends React.Component {
   constructor() {
@@ -23,6 +33,7 @@ class BlueprintContents extends React.Component {
 
   render() {
     const { components, dependencies, handleComponentDetails, handleRemoveComponent, noEditComponent } = this.props;
+    const { formatMessage } = this.props.intl;
 
     return (
       <div>
@@ -35,7 +46,7 @@ class BlueprintContents extends React.Component {
           classnames="nav nav-tabs nav-tabs-pf"
         >
           <Tab
-            tabTitle={`Selected Components <span class="badge">${components.length}</span>`}
+            tabTitle={formatMessage(messages.selected, {count: <span className="badge">{components.length}</span>})}
             active={this.state.activeTab === 'Selected'}
           >
             <ListView className="cmpsr-blueprint__components" stacked>
@@ -52,7 +63,7 @@ class BlueprintContents extends React.Component {
             </ListView>
           </Tab>
           <Tab
-            tabTitle={`Dependencies <span class="badge">${dependencies.length}</span>`}
+            tabTitle={formatMessage(messages.dependencies, {count: <span className="badge">{dependencies.length}</span>})}
             active={this.state.activeTab === 'Dependencies'}
           >
             <DependencyListView
@@ -74,7 +85,8 @@ BlueprintContents.propTypes = {
   dependencies: PropTypes.array,
   handleComponentDetails: PropTypes.func,
   handleRemoveComponent: PropTypes.func,
+  intl: intlShape.isRequired,
   noEditComponent: PropTypes.bool,
 };
 
-export default BlueprintContents;
+export default injectIntl(BlueprintContents);

--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import Link from '../../components/Link';
 import CreateImage from '../../components/Modal/CreateImage';
@@ -76,13 +77,15 @@ class BlueprintListView extends React.Component {
               </div>
               <div className="list-view-pf-actions">
                 <Link to={`/edit/${blueprint.name}`}>
-                  <button className="btn btn-default" type="button">Edit Blueprint</button>
+                  <button className="btn btn-default" type="button">
+                    <FormattedMessage defaultMessage="Edit Blueprint" />
+                  </button>
                 </Link>
                 <button
                   className="btn btn-default"
                   onClick={() => this.handleCreateImage(blueprint.name)}
                 >
-                  Create Image
+                  <FormattedMessage defaultMessage="Create Image" />
                 </button>
                 <div className="dropdown pull-right dropdown-kebab-pf">
                   <button
@@ -97,8 +100,12 @@ class BlueprintListView extends React.Component {
                     className="dropdown-menu dropdown-menu-right"
                     aria-labelledby="dropdownKebabRight9"
                   >
-                    <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e, blueprint.name)}>Export</a></li>
-                    <li><a href="#" onClick={(e) => this.props.handleShowModalDelete(e, blueprint)}>Delete</a></li>
+                    <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e, blueprint.name)}>
+                      <FormattedMessage defaultMessage="Export" />
+                    </a></li>
+                    <li><a href="#" onClick={(e) => this.props.handleShowModalDelete(e, blueprint)}>
+                      <FormattedMessage defaultMessage="Delete" />
+                    </a></li>
                   </ul>
                 </div>
               </div>
@@ -117,16 +124,32 @@ class BlueprintListView extends React.Component {
                     <div
                       className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
                     >
-                      Test<strong>2</strong></div>
-                    <div
-                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
-                    >
-                      Development<strong>0</strong>
+                      <FormattedMessage
+                        defaultMessage="Test{count}"
+                        values={{
+                          count: <strong>2</strong>
+                        }}
+                      />
                     </div>
                     <div
                       className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
                     >
-                      Production<strong>1</strong>
+                      <FormattedMessage
+                        defaultMessage="Development{count}"
+                        values={{
+                          count: <strong>0</strong>
+                        }}
+                      />
+                    </div>
+                    <div
+                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Production{count}"
+                        values={{
+                          count: <strong>1</strong>
+                        }}
+                      />
                     </div>
                   </div>
                 </div>
@@ -146,8 +169,8 @@ class BlueprintListView extends React.Component {
                         <input type="checkbox" />
                       </div>
                       <div className="list-view-pf-actions">
-                        <button className="btn btn-default">View Blueprint</button>
-                        <button className="btn btn-default">Download</button>
+                        <button className="btn btn-default"><FormattedMessage defaultMessage="View Blueprint" /></button>
+                        <button className="btn btn-default"><FormattedMessage defaultMessage="Download" /></button>
                         <div className="dropdown pull-right dropdown-kebab-pf">
                           <button
                             className="btn btn-link dropdown-toggle"
@@ -163,11 +186,11 @@ class BlueprintListView extends React.Component {
                             className="dropdown-menu dropdown-menu-right"
                             aria-labelledby="dropdownKebabRight12"
                           >
-                            <li><a >Action</a></li>
-                            <li><a >Another action</a></li>
-                            <li><a >Something else here</a></li>
+                            <li><a ><FormattedMessage defaultMessage="Action" /></a></li>
+                            <li><a ><FormattedMessage defaultMessage="Another action" /></a></li>
+                            <li><a ><FormattedMessage defaultMessage="Something else here" /></a></li>
                             <li role="separator" className="divider"></li>
-                            <li><a >Separated link</a></li>
+                            <li><a ><FormattedMessage defaultMessage="Separated link" /></a></li>
                           </ul>
                         </div>
                       </div>
@@ -178,10 +201,20 @@ class BlueprintListView extends React.Component {
                         <div className="list-view-pf-body">
                           <div className="list-view-pf-description">
                             <div className="list-group-item-heading">
-                              Image 1
+                              <FormattedMessage
+                                defaultMessage="Image {imagenum}"
+                                values={{
+                                  imagenum: 1
+                                }}
+                              />
                             </div>
                             <div className="list-group-item-text">
-                              Created from Version 1
+                              <FormattedMessage
+                                defaultMessage="Created from Version {version}"
+                                values={{
+                                  version: 1
+                                }}
+                              />
                             </div>
                           </div>
                         </div>

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -1,12 +1,25 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedDate, FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';
 import Tabs from '../../components/Tabs/Tabs';
 import Tab from '../../components/Tabs/Tab';
 import DependencyListView from '../../components/ListView/DependencyListView';
 import MetadataApi from '../../data/MetadataApi';
+
+const messages = defineMessages({
+  dependencies: {
+    defaultMessage: "Dependencies {count}"
+  },
+  hideDetails: {
+    defaultMessage: "Hide Details"
+  },
+  removeFromBlueprint: {
+    defaultMessage: "Remove from Blueprint"
+  }
+})
 
 class ComponentDetailsView extends React.Component {
   constructor() {
@@ -154,6 +167,7 @@ class ComponentDetailsView extends React.Component {
 
   render() {
     const { component } = this.props;
+    const { formatMessage } = this.props.intl;
 
     return (
       <div className="cmpsr-panel__body cmpsr-panel__body--main">
@@ -161,7 +175,14 @@ class ComponentDetailsView extends React.Component {
           {(this.state.parents.length > 0 &&
             <ol className="breadcrumb">
               <li>
-                <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>Back to {this.props.parent}</a>
+                <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>
+                  <FormattedMessage
+                    defaultMessage="Back to {parent}"
+                    values={{
+                      parent: this.props.parent
+                    }}
+                  />
+                </a>
               </li>
               {this.state.parents.map((parent, i) => (
                 <li key={i}>
@@ -174,7 +195,14 @@ class ComponentDetailsView extends React.Component {
             </ol>) ||
             <ol className="breadcrumb">
               <li>
-                <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>Back to {this.props.parent}</a>
+                <a href="#" onClick={e => this.props.handleComponentDetails(e, '')}>
+                  <FormattedMessage
+                    defaultMessage="Back to {parent}"
+                    values={{
+                      parent: this.props.parent
+                    }}
+                  />
+                </a>
               </li>
             </ol>}
           <div className="cmpsr-header__actions">
@@ -186,13 +214,15 @@ class ComponentDetailsView extends React.Component {
                     type="button"
                     onClick={e => this.props.handleAddComponent(e, 'details', this.state.componentData)}
                   >
-                    Add
+                    <FormattedMessage defaultMessage="Add" />
                   </button>
                 </li>}
               {this.props.status === 'selected' &&
                 this.state.editSelected === false &&
                 <li>
-                  <button className="btn btn-primary" type="button" onClick={this.handleEdit}>Edit</button>
+                  <button className="btn btn-primary" type="button" onClick={this.handleEdit}>
+                    <FormattedMessage defaultMessage="Edit" />
+                  </button>
                 </li>}
               {((this.props.status === 'selected' && this.state.editSelected === true) || this.props.status === 'editSelected') &&
                 <li>
@@ -201,7 +231,7 @@ class ComponentDetailsView extends React.Component {
                     type="button"
                     onClick={e => this.props.handleUpdateComponent(e, this.state.componentData)}
                   >
-                    Apply Change
+                    <FormattedMessage defaultMessage="Apply Change" />
                   </button>
                 </li>}
               {(this.props.status === 'selected' || this.props.status === 'editSelected') &&
@@ -212,10 +242,10 @@ class ComponentDetailsView extends React.Component {
                     data-toggle="tooltip"
                     data-placement="bottom"
                     title=""
-                    data-original-title="Remove from Blueprint"
+                    data-original-title={formatMessage(messages.removeFromBlueprint)}
                     onClick={e => this.props.handleRemoveComponent(e, component)}
                   >
-                    Remove
+                    <FormattedMessage defaultMessage="Remove" />
                   </button>
                 </li>}
               <li>
@@ -225,7 +255,7 @@ class ComponentDetailsView extends React.Component {
                   data-toggle="tooltip"
                   data-placement="bottom"
                   title=""
-                  data-original-title="Hide Details"
+                  data-original-title={formatMessage(messages.hideDetails)}
                   onClick={e => this.props.handleComponentDetails(e, '')}
                 >
                   <span className="pficon pficon-close" />
@@ -243,11 +273,11 @@ class ComponentDetailsView extends React.Component {
         </div>
         {(this.props.status === 'available' || this.state.editSelected === true || this.props.status === 'editSelected') &&
           <div className="cmpsr-component-details__form">
-            <h4>Component Options</h4>
+            <h4><FormattedMessage defaultMessage="Component Options" /></h4>
             <form className="form-horizontal">
               <div className="form-group">
                 <label className="col-sm-3 col-md-2 control-label" htmlFor="cmpsr-compon__version-select">
-                  Version Release
+                  <FormattedMessage defaultMessage="Version" /> <FormattedMessage defaultMessage="Release" />
                 </label>
                 <div className="col-sm-8 col-md-9">
                   <select
@@ -264,12 +294,12 @@ class ComponentDetailsView extends React.Component {
               </div>
               <div className="form-group hidden">
                 <label className="col-sm-3 col-md-2 control-label" htmlFor="cmpsr-compon__instprof-select">
-                  Install Profile
+                  <FormattedMessage defaultMessage="Install Profile" />
                 </label>
                 <div className="col-sm-8 col-md-9">
                   <select id="cmpsr-compon__instprof-select" className="form-control">
-                    <option>Default</option>
-                    <option>Debug</option>
+                    <FormattedMessage defaultMessage="Default" tagName="option" />
+                    <FormattedMessage defaultMessage="Debug" tagName="option" />
                   </select>
                 </div>
               </div>
@@ -286,23 +316,31 @@ class ComponentDetailsView extends React.Component {
               <h4 className="cmpsr-title">{this.state.componentData.summary}</h4>
               <p>{this.state.componentData.description}</p>
               <dl className="dl-horizontal">
-                <dt>Type</dt>
+                <dt><FormattedMessage defaultMessage="Type" /></dt>
                 <dd>{component.ui_type}</dd>
-                <dt>Version</dt>
+                <dt><FormattedMessage defaultMessage="Version" /></dt>
                 <dd>
                   {this.state.componentData.version}
                   {' '}
                   {this.props.status === 'selected' &&
                     this.state.editSelected === false &&
-                    <a href="#" onClick={this.handleEdit}>Update</a>}
+                    <a href="#" onClick={this.handleEdit}><FormattedMessage defaultMessage="Update" /></a>}
                 </dd>
-                <dt>Release</dt>
+                <dt><FormattedMessage defaultMessage="Release" /></dt>
                 <dd>{this.state.componentData.release}</dd>
-                <dt>Architecture</dt>
+                <dt><FormattedMessage defaultMessage="Architecture" /></dt>
                 <dd>---</dd>
-                <dt>Install Size</dt>
-                <dd>2 MB (5 MB with Dependencies)</dd>
-                <dt>URL</dt>
+                <dt><FormattedMessage defaultMessage="Install Size" /></dt>
+                <dd>
+                  <FormattedMessage
+                    defaultMessage="{size} MB ({depsize} MB with Dependencies)"
+                    values={{
+                      size: 2,
+                      depsize: 5
+                    }}
+                  />
+                </dd>
+                <dt><FormattedMessage defaultMessage="URL" /></dt>
                 {(this.state.componentData.homepage !== null &&
                   <dd>
                     <a target="_blank" href={this.state.componentData.homepage}>
@@ -310,22 +348,31 @@ class ComponentDetailsView extends React.Component {
                     </a>
                   </dd>) ||
                   <dd>&nbsp;</dd>}
-                <dt>Packager</dt>
-                <dd>Red Hat</dd>
-                <dt>Product Family</dt>
+                <dt><FormattedMessage defaultMessage="Packager" /></dt>
+                <dd><FormattedMessage defaultMessage="Red Hat" /></dd>
+                <dt><FormattedMessage defaultMessage="Product Family" /></dt>
                 <dd>---</dd>
-                <dt>Lifecycle</dt>
-                <dd>01/15/2017</dd>
-                <dt>Support Level</dt>
-                <dd>Standard</dd>
+                <dt><FormattedMessage defaultMessage="Lifecycle" /></dt>
+                <dd>
+                  <FormattedDate
+                    value={new Date(2017,0,15)}
+                    year="numeric"
+                    month="2-digit"
+                    day="2-digit"
+                  />
+                </dd>
+                <dt><FormattedMessage defaultMessage="Support Level" /></dt>
+                <dd><FormattedMessage defaultMessage="Standard" /></dd>
               </dl>
             </Tab>
             {this.state.componentData.components &&
               <Tab tabTitle="Components" active={this.state.activeTab === 'Components'}>
-                <p>Components</p>
+                <p><FormattedMessage defaultMessage="Components" /></p>
               </Tab>}
             <Tab
-              tabTitle={`Dependencies <span class="badge">${this.state.dependencies.length}</span>`}
+              tabTitle={formatMessage(messages.dependencies,
+                {count: <span className="badge">this.state.dependencies.length</span>}
+              )}
               active={this.state.activeTab === 'Dependencies'}
             >
               <DependencyListView
@@ -337,7 +384,7 @@ class ComponentDetailsView extends React.Component {
               />
             </Tab>
             <Tab tabTitle="Errata" active={this.state.activeTab === 'Errata'}>
-              <p>Errata</p>
+              <p><FormattedMessage defaultMessage="Errata" /></p>
             </Tab>
           </Tabs>
         </div>
@@ -354,6 +401,7 @@ ComponentDetailsView.propTypes = {
   handleRemoveComponent: PropTypes.func,
   handleAddComponent: PropTypes.func,
   handleUpdateComponent: PropTypes.func,
+  intl: intlShape.isRequired,
 };
 
-export default ComponentDetailsView;
+export default injectIntl(ComponentDetailsView);

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -1,8 +1,18 @@
 /* global $ */
 
 import React from 'react';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';
+
+const messages = defineMessages({
+  hideDetails: {
+    defaultMessage: "Hide Details"
+  },
+  showDetails: {
+    defaultMessage: "Show Details and More Options"
+  }
+});
 
 class ComponentInputs extends React.Component {
   componentDidMount() {
@@ -82,6 +92,7 @@ class ComponentInputs extends React.Component {
 
   render() {
     const { components } = this.props;
+    const { formatMessage } = this.props.intl;
 
     return (
       <div className="list-pf cmpsr-list-inputs cmpsr-list-pf__compacted list-pf-stacked">
@@ -94,7 +105,7 @@ class ComponentInputs extends React.Component {
               data-trigger="manual"
               data-placement="top"
               title=""
-              data-original-title={component.active ? 'Hide Details' : 'Show Details and More Options'}
+              data-original-title={component.active ? formatMessage(messages.hideDetails) : formatMessage(messages.showDetails)}
               onClick={e => this.props.handleComponentDetails(e, component)}
             >
               <div className="list-pf-content list-pf-content-flex ">
@@ -152,6 +163,7 @@ ComponentInputs.propTypes = {
   handleComponentDetails: PropTypes.func,
   handleAddComponent: PropTypes.func,
   handleRemoveComponent: PropTypes.func,
+  intl: intlShape.isRequired,
 };
 
-export default ComponentInputs;
+export default injectIntl(ComponentInputs);

--- a/components/ListView/ComponentSummaryList.js
+++ b/components/ListView/ComponentSummaryList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';
 
@@ -21,10 +22,14 @@ class ComponentSummaryList extends React.Component {
     return (
       <div className="cmpsr-summary-listview">
         <p>
-          <strong>Dependencies</strong>
+          <strong><FormattedMessage defaultMessage="Dependencies" /></strong>
           <span className="badge">{this.props.listItems.length}</span>
           <a href="#" className="pull-right" onClick={e => this.handleShowAll(e)}>
-            {`${this.state.showAll ? 'Show Less' : 'Show All'}`}
+            {this.state.showAll ? (
+              <FormattedMessage defaultMessage="Show Less" />
+            ) : (
+              <FormattedMessage defaultMessage="Show All" />
+            )}
           </a>
         </p>
         <div className="list-pf cmpsr-list-pf__compacted">

--- a/components/ListView/DependencyListView.js
+++ b/components/ListView/DependencyListView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import ListView from '../../components/ListView/ListView';
 import ListItemComponents from '../../components/ListView/ListItemComponents';
@@ -11,9 +12,11 @@ class DependencyListView extends React.Component {
       <div>
         <div className="alert alert-warning alert-dismissable hidden">
           <span className="pficon pficon-warning-triangle-o" />
-          One or more dependencies have multiple variations that could be used.
-          A default variation was automatically selected.
-          Click a flagged dependency to see other options available.
+          <FormattedMessage
+            defaultMessage="One or more dependencies have multiple variations that could be used.
+                            A default variation was automatically selected.
+                            Click a flagged dependency to see other options available."
+          />
         </div>
         <ListView className={this.props.className} stacked>
           {this.props.listItems.map((listItem, i) => (

--- a/components/ListView/ListItemChanges.js
+++ b/components/ListView/ListItemChanges.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 class ListItemChanges extends React.Component {
@@ -49,7 +50,12 @@ class ListItemChanges extends React.Component {
             <div className="list-pf-content-wrapper">
               <div className="list-pf-main-content">
                 <div className="list-pf-title text-overflow-pf">
-                  Commit {this.props.number}
+                  <FormattedMessage
+                    defaultMessage="Commit {commitNumber}"
+                    values={{
+                      commitNumber: this.props.number
+                    }}
+                  />
                   <span className="cmpsr-list-item__text--muted text-muted pull-right">
                     {listItem.time}
                   </span>
@@ -68,7 +74,7 @@ class ListItemChanges extends React.Component {
                     <ul className="list-group">
                       <li className="list-group-item">
                         <div className="row">
-                          <div className="col-sm-3">Added</div>
+                          <div className="col-sm-3"><FormattedMessage defaultMessage="Added" /></div>
                           <div className="col-sm-9">
                             <div className="row">
                               <div className="col-xs-12">
@@ -83,7 +89,7 @@ class ListItemChanges extends React.Component {
                       </li>
                       <li className="list-group-item">
                         <div className="row">
-                          <div className="col-sm-3">Removed</div>
+                          <div className="col-sm-3"><FormattedMessage defaultMessage="Removed" /></div>
                           <div className="col-sm-9">
                             <div className="row">
                               <div className="col-xs-12">

--- a/components/ListView/ListItemComponents.js
+++ b/components/ListView/ListItemComponents.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedDate, FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import ComponentTypeIcons from '../../components/ListView/ComponentTypeIcons';
 import ComponentSummaryList from '../../components/ListView/ComponentSummaryList';
@@ -87,10 +88,20 @@ class ListItemComponents extends React.Component {
               </div>
               <div className="list-pf-additional-content">
                 <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
-                  Version <strong>{listItem.version}</strong>
+                  <FormattedMessage
+                    defaultMessage="Version {version}"
+                    values={{
+                      version: <strong>{listItem.version}</strong>
+                    }}
+                  />
                 </div>
                 <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
-                  Release <strong>{listItem.release}</strong>
+                  <FormattedMessage
+                    defaultMessage="Release {release}"
+                    values={{
+                      release: <strong>{listItem.release}</strong>
+                    }}
+                  />
                 </div>
               </div>
             </div>
@@ -113,7 +124,7 @@ class ListItemComponents extends React.Component {
                         href="#"
                         onClick={e => this.props.handleComponentDetails(e, listItem, this.props.componentDetailsParent)}
                       >
-                        View
+                        <FormattedMessage defaultMessage="View" />
                       </a>
                     </li>
                     <li>
@@ -121,12 +132,14 @@ class ListItemComponents extends React.Component {
                         href="#"
                         onClick={e => this.props.handleComponentDetails(e, listItem, this.props.componentDetailsParent, 'edit')}
                       >
-                        Edit
+                        <FormattedMessage defaultMessage="Edit" />
                       </a>
                     </li>
                     <li role="separator" className="divider" />
                     <li>
-                      <a href="#" onClick={e => this.props.handleRemoveComponent(e, listItem)}>Remove</a>
+                      <a href="#" onClick={e => this.props.handleRemoveComponent(e, listItem)}>
+                        <FormattedMessage defaultMessage="Remove" />
+                      </a>
                     </li>
                   </ul>
                 </div>
@@ -141,26 +154,41 @@ class ListItemComponents extends React.Component {
                 <div className="row">
                   <div className="col-md-6">
                     <dl className="dl-horizontal clearfix">
-                      <dt>Version</dt>
+                      <dt><FormattedMessage defaultMessage="Version" /></dt>
                       <dd>{listItem.version ? listItem.version : <span>&nbsp;</span>}</dd>
-                      <dt>Release</dt>
+                      <dt><FormattedMessage defaultMessage="Release" /></dt>
                       <dd>{listItem.release ? listItem.release : <span>&nbsp;</span>}</dd>
-                      <dt>Architecture</dt>
+                      <dt><FormattedMessage defaultMessage="Architecture" /></dt>
                       <dd>---</dd>
-                      <dt>Install Size</dt>
-                      <dd>2 MB (5 MB with Dependencies)</dd>
+                      <dt><FormattedMessage defaultMessage="Install Size" /></dt>
+                      <dd>
+                        <FormattedMessage
+                          defaultMessage="{size} MB ({depSize} MB with Dependencies"
+                          values={{
+                            size: 2,
+                            depSize: 5
+                          }}
+                        />
+                      </dd>
                       <dt>URL</dt>
                       {(listItem.homepage != null &&
                         <dd><a target="_blank" href={listItem.homepage}>{listItem.homepage}</a></dd>) ||
                         <dd>&nbsp;</dd>}
-                      <dt>Packager</dt>
-                      <dd>Red Hat</dd>
-                      <dt>Product Family</dt>
+                      <dt><FormattedMessage defaultMessage="Packager" /></dt>
+                      <dd><FormattedMessage defaultMessage="Red Hat" /></dd>
+                      <dt><FormattedMessage defaultMessage="Product Family" /></dt>
                       <dd>---</dd>
-                      <dt>Lifecycle</dt>
-                      <dd>01/15/2017</dd>
-                      <dt>Support Level</dt>
-                      <dd>Standard</dd>
+                      <dt><FormattedMessage defaultMessage="Lifecycle" /></dt>
+                      <dd>
+                        <FormattedDate
+                          value={new Date(2017,0,15)}
+                          year="numeric"
+                          month="2-digit"
+                          day="2-digit"
+                        />
+                      </dd>
+                      <dt><FormattedMessage defaultMessage="Support Level" /></dt>
+                      <dd><FormattedMessage defaultMessage="Standard" /></dd>
                     </dl>
                   </div>
                   <div className="col-md-6">
@@ -169,8 +197,8 @@ class ListItemComponents extends React.Component {
                   <div className="col-md-12 hidden">
                     <div className="cmpsr-summary-listview">
                       <p>
-                        <strong>Errata</strong>
-                        <a href="#" className="pull-right hidden">Show All</a>
+                        <strong><FormattedMessage defaultMessage="Errata" /></strong>
+                        <a href="#" className="pull-right hidden"><FormattedMessage defaultMessage="Show All" /></a>
                       </p>
                       <div className="list-pf cmpsr-list-pf__compacted">
                         <div className="list-pf-item">

--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 class ListItemImages extends React.PureComponent {
@@ -21,18 +22,33 @@ class ListItemImages extends React.PureComponent {
               </div>
               <div className="list-pf-additional-content">
                 <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
-                  Type <strong>{listItem.type}</strong>
+                  <FormattedMessage
+                    defaultMessage="Type {type}"
+                    values={{
+                      type: <strong>{listItem.type}</strong>
+                    }}
+                  />
                 </div>
                 <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
-                  Date Created <strong>{listItem.date_created}</strong>
+                  <FormattedMessage
+                    defaultMessage="Date Created {date}"
+                    values={{
+                      date: <strong>{listItem.date_created}</strong>
+                    }}
+                  />
                 </div>
                 <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
-                  Install Size <strong>{listItem.size}</strong>
+                  <FormattedMessage
+                    defaultMessage="Install Size {size}"
+                    values={{
+                      size: <strong>{listItem.size}</strong>
+                    }}
+                  />
                 </div>
               </div>
             </div>
             <div className="list-pf-actions">
-              <button className="btn btn-default" type="button">Download</button>
+              <button className="btn btn-default" type="button"><FormattedMessage defaultMessage="Download" /></button>
               <div className="dropdown pull-right dropdown-kebab-pf">
                 <button
                   className="btn btn-link dropdown-toggle"
@@ -45,11 +61,11 @@ class ListItemImages extends React.PureComponent {
                   <span className="fa fa-ellipsis-v" />
                 </button>
                 <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight9">
-                  <li><a>View Blueprint Components</a></li>
-                  <li><a>View Blueprint Manifest</a></li>
-                  <li><a>Export</a></li>
+                  <li><a><FormattedMessage defaultMessage="View Blueprint Components" /></a></li>
+                  <li><a><FormattedMessage defaultMessage="View Blueprint Manifest" /></a></li>
+                  <li><a><FormattedMessage defaultMessage="Export" /></a></li>
                   <li role="separator" className="divider" />
-                  <li><a>Archive</a></li>
+                  <li><a><FormattedMessage defaultMessage="Archive" /></a></li>
                 </ul>
               </div>
             </div>

--- a/components/ListView/ListItemLabel.js
+++ b/components/ListView/ListItemLabel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 const ListItemLabel = (props) => {
@@ -7,7 +8,7 @@ const ListItemLabel = (props) => {
     dependency = (<div
       className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked"
     >
-      <span className="label label-default">Dependency</span>
+      <span className="label label-default"><FormattedMessage defaultMessage="Dependency" /></span>
     </div>);
   }
 

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import BlueprintApi from '../../data/BlueprintApi';
 import { connect } from 'react-redux';
@@ -132,24 +133,29 @@ class CreateBlueprint extends React.Component {
               >
                 <span className="pficon pficon-close"></span>
               </button>
-              <h4 className="modal-title" id="myModalLabel">Create Blueprint</h4>
+              <h4 className="modal-title" id="myModalLabel"><FormattedMessage defaultMessage="Create Blueprint" /></h4>
             </div>
             <div className="modal-body">
               {(createBlueprint.errorInline && createBlueprint.errorNameVisible) &&
                 <div className="alert alert-danger">
                   <span className="pficon pficon-error-circle-o"></span>
-                  <strong>Required information is missing.</strong>
+                  <strong><FormattedMessage defaultMessage="Required information is missing." /></strong>
                 </div>
               }
               {(createBlueprint.errorInline && createBlueprint.errorDuplicateVisible) &&
                 <div className="alert alert-danger">
                   <span className="pficon pficon-error-circle-o"></span>
-                  <strong>Specify a new blueprint name.</strong>
+                  <strong><FormattedMessage defaultMessage="Specify a new blueprint name." /></strong>
                 </div>
               }
               <form className="form-horizontal" onKeyPress={(e) => this.handleEnterKey(e)}>
                 <p className="fields-status-pf">
-                  The fields marked with <span className="required-pf">*</span> are required.
+                  <FormattedMessage
+                    defaultMessage="The fields marked with {val} are required."
+                    values={{
+                      val: <span className="required-pf">*</span>
+                    }}
+                  />
                 </p>
                 <div
                   className={`form-group ${(createBlueprint.errorNameVisible || createBlueprint.errorDuplicateVisible)
@@ -158,7 +164,7 @@ class CreateBlueprint extends React.Component {
                   <label
                     className="col-sm-3 control-label required-pf"
                     htmlFor="textInput-modal-markup"
-                  >Name</label>
+                  ><FormattedMessage defaultMessage="Name" /></label>
                   <div className="col-sm-9">
                     <input
                       type="text"
@@ -170,10 +176,17 @@ class CreateBlueprint extends React.Component {
                       onBlur={(e) => this.handleErrors(e.target.value)}
                     />
                     {createBlueprint.errorNameVisible &&
-                      <span className="help-block">A blueprint name is required.</span>
+                      <span className="help-block"><FormattedMessage defaultMessage="A blueprint name is required." /></span>
                     }
                     {createBlueprint.errorDuplicateVisible &&
-                      <span className="help-block">The name "{createBlueprint.blueprint.name}" already exists.</span>
+                      <span className="help-block">
+                        <FormattedMessage
+                          defaultMessage="The name {name} already exists."
+                          values={{
+                            name: createBlueprint.blueprint.name
+                          }}
+                        />
+                      </span>
                     }
                   </div>
                 </div>
@@ -181,7 +194,7 @@ class CreateBlueprint extends React.Component {
                   <label
                     className="col-sm-3 control-label"
                     htmlFor="textInput2-modal-markup"
-                  >Description</label>
+                  ><FormattedMessage defaultMessage="Description" /></label>
                   <div className="col-sm-9">
                     <input
                       type="text"
@@ -202,7 +215,7 @@ class CreateBlueprint extends React.Component {
                 onMouseEnter={() => this.errorChecking(false)}
                 onMouseLeave={() => this.errorChecking(true)}
                 onClick={(e) => this.dismissErrors(e)}
-              >Cancel</button>
+              ><FormattedMessage defaultMessage="Cancel" /></button>
               {(createBlueprint.blueprint.name === '' || createBlueprint.errorDuplicateVisible) &&
                 <button
                   type="button"
@@ -214,7 +227,7 @@ class CreateBlueprint extends React.Component {
                   type="button"
                   className="btn btn-primary"
                   onClick={(e) => { this.handleCreateBlueprint(e, createBlueprint.blueprint); }}
-                >Create</button>
+                ><FormattedMessage defaultMessage="Create" /></button>
               }
             </div>
           </div>

--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import NotificationsApi from '../../data/NotificationsApi';
 
@@ -32,14 +33,14 @@ class CreateImage extends React.Component {
               <button type="button" className="close" data-dismiss="modal" aria-hidden="true">
                 <span className="pficon pficon-close"></span>
               </button>
-              <h4 className="modal-title" id="myModalLabel">Create Image</h4>
+              <h4 className="modal-title" id="myModalLabel"><FormattedMessage defaultMessage="Create Image" /></h4>
             </div>
             <div className="modal-body">
               <form className="form-horizontal">
                 <div className="form-group">
                   <label
                     className="col-sm-3 control-label"
-                  >Blueprint</label>
+                  ><FormattedMessage defaultMessage="Blueprint" /></label>
                   <div className="col-sm-9">
                     <p className="form-control-static">{this.props.blueprint}</p>
                   </div>
@@ -48,7 +49,7 @@ class CreateImage extends React.Component {
                   <label
                     className="col-sm-3 control-label"
                     htmlFor="textInput-modal-markup"
-                  >Image Type</label>
+                  ><FormattedMessage defaultMessage="Image Type" /></label>
                   <div className="col-sm-9">
                     <select className="form-control">
                       {this.props.imageTypes !== undefined && this.props.imageTypes.map((type, i) =>
@@ -61,18 +62,22 @@ class CreateImage extends React.Component {
                   <label
                     className="col-sm-3 control-label"
                     htmlFor="textInput2-modal-markup"
-                  >Architecture</label>
+                  ><FormattedMessage defaultMessage="Architecture" /></label>
                   <div className="col-sm-9">
                     <select className="form-control">
-                      <option>x86_64</option>
+                      <FormattedMessage defaultMessage="x86_64" tagName="option" />
                     </select>
                   </div>
                 </div>
               </form>
             </div>
             <div className="modal-footer">
-              <button type="button" className="btn btn-default" data-dismiss="modal">Cancel</button>
-              <button type="button" className="btn btn-primary" onClick={this.handleCreateImage}>Create</button>
+              <button type="button" className="btn btn-default" data-dismiss="modal">
+                <FormattedMessage defaultMessage="Cancel" />
+              </button>
+              <button type="button" className="btn btn-primary" onClick={this.handleCreateImage}>
+                <FormattedMessage defaultMessage="Create" />
+              </button>
             </div>
           </div>
         </div>

--- a/components/Modal/DeleteBlueprint.js
+++ b/components/Modal/DeleteBlueprint.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 class DeleteBlueprint extends React.Component {
@@ -31,24 +32,31 @@ class DeleteBlueprint extends React.Component {
               >
                 <span className="pficon pficon-close"></span>
               </button>
-              <h4 className="modal-title" id="myModalLabel">Delete Blueprint</h4>
+              <h4 className="modal-title" id="myModalLabel"><FormattedMessage defaultMessage="Delete Blueprint" /></h4>
             </div>
             <div className="modal-body">
-              <p>Are you sure you want to delete the blueprint <strong>{this.props.blueprint.name}</strong>?</p>
+              <p>
+                <FormattedMessage
+                  defaultMessage="Are you sure you want to delete the blueprint {name}?"
+                  values={{
+                    name: <strong>{this.props.blueprint.name}</strong>
+                  }}
+                />
+              </p>
             </div>
             <div className="modal-footer">
-              <p className="pull-left">This action cannot be undone.</p>
+              <p className="pull-left"><FormattedMessage defaultMessage="This action cannot be undone." /></p>
               <button
                 type="button"
                 className="btn btn-default"
                 data-dismiss="modal"
-              >Cancel</button>
+              ><FormattedMessage defaultMessage="Cancel" /></button>
               <button
                 type="button"
                 className="btn btn-danger"
                 data-dismiss="modal"
                 onClick={(e) => this.props.handleDelete(e, this.props.blueprint.id)}
-              >Delete</button>
+              ><FormattedMessage defaultMessage="Delete" /></button>
             </div>
           </div>
         </div>

--- a/components/Modal/ExportBlueprint.js
+++ b/components/Modal/ExportBlueprint.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 class ExportBlueprint extends React.Component {
@@ -36,14 +37,14 @@ class ExportBlueprint extends React.Component {
               >
                 <span className="pficon pficon-close"></span>
               </button>
-              <h4 className="modal-title" id="myModalLabel">Export Blueprint</h4>
+              <h4 className="modal-title" id="myModalLabel"><FormattedMessage defaultMessage="Export Blueprint" /></h4>
             </div>
             <div className="modal-body">
               <form className="form-horizontal" onKeyPress={(e) => this.handleEnterKey(e)}>
                 <div className="form-group">
                   <label
                     className="col-sm-3 control-label"
-                  >Blueprint</label>
+                  ><FormattedMessage defaultMessage="Blueprint" /></label>
                   <div className="col-sm-9">
                     <p className="form-control-static">{this.props.blueprint}</p>
                   </div>
@@ -52,10 +53,10 @@ class ExportBlueprint extends React.Component {
                   <label
                     className="col-sm-3 control-label"
                     htmlFor="textInput-modal-markup"
-                  >Export as</label>
+                  ><FormattedMessage defaultMessage="Export as" /></label>
                   <div className="col-sm-9">
                     <select className="form-control">
-                      <option>Text</option>
+                      <FormattedMessage defaultMessage="Text" tagName="option" />
                     </select>
                   </div>
                 </div>
@@ -63,7 +64,7 @@ class ExportBlueprint extends React.Component {
                   <label
                     className="col-sm-3 control-label"
                     htmlFor="textInput2-modal-markup"
-                  >Contents</label>
+                  ><FormattedMessage defaultMessage="Contents" /></label>
                   {this.props.contents &&
                     <div className="col-sm-9">
                       <textarea
@@ -76,7 +77,14 @@ class ExportBlueprint extends React.Component {
                           `${comp.name}-${comp.version}-${comp.release}`
                         )).join('\n')}
                       />
-                      <p>{this.props.contents.length} total components</p>
+                      <p>
+                        <FormattedMessage
+                          defaultMessage="{count} total components"
+                          values={{
+                            count: this.props.contents.length
+                          }}
+                        />
+                      </p>
                     </div>
                     ||
                     <div className="col-sm-1">
@@ -91,8 +99,10 @@ class ExportBlueprint extends React.Component {
                 type="button"
                 className="btn btn-default"
                 data-dismiss="modal"
-              >Close</button>
-              <button type="button" className="btn btn-primary" onClick={() => this.handleCopy()}>Copy</button>
+              ><FormattedMessage defaultMessage="Close" /></button>
+              <button type="button" className="btn btn-primary" onClick={() => this.handleCopy()}>
+                <FormattedMessage defaultMessage="Copy" />
+              </button>
             </div>
           </div>
         </div>

--- a/components/Notifications/Notification.js
+++ b/components/Notifications/Notification.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import NotificationsApi from '../../data/NotificationsApi';
 
@@ -114,7 +115,7 @@ class Notification extends React.PureComponent {
               )}
               <li>
                 <a href="#" onClick={(e) => this.handleClose(e, this.props.id)}>
-                  Close
+                  <FormattedMessage defaultMessage="Close" />
                 </a>
               </li>
             </ul>

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -1,11 +1,18 @@
 import React from 'react';
+import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
+
+const messages = defineMessages({
+  filterPlaceholder: {
+    defaultMessage: "Filter By Name..."
+  }
+});
 
 const Toolbar = props => (
   <div className="toolbar-pf">
     <form className="toolbar-pf-actions">
       <div className="form-group toolbar-pf-filter">
-        <label className="sr-only" htmlFor="filter">Name</label>
+        <label className="sr-only" htmlFor="filter"><FormattedMessage defaultMessage="Name" /></label>
         <div className="input-group">
           <div className="input-group-btn">
             <button
@@ -15,14 +22,19 @@ const Toolbar = props => (
               aria-haspopup="true"
               aria-expanded="false"
             >
-              Name<span className="caret" />
+              <FormattedMessage defaultMessage="Name" /><span className="caret" />
             </button>
             <ul className="dropdown-menu">
-              <li><a>Name</a></li>
-              <li><a>Version</a></li>
+              <li><a><FormattedMessage defaultMessage="Name" /></a></li>
+              <li><a><FormattedMessage defaultMessage="Version" /></a></li>
             </ul>
           </div>
-          <input type="text" className="form-control" id="filter" placeholder="Filter By Name..." />
+          <input 
+            type="text"
+            className="form-control"
+            id="filter"
+            placeholder={props.intl.formatMessage(messages.filterPlaceholder)}
+          />
         </div>
       </div>
       <div className="form-group">
@@ -34,11 +46,11 @@ const Toolbar = props => (
             aria-haspopup="true"
             aria-expanded="false"
           >
-            Name<span className="caret" />
+            <FormattedMessage defaultMessage="Name" /><span className="caret" />
           </button>
           <ul className="dropdown-menu">
-            <li><a>Name</a></li>
-            <li><a>Version</a></li>
+            <li><a><FormattedMessage defaultMessage="Name" /></a></li>
+            <li><a><FormattedMessage defaultMessage="Version" /></a></li>
           </ul>
         </div>
         {props.componentsSortKey === 'name' && props.componentsSortValue === 'DESC' &&
@@ -98,6 +110,7 @@ const Toolbar = props => (
 
 Toolbar.propTypes = {
   handleHistory: PropTypes.func,
+  intl: intlShape.isRequired,
 };
 
-export default Toolbar;
+export default injectIntl(Toolbar);

--- a/components/Wizard/WizardView.js
+++ b/components/Wizard/WizardView.js
@@ -1,8 +1,15 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 // import Wizard from './Wizard';
+
+const messages = defineMessages({
+  closeLabel: {
+    defaultMessage: "Close"
+  }
+});
 
 class WizardView extends React.Component {
 
@@ -16,6 +23,7 @@ class WizardView extends React.Component {
 
 
   render() {
+    const { formatMessage } = this.props.intl;
     return (
       <div className="modal " id="complete" tabIndex="-1" role="dialog">
         <div className="modal-dialog modal-lg wizard-pf">
@@ -24,10 +32,10 @@ class WizardView extends React.Component {
               <button
                 type="button"
                 className="close wizard-pf-dismiss"
-                aria-label="Close"
+                aria-label={formatMessage(messages.closeLabel)}
                 onClick={this.handleClose}
               ><span aria-hidden="true">&times;</span></button>
-              <dt className="modal-title">Wizard Title</dt>
+              <dt className="modal-title"><FormattedMessage defaultMessage="Wizard Title" /></dt>
             </div>
             <div className="modal-body wizard-pf-body clearfix">
               <div className="wizard-pf-steps hidden">
@@ -35,19 +43,19 @@ class WizardView extends React.Component {
                   <li className="wizard-pf-step active" data-tabgroup="1">
                     <a>
                       <span className="wizard-pf-step-number">1</span>
-                      <span className="wizard-pf-step-title">First Step</span>
+                      <span className="wizard-pf-step-title"><FormattedMessage defaultMessage="First Step" /></span>
                     </a>
                   </li>
                   <li className="wizard-pf-step" data-tabgroup="2">
                     <a>
                       <span className="wizard-pf-step-number">2</span>
-                      <span className="wizard-pf-step-title">Second Step</span>
+                      <span className="wizard-pf-step-title"><FormattedMessage defaultMessage="Second Step" /></span>
                     </a>
                   </li>
                   <li className="wizard-pf-step" data-tabgroup="3">
                     <a>
                       <span className="wizard-pf-step-number">3</span>
-                      <span className="wizard-pf-step-title">Review</span>
+                      <span className="wizard-pf-step-title"><FormattedMessage defaultMessage="Review" /></span>
                     </a>
                   </li>
                 </ul>
@@ -59,13 +67,13 @@ class WizardView extends React.Component {
                     <li className="list-group-item active">
                       <a href="#">
                         <span className="wizard-pf-substep-number">1A.</span>
-                        <span className="wizard-pf-substep-title">Details</span>
+                        <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Details" /></span>
                       </a>
                     </li>
                     <li className="list-group-item">
                       <a href="#">
                         <span className="wizard-pf-substep-number">1B.</span>
-                        <span className="wizard-pf-substep-title">Settings</span>
+                        <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Settings" /></span>
                       </a>
                     </li>
                   </ul>
@@ -73,13 +81,13 @@ class WizardView extends React.Component {
                     <li className="list-group-item">
                       <a href="#">
                         <span className="wizard-pf-substep-number">2A.</span>
-                        <span className="wizard-pf-substep-title">Details</span>
+                        <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Details" /></span>
                       </a>
                     </li>
                     <li className="list-group-item">
                       <a href="#">
                         <span className="wizard-pf-substep-number">2B.</span>
-                        <span className="wizard-pf-substep-title">Settings</span>
+                        <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Settings" /></span>
                       </a>
                     </li>
                   </ul>
@@ -87,13 +95,13 @@ class WizardView extends React.Component {
                     <li className="list-group-item">
                       <a>
                         <span className="wizard-pf-substep-number">3A.</span>
-                        <span className="wizard-pf-substep-title">Summary</span>
+                        <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Summary" /></span>
                       </a>
                     </li>
                     <li className="list-group-item">
                       <a>
                         <span className="wizard-pf-substep-number">3B.</span>
-                        <span className="wizard-pf-substep-title">Progress</span>
+                        <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Progress" /></span>
                       </a>
                     </li>
                   </ul>
@@ -101,7 +109,7 @@ class WizardView extends React.Component {
                 <div className="wizard-pf-main">
                   <div className="wizard-pf-loading blank-slate-pf">
                     <div className="spinner spinner-lg blank-slate-pf-icon"></div>
-                    <h3 className="blank-slate-pf-main-action">Loading Wizard</h3>
+                    <h3 className="blank-slate-pf-main-action"><FormattedMessage defaultMessage="Loading Wizard" /></h3>
                     <p className="blank-slate-pf-secondary-action">Lorem ipsum dolor sit amet,
                     porta at suspendisse ac, ut wisi
                     vivamus, lorem sociosqu eget nunc amet. </p>
@@ -110,7 +118,7 @@ class WizardView extends React.Component {
                     <form className="form-horizontal">
                       <div className="form-group required">
                         <label className="col-sm-2 control-label" htmlhtmlFor="textInput-markup">
-                          Name
+                          <FormattedMessage defaultMessage="Name" />
                         </label>
                         <div className="col-sm-10">
                           <input type="text" data-id="textInput-markup" className="form-control" />
@@ -120,7 +128,7 @@ class WizardView extends React.Component {
                         <label
                           className="col-sm-2 control-label"
                           htmlhtmlFor="descriptionInput-markup"
-                        >Description (Optional)</label>
+                        ><FormattedMessage defaultMessage="Description (Optional)" /></label>
                         <div className="col-sm-10">
                           <textarea
                             data-id="descriptionInput-markup"
@@ -200,7 +208,7 @@ class WizardView extends React.Component {
                               $(this).toggleClass('collapsed');
                               $('#reviewStep1').toggleClass('collapse');
                             }}
-                          >First Step</a>
+                          ><FormattedMessage defaultMessage="First Step" /></a>
                           <div id="reviewStep1" className="wizard-pf-review-substeps">
                             <ul className="list-group">
                               <li className="list-group-item">
@@ -211,22 +219,24 @@ class WizardView extends React.Component {
                                   }}
                                 >
                                   <span className="wizard-pf-substep-number">1A.</span>
-                                  <span className="wizard-pf-substep-title">Details</span>
+                                  <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Details" /></span>
                                 </a>
                                 <div id="reviewStep1Substep1" className="wizard-pf-review-content">
                                   <form className="form">
                                     <div className="wizard-pf-review-item">
-                                      <span className="wizard-pf-review-item-label">Name:</span>
+                                      <span className="wizard-pf-review-item-label">
+                                        <FormattedMessage defaultMessage="Name:" />
+                                      </span>
                                       <span className="wizard-pf-review-item-value">
-                                        First Last
+                                        <FormattedMessage defaultMessage="First Last" />
                                       </span>
                                     </div>
                                     <div className="wizard-pf-review-item">
                                       <span className="wizard-pf-review-item-label">
-                                        Description:
+                                        <FormattedMessage defaultMessage="Description:" />
                                       </span>
                                       <span className="wizard-pf-review-item-value">
-                                        This is the description
+                                        <FormattedMessage defaultMessage="This is the description" />
                                       </span>
                                     </div>
                                   </form>
@@ -240,13 +250,17 @@ class WizardView extends React.Component {
                                   }}
                                 >
                                   <span className="wizard-pf-substep-number">1B.</span>
-                                  <span className="wizard-pf-substep-title">Settings</span>
+                                  <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Settings" /></span>
                                 </a>
                                 <div id="reviewStep1Substep2" className="wizard-pf-review-content">
                                   <form className="form">
                                     <div className="wizard-pf-review-item">
-                                      <div className="wizard-pf-review-item-field">Setting A</div>
-                                      <div className="wizard-pf-review-item-field">Setting B</div>
+                                      <div className="wizard-pf-review-item-field">
+                                        <FormattedMessage defaultMessage="Setting A" />
+                                      </div>
+                                      <div className="wizard-pf-review-item-field">
+                                        <FormattedMessage defaultMessage="Setting B" />
+                                      </div>
                                     </div>
                                   </form>
                                 </div>
@@ -260,7 +274,7 @@ class WizardView extends React.Component {
                               $(this).toggleClass('collapsed');
                               $('#reviewStep2').toggleClass('collapse');
                             }}
-                          >Second Step</a>
+                          ><FormattedMessage defaultMessage="Second Step" /></a>
                           <div id="reviewStep2" className="wizard-pf-review-substeps">
                             <ul className="list-group">
                               <li className="list-group-item">
@@ -271,22 +285,24 @@ class WizardView extends React.Component {
                                   }}
                                 >
                                   <span className="wizard-pf-substep-number">2A.</span>
-                                  <span className="wizard-pf-substep-title">Details</span>
+                                  <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Details" /></span>
                                 </a>
                                 <div id="reviewStep2Substep1" className="wizard-pf-review-content">
                                   <form className="form">
                                     <div className="wizard-pf-review-item">
-                                      <span className="wizard-pf-review-item-label">Name:</span>
+                                      <span className="wizard-pf-review-item-label">
+                                        <FormattedMessage defaultMessage="Name:" />
+                                      </span>
                                       <span className="wizard-pf-review-item-value">
-                                        First Last
+                                        <FormattedMessage defaultMessage="First Last" />
                                       </span>
                                     </div>
                                     <div className="wizard-pf-review-item">
                                       <span className="wizard-pf-review-item-label">
-                                        Description:
+                                        <FormattedMessage defaultMessage="Description:" />
                                       </span>
                                       <span className="wizard-pf-review-item-value">
-                                        This is the description
+                                        <FormattedMessage defaultMessage="This is the description" />
                                       </span>
                                     </div>
                                   </form>
@@ -300,13 +316,17 @@ class WizardView extends React.Component {
                                   }}
                                 >
                                   <span className="wizard-pf-substep-number">2B.</span>
-                                  <span className="wizard-pf-substep-title">Settings</span>
+                                  <span className="wizard-pf-substep-title"><FormattedMessage defaultMessage="Settings" /></span>
                                 </a>
                                 <div id="reviewStep2Substep2" className="wizard-pf-review-content">
                                   <form className="form">
                                     <div className="wizard-pf-review-item">
-                                      <div className="wizard-pf-review-item-field">Setting A</div>
-                                      <div className="wizard-pf-review-item-field">Setting B</div>
+                                      <div className="wizard-pf-review-item-field">
+                                        <FormattedMessage defaultMessage="Setting A" />
+                                      </div>
+                                      <div className="wizard-pf-review-item-field">
+                                        <FormattedMessage defaultMessage="Setting B" />
+                                      </div>
                                     </div>
                                   </form>
                                 </div>
@@ -320,7 +340,7 @@ class WizardView extends React.Component {
                   <div className="wizard-pf-contents hidden">
                     <div className="wizard-pf-process blank-slate-pf">
                       <div className="spinner spinner-lg blank-slate-pf-icon"></div>
-                      <h3 className="blank-slate-pf-main-action">Deployment in progress</h3>
+                      <h3 className="blank-slate-pf-main-action"><FormattedMessage defaultMessage="Deployment in progress" /></h3>
                       <p className="blank-slate-pf-secondary-action">Lorem ipsum dolor sit amet,
                       porta at suspendisse ac, ut wisi
                       vivamus, lorem sociosqu eget nunc amet. </p>
@@ -329,12 +349,14 @@ class WizardView extends React.Component {
                       <div className="wizard-pf-success-icon">
                         <span className="glyphicon glyphicon-ok-circle"></span>
                       </div>
-                      <h3 className="blank-slate-pf-main-action">Deployment was successful</h3>
+                      <h3 className="blank-slate-pf-main-action">
+                        <FormattedMessage defaultMessage="Deployment was successful" />
+                      </h3>
                       <p className="blank-slate-pf-secondary-action">Lorem ipsum dolor sit amet,
                       porta at suspendisse ac, ut wisi
                       vivamus, lorem sociosqu eget nunc amet. </p>
                       <button type="button" className="btn btn-lg btn-primary">
-                        View Deployment
+                        <FormattedMessage defaultMessage="View Deployment" />
                       </button>
 
                     </div>
@@ -349,24 +371,24 @@ class WizardView extends React.Component {
                 type="button"
                 className="btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss"
                 onClick={this.handleClose}
-              >Cancel</button>
+              ><FormattedMessage defaultMessage="Cancel" /></button>
               <button type="button" className="btn btn-default wizard-pf-back disabled">
                 <span className="i fa fa-angle-left"></span>
-                Back
+                <FormattedMessage defaultMessage="Back" />
               </button>
               <button type="button" className="btn btn-primary wizard-pf-next disabled">
-                Next
+                <FormattedMessage defaultMessage="Next" />
                 <span className="i fa fa-angle-right"></span>
               </button>
               <button type="button" className="btn btn-primary hidden wizard-pf-finish">
-                Deploy
+                <FormattedMessage defaultMessage="Deploy" />
                 <span className="i fa fa-angle-right"></span>
               </button>
               <button
                 type="button"
                 className="btn btn-primary hidden wizard-pf-close wizard-pf-dismiss"
                 onClick={this.handleClose}
-              >Close</button>
+              ><FormattedMessage defaultMessage="Close" /></button>
 
             </div>{/* .wizard-pf-footer */}
           </div>{/* /.modal-content */}
@@ -378,6 +400,7 @@ class WizardView extends React.Component {
 
 WizardView.propTypes = {
   handleClose: PropTypes.func,
+  intl: intlShape.isRequired,
 };
 
-export default WizardView;
+export default injectIntl(WizardView);

--- a/data/NotificationsApi.js
+++ b/data/NotificationsApi.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 
 class NotificationsApi {
   constructor() {
@@ -34,8 +35,15 @@ class NotificationsApi {
       case 'creating': {
         notification = {
           type: 'process',
-          message: <span><strong>{blueprint}:</strong> Creating image.</span>,
-          action: <a href="#">Cancel</a>,
+          message: <span>
+            <FormattedMessage
+              defaultMessage="{blueprint} Creating image."
+              values={{
+                blueprint: <strong>{blueprint}:</strong>
+              }}
+            />
+          </span>,
+          action: <a href="#"><FormattedMessage defaultMessage="Cancel" /></a>,
           dismiss: true,
         };
         const index = this.notifications.length;
@@ -52,7 +60,14 @@ class NotificationsApi {
       case 'created': {
         notification = {
           type: 'success',
-          message: <span><strong>{blueprint}:</strong> Image creation is complete.</span>,
+          message: <span>
+            <FormattedMessage
+              defaultMessage="{blueprint} Image creation is complete."
+              values={{
+                blueprint: <strong>{blueprint}:</strong>
+              }}
+            />
+          </span>,
           // action: <a href="#void">Download (.iso)</a>,
           // this link will need to be implemented when the build process
           // is implemented; this function will need to be extended to handle
@@ -69,7 +84,14 @@ class NotificationsApi {
         notification = {
           type: 'process',
           label: 'committing',
-          message: <span><strong>{blueprint}:</strong> Committing blueprint.</span>,
+          message: <span>
+            <FormattedMessage
+              defaultMessage="{blueprint} Committing blueprint."
+              values={{
+                blueprint: <strong>{blueprint}:</strong>
+              }}
+            />
+          </span>,
           dismiss: true,
         };
         break;
@@ -78,7 +100,14 @@ class NotificationsApi {
         notification = {
           type: 'success',
           label: 'committed',
-          message: <span><strong>{blueprint}:</strong> Blueprint changes are committed.</span>,
+          message: <span>
+            <FormattedMessage
+              defaultMessage="{blueprint} Blueprint changes are committed."
+              values={{
+                blueprint: <strong>{blueprint}:</strong>
+              }}
+            />
+          </span>,
           dismiss: true,
           fade: true,
         };
@@ -87,7 +116,14 @@ class NotificationsApi {
       case 'commitFailed': {
         notification = {
           type: 'error',
-          message: <span><strong>{blueprint}:</strong> Commit failed.</span>,
+          message: <span>
+            <FormattedMessage
+              defaultMessage="{blueprint} Commit failed."
+              values={{
+                blueprint: <strong>{blueprint}:</strong>
+              }}
+            />
+          </span>,
           dismiss: true,
         };
         break;

--- a/main.js
+++ b/main.js
@@ -3,6 +3,8 @@ import 'whatwg-fetch';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {addLocaleData, IntlProvider} from 'react-intl';
+import enLocaleData from 'react-intl/locale-data/en';
 import FastClick from 'fastclick';
 import { Provider } from 'react-redux';
 import 'bootstrap';
@@ -15,8 +17,15 @@ import history from './core/history';
 let routes = require('./routes.json'); // Loaded with utils/routes-loader.js
 const container = document.getElementById('main');
 
+addLocaleData(enLocaleData);
+
 function renderComponent(component) {
-  ReactDOM.render(<Provider store={store}>{component}</Provider>, container);
+  ReactDOM.render(
+    <Provider store={store}>
+      <IntlProvider locale='en'>
+        {component}
+      </IntlProvider>
+    </Provider>, container);
 }
 
 // Find and render a web page matching the current URL path,

--- a/main.js
+++ b/main.js
@@ -17,14 +17,29 @@ import history from './core/history';
 let routes = require('./routes.json'); // Loaded with utils/routes-loader.js
 const container = document.getElementById('main');
 
+// TODO: select language to use
+let userLanguage = 'en';
+let translations = require('./build/translations.json');
+let messages = undefined;
+if (userLanguage in translations) {
+  messages = translations[userLanguage];
+}
+
+// TODO what other locale data should be loaded?
 addLocaleData(enLocaleData);
 
 function renderComponent(component) {
   ReactDOM.render(
     <Provider store={store}>
-      <IntlProvider locale='en'>
-        {component}
-      </IntlProvider>
+      {messages !== undefined ? (
+        <IntlProvider locale={userLanguage} messages={messages}>
+          {component}
+        </IntlProvider>
+      ) : (
+        <IntlProvider locale='en'>
+          {component}
+        </IntlProvider>
+      )}
     </Provider>, container);
 }
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "postcss-selector-matches": "^2.0.1",
     "postcss-selector-not": "^2.0.0",
     "react-hot-loader": "^3.0.0-beta.2",
+    "react-intl-po": "^2.2.2",
     "react-test-renderer": "^15.6.1",
     "s3": "^4.4.0",
     "style-loader": "^0.13.1",
@@ -93,7 +94,8 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
     "webpack-dev-middleware": "^1.6.1",
-    "webpack-hot-middleware": "^2.12.2"
+    "webpack-hot-middleware": "^2.12.2",
+    "zanata-js": "^2.1.4"
   },
   "jest": {
     "testRegex": "(/test/unit/.*\\.spec.js)$",
@@ -159,13 +161,15 @@
     "stylelint": "stylelint \"components/**/*.css\" \"pages/**/*.css\"",
     "lint": "npm run eslint && npm run stylelint",
     "clean": "node run clean",
-    "build": "node run build",
+    "build": "npm run translations:pull && node run build",
     "build:debug": "node run build --debug",
     "publish": "node run publish",
     "publish:debug": "node run publish --debug",
     "start": "node run",
     "test": "jest",
     "test:watch": "npm test -- --watch",
-    "test:cov": "npm test -- --coverage"
+    "test:cov": "npm test -- --coverage",
+    "translations:pull": "zanata-js project pull -v --po-dir build/po --pot-dir build/po && rip po2json 'build/po/*.po' -m 'build/messages/**/*.json' -o build/translations.json -c id",
+    "translations:push": "rip json2pot 'build/messages/**/*.json' -o build/po/welder-web.pot -c id && zanata-js project push -v --pot-dir build/po"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "patternfly-webcomponents": "0.0.8",
     "react": "^15.2.1",
     "react-dom": "^15.6.1",
+    "react-intl": "^2.4.0",
     "react-patternfly-shims": "0.0.2",
     "react-redux": "^5.0.5",
     "redux": "^3.6.0",
@@ -37,6 +38,8 @@
     "babel-jest": "^16.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-istanbul": "^4.1.4",
+    "babel-plugin-react-intl": "^2.4.0",
+    "babel-plugin-react-intl-auto": "^1.1.0",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
@@ -113,7 +116,19 @@
       "es2015"
     ],
     "plugins": [
-      "transform-runtime"
+      "transform-runtime",
+      [
+        "react-intl-auto",
+        {
+          "filebase": true
+        }
+      ],
+      [
+        "react-intl",
+        {
+          "messagesDir": "./build/messages/"
+        }
+      ]
     ]
   },
   "eslintConfig": {

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedDate, FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import Link from '../../components/Link';
 import Layout from '../../components/Layout';
@@ -24,6 +25,27 @@ import {
   componentsSortSetKey, componentsSortSetValue, dependenciesSortSetKey, dependenciesSortSetValue,
 } from '../../core/actions/sort';
 import { makeGetBlueprintById, makeGetSortedSelectedComponents, makeGetSortedDependencies } from '../../core/selectors';
+
+const messages = defineMessages({
+  blueprint: {
+    defaultMessage: "Blueprint"
+  },
+  emptyBlueprintTitle: {
+    defaultMessage: "Empty Blueprint"
+  },
+  emptyBlueprintMessage: {
+    defaultMessage: "There are no components listed in the blueprint. Edit the blueprint to add components."
+  },
+  noImagesTitle: {
+    defaultMessage: "No Images"
+  },
+  noImagesMessage: {
+    defaultMessage: "No images have been created from this blueprint."
+  },
+  filterPlaceholder: {
+    defaultMessage: "Filter By Name..."
+  }
+});
 
 class BlueprintPage extends React.Component {
   constructor() {
@@ -98,7 +120,7 @@ class BlueprintPage extends React.Component {
   }
 
   componentDidMount() {
-    document.title = 'Blueprint';
+    document.title = this.props.intl.formatMessage(messages.blueprint);
   }
 
   setNotifications() {
@@ -161,17 +183,21 @@ class BlueprintPage extends React.Component {
       activeComponent, activeComponentParent, activeComponentStatus,
     } = this.props.blueprintPage;
 
+    const { formatMessage } = this.props.intl;
+
     return (
       <Layout className="container-fluid" ref="layout">
         <header className="cmpsr-header">
           <ol className="breadcrumb">
-            <li><Link to="/blueprints">Back to Blueprints</Link></li>
+            <li><Link to="/blueprints"><FormattedMessage defaultMessage="Back to Blueprints" /></Link></li>
             <li className="active"><strong>{this.props.route.params.blueprint}</strong></li>
           </ol>
           <div className="cmpsr-header__actions">
             <ul className="list-inline">
               <li>
-                <Link to={`/edit/${this.props.route.params.blueprint}`} className="btn btn-default">Edit Blueprint</Link>
+                <Link to={`/edit/${this.props.route.params.blueprint}`} className="btn btn-default">
+                  <FormattedMessage defaultMessage="Edit Blueprint" />
+                </Link>
               </li>
               <li>
                 <button
@@ -181,7 +207,7 @@ class BlueprintPage extends React.Component {
                   data-target="#cmpsr-modal-crt-image"
                   type="button"
                 >
-                  Create Image
+                  <FormattedMessage defaultMessage="Create Image" />
                 </button>
               </li>
               <li>
@@ -198,9 +224,9 @@ class BlueprintPage extends React.Component {
                   </button>
                   <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
                     {selectedComponents.length &&
-                      <li><a href="#" onClick={this.handleShowModalExport}>Export</a></li>
+                      <li><a href="#" onClick={this.handleShowModalExport}><FormattedMessage defaultMessage="Export" /></a></li>
                     ||
-                      <li className="disabled"><a>Export</a></li>
+                      <li className="disabled"><a><FormattedMessage defaultMessage="Export" /></a></li>
                     }
                   </ul>
                 </div>
@@ -221,7 +247,7 @@ class BlueprintPage extends React.Component {
                 <dl className="dl-horizontal mt-">
                   <dt>Name</dt>
                   <dd>{blueprint.name}</dd>
-                  <dt>Description</dt>
+                  <dt><FormattedMessage defaultMessage="Description" /></dt>
                   {(editDescriptionVisible &&
                     <dd>
                       <div className="input-group">
@@ -247,15 +273,29 @@ class BlueprintPage extends React.Component {
                         <span className="pficon pficon-edit" />
                       </button>
                     </dd>}
-                  <dt>Install size</dt>
-                  <dd>2,678 KB</dd>
-                  <dt>Last modified date</dt>
-                  <dd>Thu,  9 Nov 2017</dd>
+                  <dt><FormattedMessage defaultMessage="Install size" /></dt>
+                  <dd>
+                    <FormattedMessage
+                      defaultMessage="{size, number} KB"
+                      values={{
+                        size: 2678
+                      }}
+                    />
+                  </dd>
+                  <dt><FormattedMessage defaultMessage="Last modified date" /></dt>
+                  <dd><FormattedDate
+                    value={new Date('2017-11-07T00:00:00')}
+                    year='numeric'
+                    weekday='short'
+                    month='short'
+                    day='numeric'
+                  />
+                  </dd>
                 </dl>
               </div>
               <div className="col-sm-6 col-lg-8">
                 <div className="cmpsr-summary-listview">
-                  <p><strong>Changes</strong></p>
+                  <p><strong><FormattedMessage defaultMessage="Changes" /></strong></p>
                   <div className="list-pf cmpsr-list-pf list-pf-stacked cmpsr-list-pf__compacted cmpsr-blueprint__changes">
                     {this.state.changes.map((change, i) => (
                       <ListItemChanges
@@ -286,19 +326,60 @@ class BlueprintPage extends React.Component {
                               aria-haspopup="true"
                               aria-expanded="false"
                             >
-                              Commit 5<span className="caret" />
+                              <FormattedMessage
+                                defaultMessage="Commit {commitNumber}"
+                                values={{
+                                  commitNumber: 5
+                                }}
+                              />
+                              <span className="caret" />
                             </button>
                             <ul className="dropdown-menu">
-                              <li><a>Commit 5</a></li>
-                              <li><a>Commit 4</a></li>
-                              <li><a>Commit 3</a></li>
-                              <li><a>Commit 2</a></li>
-                              <li><a>Commit 1</a></li>
+                              <li><a>
+                                <FormattedMessage
+                                  defaultMessage="Commit {commitNumber}"
+                                  values={{
+                                    commitNumber: 5
+                                  }}
+                                />
+                              </a></li>
+                              <li><a>
+                                <FormattedMessage
+                                  defaultMessage="Commit {commitNumber}"
+                                  values={{
+                                    commitNumber: 4
+                                  }}
+                                />
+                              </a></li>
+                              <li><a>
+                                <FormattedMessage
+                                  defaultMessage="Commit {commitNumber}"
+                                  values={{
+                                    commitNumber: 3
+                                  }}
+                                />
+                              </a></li>
+                              <li><a>
+                                <FormattedMessage
+                                  defaultMessage="Commit {commitNumber}"
+                                  values={{
+                                    commitNumber: 2
+                                  }}
+                                />
+                              </a></li>
+                              <li><a>
+                                <FormattedMessage
+                                  defaultMessage="Commit {commitNumber}"
+                                  values={{
+                                    commitNumber: 1
+                                  }}
+                                />
+                              </a></li>
                             </ul>
                           </div>
                         </div>
                         <div className="form-group toolbar-pf-filter">
-                          <label className="sr-only" htmlFor="filter">Name</label>
+                          <label className="sr-only" htmlFor="filter"><FormattedMessage defaultMessage="Name" /></label>
                           <div className="input-group">
                             <div className="input-group-btn">
                               <button
@@ -308,14 +389,19 @@ class BlueprintPage extends React.Component {
                                 aria-haspopup="true"
                                 aria-expanded="false"
                               >
-                                Name<span className="caret" />
+                                <FormattedMessage defaultMessage="Name" /><span className="caret" />
                               </button>
                               <ul className="dropdown-menu">
-                                <li><a>Name</a></li>
-                                <li><a>Version</a></li>
+                                <li><a><FormattedMessage defaultMessage="Name" /></a></li>
+                                <li><a><FormattedMessage defaultMessage="Version" /></a></li>
                               </ul>
                             </div>
-                            <input type="text" className="form-control" id="filter" placeholder="Filter By Name..." />
+                            <input
+                              type="text"
+                              className="form-control"
+                              id="filter"
+                              placeholder={formatMessage(messages.filterPlaceholder)}
+                            />
                           </div>
                         </div>
                         <div className="form-group">
@@ -327,11 +413,11 @@ class BlueprintPage extends React.Component {
                               aria-haspopup="true"
                               aria-expanded="false"
                             >
-                              Name<span className="caret" />
+                              <FormattedMessage defaultMessage="Name" /><span className="caret" />
                             </button>
                             <ul className="dropdown-menu">
-                              <li><a>Name</a></li>
-                              <li><a>Version</a></li>
+                              <li><a><FormattedMessage defaultMessage="Name" /></a></li>
+                              <li><a><FormattedMessage defaultMessage="Version" /></a></li>
                             </ul>
                           </div>
                           {this.props.componentsSortKey === 'name' && this.props.componentsSortValue === 'DESC' &&
@@ -364,12 +450,12 @@ class BlueprintPage extends React.Component {
                   </div>
                   {(selectedComponents === undefined || selectedComponents.length === 0) &&
                     <EmptyState
-                      title={'Empty Blueprint'}
-                      message={'There are no components listed in the blueprint. Edit the blueprint to add components.'}
+                      title={formatMessage(messages.emptyBlueprintTitle)}
+                      message={formatMessage(messages.emptyBlueprintMessage)}
                     >
                       <Link to={`/edit/${this.props.route.params.blueprint}`}>
                         <button className="btn btn-default btn-primary" type="button">
-                          Edit Blueprint
+                          <FormattedMessage defaultMessage="Edit Blueprint" />
                         </button>
                       </Link>
                     </EmptyState> ||
@@ -381,7 +467,9 @@ class BlueprintPage extends React.Component {
                     />}
                 </div>) ||
                 <div className="col-sm-12 cmpsr-component-details--view">
-                  <h3 className="cmpsr-panel__title cmpsr-panel__title--main">Component Details</h3>
+                  <h3 className="cmpsr-panel__title cmpsr-panel__title--main">
+                    <FormattedMessage defaultMessage="Component Details" />
+                  </h3>
                   <ComponentDetailsView
                     parent={this.props.route.params.blueprint}
                     component={activeComponent}
@@ -395,7 +483,10 @@ class BlueprintPage extends React.Component {
           <Tab tabTitle="Images" active={activeTab === 'Images'}>
             <div className="tab-container">
               {(this.state.images.length === 0 &&
-                <EmptyState title={'No Images'} message={'No images have been created from this blueprint.'}>
+                <EmptyState
+                  title={formatMessage(messages.noImagesTitle)} 
+                  message={formatMessage(messages.noImagesMessage)}
+                >
                   <button
                     className="btn btn-default"
                     id="cmpsr-btn-crt-image"
@@ -403,7 +494,7 @@ class BlueprintPage extends React.Component {
                     data-target="#cmpsr-modal-crt-image"
                     type="button"
                   >
-                    Create Image
+                    <FormattedMessage defaultMessage="Create Image" />
                   </button>
                 </EmptyState>) ||
                 <ListView className="cmpsr-blueprint__images cmpsr-list">
@@ -456,6 +547,7 @@ BlueprintPage.propTypes = {
   dependencies: PropTypes.array,
   componentsSortKey: PropTypes.string,
   componentsSortValue: PropTypes.string,
+  intl: intlShape.isRequired,
 };
 
 const makeMapStateToProps = () => {
@@ -534,4 +626,4 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(BlueprintPage);
+export default connect(makeMapStateToProps, mapDispatchToProps)(injectIntl(BlueprintPage));

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from 'react';
+import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import Link from '../../components/Link';
 import Layout from '../../components/Layout';
@@ -31,6 +32,21 @@ import {
 import {
   makeGetBlueprintById, makeGetSortedSelectedComponents, makeGetSortedDependencies, makeGetFutureLength, makeGetPastLength
 } from '../../core/selectors';
+
+const messages = defineMessages({
+  addComponentTitle: {
+    defaultMessage: "Add Blueprint Components"
+  },
+  addComponentMessage: {
+    defaultMessage: "Browse or search for components, then add them to the blueprint."
+  },
+  blueprintTitle: {
+    defaultMessage: "Blueprint"
+  },
+  filterByPlaceholder: {
+    defaultMessage: "Filter By Name..."
+  }
+});
 
 class EditBlueprintPage extends React.Component {
   constructor() {
@@ -63,7 +79,7 @@ class EditBlueprintPage extends React.Component {
   }
 
   componentDidMount() {
-    document.title = 'Blueprint';
+    document.title = this.props.intl.formatMessage(messages.blueprintTitle);
   }
 
   componentWillUnmount() {
@@ -414,6 +430,8 @@ class EditBlueprintPage extends React.Component {
       + blueprint.workspacePendingChanges.addedChanges.length
       + blueprint.workspacePendingChanges.deletedChanges.length;
 
+    const { formatMessage } = this.props.intl;
+
     return (
       <Layout
         className="cmpsr-grid__wrapper"
@@ -423,44 +441,48 @@ class EditBlueprintPage extends React.Component {
       >
         <header className="cmpsr-header">
           <ol className="breadcrumb">
-            <li><Link to="/blueprints">Back to Blueprints</Link></li>
+            <li><Link to="/blueprints"><FormattedMessage defaultMessage="Back to Blueprints" /></Link></li>
             <li><Link to={`/blueprint/${blueprintDisplayName}`}>{blueprintDisplayName}</Link></li>
-            <li className="active"><strong>Edit Blueprint</strong></li>
+            <li className="active"><strong><FormattedMessage defaultMessage="Edit Blueprint" /></strong></li>
           </ol>
           <div className="cmpsr-header__actions">
             <ul className="list-inline">
               {numPendingChanges > 0 &&
                 <li>
                   <a href="#" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>
-                    {numPendingChanges !== 1 &&
-                      <span>{numPendingChanges} Pending Changes</span>
-                    ||
-                      <span>1 Pending Change</span>
-                    }
+                    <FormattedMessage
+                      defaultMessage="{pendingChanges, plural,
+                        one {# Pending Change}
+                        other {# Pending Changes}
+                        }"
+                      values={{
+                        pendingChanges: numPendingChanges
+                      }}
+                    />
                   </a>
                 </li>
               }
               {numPendingChanges > 0 &&
                 <li>
                   <button className="btn btn-primary" onClick={e => this.handleShowModal(e, 'modalPendingChanges')}>
-                    Commit
+                    <FormattedMessage defaultMessage="Commit" />
                   </button>
                 </li>
               ||
                 <li>
-                  <button className="btn btn-primary disabled" type="button">Commit</button>
+                  <button className="btn btn-primary disabled" type="button"><FormattedMessage defaultMessage="Commit" /></button>
                 </li>
               }
               {numPendingChanges > 0 &&
                 <li>
                   <button className="btn btn-default" type="button" onClick={this.handleDiscardChanges}>
-                    Discard Changes
+                    <FormattedMessage defaultMessage="Discard Changes" />
                   </button>
                 </li>
               ||
                 <li>
                   <button className="btn btn-default disabled" type="button">
-                    Discard Changes
+                    <FormattedMessage defaultMessage="Discard Changes" />
                   </button>
                 </li>
               }
@@ -472,7 +494,7 @@ class EditBlueprintPage extends React.Component {
                   data-target="#cmpsr-modal-crt-image"
                   type="button"
                 >
-                  Create Image
+                  <FormattedMessage defaultMessage="Create Image" />
                 </button>
               </li>
               <li>
@@ -489,9 +511,13 @@ class EditBlueprintPage extends React.Component {
                   </button>
                   <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
                     {selectedComponents.length &&
-                      <li><a href="#" onClick={e => this.handleShowModal(e, 'modalExportBlueprint')}>Export</a></li>
+                      <li><a href="#" onClick={e => this.handleShowModal(e, 'modalExportBlueprint')}>
+                        <FormattedMessage defaultMessage="Export" />
+                      </a></li>
                     ||
-                      <li className="disabled"><a>Export</a></li>
+                      <li className="disabled"><a>
+                        <FormattedMessage defaultMessage="Export" />
+                      </a></li>
                     }
                   </ul>
                 </div>
@@ -503,13 +529,24 @@ class EditBlueprintPage extends React.Component {
           <div className="cmpsr-title">
             <h1 className="cmpsr-title__item">{blueprintDisplayName}</h1>
             <p className="cmpsr-title__item">
-              <span className="text-muted">Total Disk Space: 1,234 KB</span>
+              <span className="text-muted">
+                <FormattedMessage
+                  defaultMessage="Total Disk Space: {space, number} KB"
+                  values={{
+                    space: 1234
+                  }}
+                />
+              </span>
             </p>
           </div>
         </header>
         {(inputs.selectedInput !== undefined && inputs.selectedInput.component === '' &&
-          <h3 className="cmpsr-panel__title cmpsr-panel__title--main">Blueprint Components</h3>) ||
-          <h3 className="cmpsr-panel__title cmpsr-panel__title--main">Component Details</h3>}
+          <h3 className="cmpsr-panel__title cmpsr-panel__title--main">
+            <FormattedMessage defaultMessage="Blueprint Components" />
+          </h3>) ||
+          <h3 className="cmpsr-panel__title cmpsr-panel__title--main">
+            <FormattedMessage defaultMessage="Component Details" />
+          </h3>}
         {(inputs.selectedInput !== undefined && inputs.selectedInput.component === '' &&
           <div className="cmpsr-panel__body cmpsr-panel__body--main">
           {componentsSortKey !== undefined && componentsSortValue !== undefined &&
@@ -529,8 +566,8 @@ class EditBlueprintPage extends React.Component {
           }
             {((selectedComponents === undefined || selectedComponents.length === 0) &&
               <EmptyState
-                title={'Add Blueprint Components'}
-                message={'Browse or search for components, then add them to the blueprint.'}
+                title={formatMessage(messages.addComponentTitle)}
+                message={formatMessage(messages.addComponentMessage)}
               />) ||
               <BlueprintContents
                 components={selectedComponents}
@@ -551,13 +588,17 @@ class EditBlueprintPage extends React.Component {
             handleRemoveComponent={this.handleRemoveComponent}
           />}
 
-        <h3 className="cmpsr-panel__title cmpsr-panel__title--sidebar">Available Components</h3>
+        <h3 className="cmpsr-panel__title cmpsr-panel__title--sidebar">
+          <FormattedMessage defaultMessage="Available Components" />
+        </h3>
         <div className="cmpsr-panel__body cmpsr-panel__body--sidebar">
 
           <div className="toolbar-pf">
             <form className="toolbar-pf-actions">
               <div className="form-group toolbar-pf-filter">
-                <label className="sr-only" htmlFor="cmpsr-blueprint-input-filter">Name</label>
+                <label className="sr-only" htmlFor="cmpsr-blueprint-input-filter">
+                  <FormattedMessage defaultMessage="Name" />
+                </label>
                 <div className="input-group">
                   <div className="input-group-btn">
                     <button
@@ -567,22 +608,22 @@ class EditBlueprintPage extends React.Component {
                       aria-haspopup="true"
                       aria-expanded="false"
                     >
-                      Name <span className="caret" />
+                      <FormattedMessage defaultMessage="Name" /> <span className="caret" />
                     </button>
                     <ul className="dropdown-menu">
-                      <li><a href="#">Type</a></li>
-                      <li><a href="#">Name</a></li>
-                      <li><a href="#">Version</a></li>
-                      <li><a href="#">Release</a></li>
-                      <li><a href="#">Lifecycle</a></li>
-                      <li><a href="#">Support Level</a></li>
+                      <li><a href="#"><FormattedMessage defaultMessage="Type" /></a></li>
+                      <li><a href="#"><FormattedMessage defaultMessage="Name" /></a></li>
+                      <li><a href="#"><FormattedMessage defaultMessage="Version" /></a></li>
+                      <li><a href="#"><FormattedMessage defaultMessage="Release" /></a></li>
+                      <li><a href="#"><FormattedMessage defaultMessage="Lifecycle" /></a></li>
+                      <li><a href="#"><FormattedMessage defaultMessage="Support Level" /></a></li>
                     </ul>
                   </div>
                   <input
                     type="text"
                     className="form-control"
                     id="cmpsr-blueprint-input-filter"
-                    placeholder="Filter By Name..."
+                    placeholder={formatMessage(messages.filterByPlaceholder)}
                     onKeyPress={e => this.getFilteredInputs(e)}
                   />
                 </div>
@@ -605,14 +646,16 @@ class EditBlueprintPage extends React.Component {
                 <ul className="list-inline">
                   <li>
                     <span className="label label-info">
-                      Name: {inputs.inputFilters.value}
+                      <FormattedMessage defaultMessage="Name:" /> {inputs.inputFilters.value}
                       <a href="#" onClick={e => this.handleClearFilters(e)}>
                         <span className="pficon pficon-close" />
                       </a>
                     </span>
                   </li>
                   <li>
-                    <a href="#" onClick={e => this.handleClearFilters(e)}>Clear All Filters</a>
+                    <a href="#" onClick={e => this.handleClearFilters(e)}>
+                      <FormattedMessage defaultMessage="Clear All Filters" />
+                    </a>
                   </li>
                 </ul>}
               <Pagination
@@ -630,7 +673,12 @@ class EditBlueprintPage extends React.Component {
               <span className="pficon pficon-close" />
             </button>
             <span className="pficon pficon-info" />
-            <strong>Select components</strong> in this list to add to the blueprint.
+            <FormattedMessage
+              defaultMessage="{selectComponents} in this list to add to the blueprint."
+              values={{
+                selectComponents: <strong><FormattedMessage defaultMessage="Select components" /></strong>
+              }}
+            />
           </div>
           {inputs.inputComponents !== undefined &&
             <ComponentInputs
@@ -701,6 +749,7 @@ EditBlueprintPage.propTypes = {
   redo: PropTypes.func,
   commitToWorkspace: PropTypes.func,
   deleteHistory: PropTypes.func,
+  intl: intlShape.isRequired,
 };
 
 const makeMapStateToProps = () => {
@@ -811,4 +860,4 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(EditBlueprintPage);
+export default connect(makeMapStateToProps, mapDispatchToProps)(injectIntl(EditBlueprintPage));

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import Layout from '../../components/Layout';
 import BlueprintListView from '../../components/ListView/BlueprintListView';
@@ -20,6 +21,22 @@ import {
 import { blueprintsSortSetKey, blueprintsSortSetValue } from '../../core/actions/sort';
 import { makeGetSortedBlueprints } from '../../core/selectors';
 
+const messages = defineMessages({
+  blueprintsTitle: {
+    defaultMessage: "Blueprints"
+  },
+  emptyTitle: {
+    defaultMessage: "No Blueprints",
+  },
+  emptyMessage: {
+    defaultMessage: "Create a blueprint to define the contents that will be included in the images you create. " +
+                    "Images can be produced in a variety of output formats."
+  },
+  filterByPlaceholder: {
+    defaultMessage: "Filter By Name..."
+  }
+});
+
 class BlueprintsPage extends React.Component {
   constructor() {
     super();
@@ -35,7 +52,7 @@ class BlueprintsPage extends React.Component {
   }
 
   componentDidMount() {
-    document.title = 'Blueprints';
+    document.title = this.props.intl.formatMessage(messages.blueprintsTitle);
   }
 
   setNotifications() {
@@ -87,13 +104,14 @@ class BlueprintsPage extends React.Component {
 
   render() {
     const { blueprints, exportBlueprint, deleteBlueprint, createImage, blueprintSortKey, blueprintSortValue } = this.props;
+    const { formatMessage } = this.props.intl;
     return (
       <Layout className="container-fluid" ref="layout">
         <div className="row toolbar-pf">
           <div className="col-sm-12">
             <form className="toolbar-pf-actions">
               <div className="form-group toolbar-pf-filter">
-                <label className="sr-only" htmlFor="filter">Name</label>
+                <label className="sr-only" htmlFor="filter"><FormattedMessage defaultMessage="Name" /></label>
                 <div className="input-group">
                   <div className="input-group-btn">
                     <button
@@ -103,14 +121,19 @@ class BlueprintsPage extends React.Component {
                       aria-haspopup="true"
                       aria-expanded="false"
                     >
-                      Name<span className="caret" />
+                      <FormattedMessage defaultMessage="Name" /><span className="caret" />
                     </button>
                     <ul className="dropdown-menu">
-                      <li><a>Name</a></li>
-                      <li><a>Version</a></li>
+                      <li><a><FormattedMessage defaultMessage="Name" /></a></li>
+                      <li><a><FormattedMessage defaultMessage="Version" /></a></li>
                     </ul>
                   </div>
-                  <input type="text" className="form-control" id="filter" placeholder="Filter By Name..." />
+                  <input
+                    type="text" 
+                    className="form-control"
+                    id="filter"
+                    placeholder={formatMessage(messages.filterByPlaceholder)}
+                  />
                 </div>
               </div>
               <div className="form-group">
@@ -122,11 +145,11 @@ class BlueprintsPage extends React.Component {
                     aria-haspopup="true"
                     aria-expanded="false"
                   >
-                    Name<span className="caret" />
+                    <FormattedMessage defaultMessage="Name" /><span className="caret" />
                   </button>
                   <ul className="dropdown-menu">
-                    <li><a>Name</a></li>
-                    <li><a>Version</a></li>
+                    <li><a><FormattedMessage defaultMessage="Name" /></a></li>
+                    <li><a><FormattedMessage defaultMessage="Version" /></a></li>
                   </ul>
                 </div>
               {blueprintSortKey === 'name' && blueprintSortValue === 'DESC' &&
@@ -143,7 +166,7 @@ class BlueprintsPage extends React.Component {
               <div className="toolbar-pf-action-right">
                 <div className="form-group">
                   <button className="btn btn-default" type="button" data-toggle="modal" data-target="#cmpsr-modal-crt-blueprint">
-                    Create Blueprint
+                    <FormattedMessage defaultMessage="Create Blueprint" />
                   </button>
                 </div>
               </div>
@@ -152,10 +175,8 @@ class BlueprintsPage extends React.Component {
         </div>
       {blueprints.length === 0 &&
         <EmptyState
-          title="No Blueprints"
-          message={`Create a blueprint to define the contents that will be included
-            in the images you create. Images can be produced in a variety of
-            output formats.`}
+          title={formatMessage(messages.emptyTitle)}
+          message={formatMessage(messages.emptyMessage)}
         >
           <button
             className="btn btn-primary btn-lg"
@@ -163,7 +184,7 @@ class BlueprintsPage extends React.Component {
             data-toggle="modal"
             data-target="#cmpsr-modal-crt-blueprint"
           >
-            Create Blueprint
+            <FormattedMessage defaultMessage="Create Blueprint" />
           </button>
         </EmptyState>
       }
@@ -213,6 +234,7 @@ BlueprintsPage.propTypes = {
   blueprintSortValue: PropTypes.string,
   blueprintsSortSetKey: PropTypes.func,
   blueprintsSortSetValue: PropTypes.func,
+  intl: intlShape.isRequired,
 };
 
 const makeMapStateToProps = () => {
@@ -275,4 +297,4 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(BlueprintsPage);
+export default connect(makeMapStateToProps, mapDispatchToProps)(injectIntl(BlueprintsPage));

--- a/pages/error/index.js
+++ b/pages/error/index.js
@@ -1,8 +1,24 @@
 import React from 'react';
+import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import history from '../../core/history';
 import Link from '../../components/Link';
 import s from './styles.css';
+
+const messages = defineMessages({
+  errorMessage: {
+    defaultMessage: "Error"
+  },
+  pageNotFoundMessage: {
+    defaultMessage: "Page Not Found"
+  },
+  pageNotFoundTitle: {
+    defaultMessage: "Page not found"
+  },
+  oupsTitle: {
+    defaultMessage: "Oups, something went wrong"
+  }
+});
 
 class ErrorPage extends React.Component {
   constructor() {
@@ -12,7 +28,8 @@ class ErrorPage extends React.Component {
 
   componentDidMount() {
     document.title = this.props.error && this.props.error.status === 404 ?
-      'Page Not Found' : 'Error';
+      this.props.intl.formatMessage(messages.pageNotFoundMessage) :
+      this.props.intl.formatMessage(messages.errorMessage);
   }
 
   goBack(event) {
@@ -21,11 +38,13 @@ class ErrorPage extends React.Component {
   }
 
   render() {
+    const { formatMessage } = this.props.intl;
+
     if (this.props.error) console.error(this.props.error); // eslint-disable-line no-console
 
     const [code, title] = this.props.error && this.props.error.status === 404 ?
-      ['404', 'Page not found'] :
-      ['Error', 'Oups, something went wrong'];
+      ['404', formatMessage(messages.pageNotFoundTitle)] :
+      ['Error', formatMessage(messages.oupsTitle)];
 
     return (
       <div className={s.container}>
@@ -34,12 +53,17 @@ class ErrorPage extends React.Component {
           <p className={s.title}>{title}</p>
           {code === '404' &&
             <p className={s.text}>
-              The page you're looking for does not exist or an another error occurred.
+              <FormattedMessage defaultMessage="The page you're looking for does not exist or an another error occurred." />
             </p>
           }
           <p className={s.text}>
-            <a href="/" onClick={this.goBack}>Go back</a>, or head over to the&nbsp;
-            <Link to="/">home page</Link> to choose a new direction.
+            <FormattedMessage
+              defaultMessage="{goBack}, or head over to the&nbsp;{homePage} to choose a new direction."
+              values={{
+                goBack: <a href="/" onClick={this.goBack}><FormattedMessage defaultMessage="Go back" /></a>,
+                homePage: <Link to="/"><FormattedMessage defaultMessage="home page" /></Link>
+              }}
+            />
           </p>
         </main>
       </div>
@@ -50,6 +74,7 @@ class ErrorPage extends React.Component {
 
 ErrorPage.propTypes = {
   error: PropTypes.object,
+  intl: intlShape.isRequired,
 };
 
-export default ErrorPage;
+export default injectIntl(ErrorPage);

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<config xmlns="http://zanata.org/namespace/config">
+  <url>https://fedora.zanata.org/</url>
+  <project>welder-web</project>
+  <project-version>master</project-version>
+  <project-type>gettext</project-type>
+
+</config>


### PR DESCRIPTION
There's a lot missing. These commits can hopefully get things started, by providing the framework for marking translatable messages and retrieving the translations for those messages from Zanata.

The basic idea with react-intl is that anything translatable should be wrapped in a <FormattedMessage> component, and I'll write up a blog post with more of the details on how to go about that. I went ahead and did that for everything I could, though I probably missed some here and there. Additionally, I did not touch two of the components files because I think they might need some extra work to make them translatable: components/Modal/PendingChanges.js appears to split sentences up across columns, which doesn't really work. components/Pagination/Pagination.js also has a bunch of markup interleaved with the text; this one might be usable as-is, but I got pretty confused about what is being displayed and how, so someone else can handle that one.

Besides those components and any other strings that I missed, the main thing missing is actually selecting a language. I don't know how to do that, and I don't know how cockpit handles that, so that's something that needs to be solved. Related to that, react-intl requires that locale data be loaded for any languages being used (like the import at https://github.com/weldr/welder-web/compare/master...dashea:i18n-react-intl?expand=1#diff-7a9076d6d94e62c13d641aa71f19ae8eR7 plus the addLocaleData call a few lines down), so we'll need some way of defining or generating that list of locales to load.

There is another npm module, 'react-intl-redux', that combines the react-intl <IntlProvider> and the redux <Provider>, so that might also be something we want to use?