### PR TITLE
Test target for cockpit composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ cockpit-composer-rpm: dist-gzip cockpit-composer.spec
 	find `pwd`/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
 	rm -r "`pwd`/rpmbuild"
 
+# targets used by Jenkins to execute rpmbuild sanity tests
+test_rpmbuild: srpm rpm
+test_rpmbuild_cockpit-composer: cockpit-composer-srpm cockpit-composer-rpm
+
 eslint:
 	npm run eslint
 


### PR DESCRIPTION
Depends on #237.
Adds two targets which are used by Jenkins to schedule RPM builds and do some sanity tests on the resulting RPMs.

ATM we don't do any sanity testing, just build the artifacts.