### PR TITLE
Fix style of pagination input under available components

### DIFF
--- a/components/Pagination/Pagination.js
+++ b/components/Pagination/Pagination.js
@@ -54,7 +54,7 @@ class Pagination extends React.Component {
     if (this.state.pageValue !== '') {
       pageInput = (
         <input
-          className="pagination-pf-page"
+          className="pagination-pf-page form-control"
           ref="paginationPage"
           type="text" value={this.state.pageValue + 1}
           id="cmpsr-blueprint-inputs-page"
@@ -68,7 +68,7 @@ class Pagination extends React.Component {
     } else {
       pageInput = (
         <input
-          className="pagination-pf-page"
+          className="pagination-pf-page form-control"
           ref="paginationPage"
           type="text" value=""
           id="cmpsr-blueprint-inputs-page"


### PR DESCRIPTION
Under Firefox on Linux the pagination input rendered to tall due
to the element not having the form-control class, like the other
inputs on the page. This fixes that.

Fixes issue #175