### PR TITLE
fix layout issue with Edit page

### DIFF
--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -502,9 +502,6 @@ class EditBlueprintPage extends React.Component {
           </div>
           <div className="cmpsr-title">
             <h1 className="cmpsr-title__item">{blueprintDisplayName}</h1>
-            <p className="cmpsr-title__item">
-              <span className="text-muted">Total Disk Space: 1,234 KB</span>
-            </p>
           </div>
         </header>
         {(inputs.selectedInput !== undefined && inputs.selectedInput.component === '' &&

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,11 +1,4 @@
-[data-toggle] {
-  cursor: pointer;
-}
-/* This is added for the export dialog so that the contents have higher contrast */
-textarea.form-control[readonly] {
-  background-color: inherit;
-  color: inherit;
-}
+
 /* Blueprint Edit layout */
 .cmpsr-grid__wrapper {
   display: grid;
@@ -20,8 +13,9 @@ textarea.form-control[readonly] {
     "inputs edit";
   overflow: auto;
   position: absolute;
-  top: 60px;
+  top: 0;
   bottom: 0;
+  width: 100%;
 }
 /* Blueprint Edit page header */
 .cmpsr-grid__wrapper .cmpsr-header {
@@ -340,10 +334,13 @@ textarea.form-control[readonly] {
 /* ------------------------------- */
 /* modifications to patternfly css */
 
-/* masthead */
-/* without an icon in the masthead, the logo sits too high relative to other elements */
-.navbar-brand {
-  line-height: 35px;
+/* body displays in an iframe without nav */
+/* resetting body so that grid layout can fill page */
+body, html {
+  height: 100%;
+}
+body {
+  position: relative;
 }
 
 /* empty state */
@@ -365,4 +362,14 @@ textarea.form-control[readonly] {
 /* disable pointer events for both <a> and <button> */
 .btn.disabled, fieldset[disabled] .btn {
     pointer-events: none;
+}
+
+[data-toggle] {
+  cursor: pointer;
+}
+
+/* This is added for the export dialog so that the contents have higher contrast */
+textarea.form-control[readonly] {
+  background-color: inherit;
+  color: inherit;
 }


### PR DESCRIPTION
This update fixes an issue where a large margin displays above the contents of the Edit Blueprint page, as shown in the following image:

![screenshot from 2018-04-19 23-01-03](https://user-images.githubusercontent.com/21063328/39946030-9d24d4d6-553a-11e8-9c31-5bd6791cec19.png)
