### PR TITLE
core: Use escalated privileges to access Lorax API if possible

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -12,9 +12,11 @@ welderApiScheme = welderApiScheme || 'http';
 function setupCockpitHttp() {
   const useHttps = welderApiScheme === 'https';
   const port = welderApiPort || (useHttps ? 443 : 80);
+  const superUser = welderApiPort ? "try" : undefined;
   cockpitHttp = cockpit.http(port, {
     address: welderApiHost,
     tls: useHttps ? {} : undefined,
+    superuser: superUser
   });
 }
 


### PR DESCRIPTION
If the logged in Cockpit user can escalate privileges (ie: sudo)
then use this to access the Lorax API.

Without this, users who are non-root and not in the weldr group
will fail access to composer. This failure can be seen in the
Javascript Console and results in:

    cockpitFetch: ... failed: Not permitted to perform this action.