### PR TITLE
Fix the version number generated for copr builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -2,6 +2,6 @@ makedir := $(dir $(lastword $(MAKEFILE_LIST)))
 topdir  := $(makedir)/..
 
 srpm:
-	dnf -y install npm jq
+	dnf -y install npm jq git
 	$(MAKE) -C $(topdir) srpm
 	cp $(topdir)/*.src.rpm $(outdir)

--- a/rpmversion.sh
+++ b/rpmversion.sh
@@ -2,7 +2,8 @@
 
 # Generate the version and release strings to use in the spec file.
 # The output of this script is "<VERSION>-<RELEASE>",
-# e.g. something gross but fully guildelines compliant like "0.0.1-39.0.20180516gita13e5bd%{?dist}"
+# where <RELEASE> is 1 for the actual release tag, 2 for one commit after the
+# release, and so on.
 
 # Try to git describe. If that fails, just fall back to the version in package.json
 gitdesc="$(git describe --exclude '*jenkins*' 2>/dev/null)"
@@ -11,14 +12,12 @@ if [ $? -ne 0 ]; then
 else
     # Git describe will output either "<version>" for an exact match,
     # or "<version>-<number of commits since version>-g<hash>" if HEAD is newer than the tag
-    # Check for the case without any extra junk
     if ! echo "$gitdesc" | grep -q -- - ;then
         echo "${gitdesc}-1%{?dist}"
     else
+        # Add 1 to the number of commits
         version="$(echo "$gitdesc" | sed 's/-.*//')"
-        pkgrel="$(echo "$gitdesc" | sed 's/.*-\([[:digit:]]\+\)-g.*/\1/')"
-        snapinfo_commit="$(echo "$gitdesc" | sed 's/.*-g//')"
-        today="$(date +%Y%m%d)"
-        echo "${version}-${pkgrel}.0.${today}git${snapinfo_commit}%{?dist}"
+        pkgrel="$(("$(echo "$gitdesc" | sed 's/.*-\([[:digit:]]\+\)-g.*/\1/')" + 1))"
+        echo "${version}-${pkgrel}%{?dist}"
     fi
 fi


### PR DESCRIPTION
Make git available during `make srpm`, and make the release number something less horrible