### PR TITLE
Blueprints page UI refinements

### DIFF
--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -6,6 +6,7 @@ import ListView from '../../components/ListView/ListView';
 import ListItemComponents from '../../components/ListView/ListItemComponents';
 import DependencyListView from '../../components/ListView/DependencyListView';
 import EmptyState from '../../components/EmptyState/EmptyState';
+import Loading from '../../components/Loading/Loading';
 
 class BlueprintContents extends React.Component {
   constructor() {
@@ -25,79 +26,96 @@ class BlueprintContents extends React.Component {
   render() {
     const {
       components, dependencies, handleComponentDetails, handleRemoveComponent,
-      noEditComponent, filterClearValues,
+      noEditComponent, filterClearValues, filterValues, errorState, fetchingState
     } = this.props;
 
     return (
       <div>
-        <Tabs
-          key={components.length}
-          ref={c => {
-            this.pfTabs = c;
-          }}
-          tabChanged={this.handleTabChanged}
-          classnames="nav nav-tabs nav-tabs-pf"
-        >
-          <Tab
-            tabTitle={`Selected Components <span class="badge">${components.length}</span>`}
-            active={this.state.activeTab === 'Selected'}
-          >
-            {components.length === 0 &&
-              <EmptyState
-                title="No Results Match the Filter Criteria"
-                message={`Modify your filter criteria to get results.`}
-              >
-                <button
-                  className="btn btn-link btn-lg"
-                  type="button"
-                  onClick={() => filterClearValues([])}
-                >
-                  Clear All Filters
-                </button>
-              </EmptyState>
-            ||
-              <ListView className="cmpsr-blueprint__components" stacked>
-                {components.map((listItem, i) => (
-                  <ListItemComponents
-                    listItemParent="cmpsr-blueprint__components"
-                    listItem={listItem}
-                    key={i}
-                    handleRemoveComponent={handleRemoveComponent}
-                    handleComponentDetails={handleComponentDetails}
-                    noEditComponent={noEditComponent}
-                  />
-                ))}
-              </ListView>
-            }
-          </Tab>
-          <Tab
-            tabTitle={`Dependencies <span class="badge">${dependencies.length}</span>`}
-            active={this.state.activeTab === 'Dependencies'}
-          >
-          {dependencies.length === 0 &&
-            <EmptyState
-              title="No Results Match the Filter Criteria"
-              message={`Modify your filter criteria to get results.`}
-            >
-              <button
-                className="btn btn-link btn-lg"
-                type="button"
-                onClick={() => filterClearValues([])}
-              >
-                Clear All Filters
-              </button>
-            </EmptyState>
+        {fetchingState === true &&
+          <Loading />
           ||
-            <DependencyListView
-              className="cmpsr-blueprint__dependencies"
-              listItems={dependencies}
-              handleRemoveComponent={handleRemoveComponent}
-              handleComponentDetails={handleComponentDetails}
-              noEditComponent={noEditComponent}
+          (errorState !== undefined &&
+            <EmptyState
+              title="An Error Occurred"
+              message="An error occurred while trying to get blueprint contents."
             />
-            }
-          </Tab>
-        </Tabs>
+            ||
+            ((components.length === 0 && filterValues.length === 0) &&
+              <div>
+                {this.props.children}
+              </div>
+              ||
+              <Tabs
+                key={components.length}
+                ref={c => {
+                  this.pfTabs = c;
+                }}
+                tabChanged={this.handleTabChanged}
+                classnames="nav nav-tabs nav-tabs-pf"
+              >
+                <Tab
+                  tabTitle={`Selected Components <span class="badge">${components.length}</span>`}
+                  active={this.state.activeTab === 'Selected'}
+                >
+                  {components.length === 0 &&
+                    <EmptyState
+                      title="No Results Match the Filter Criteria"
+                      message={`Modify your filter criteria to get results.`}
+                    >
+                      <button
+                        className="btn btn-link btn-lg"
+                        type="button"
+                        onClick={() => filterClearValues([])}
+                      >
+                        Clear All Filters
+                      </button>
+                    </EmptyState>
+                  ||
+                    <ListView className="cmpsr-blueprint__components" stacked>
+                      {components.map((listItem, i) => (
+                        <ListItemComponents
+                          listItemParent="cmpsr-blueprint__components"
+                          listItem={listItem}
+                          key={i}
+                          handleRemoveComponent={handleRemoveComponent}
+                          handleComponentDetails={handleComponentDetails}
+                          noEditComponent={noEditComponent}
+                        />
+                      ))}
+                    </ListView>
+                  }
+                </Tab>
+                <Tab
+                  tabTitle={`Dependencies <span class="badge">${dependencies.length}</span>`}
+                  active={this.state.activeTab === 'Dependencies'}
+                >
+                  {dependencies.length === 0 &&
+                    <EmptyState
+                      title="No Results Match the Filter Criteria"
+                      message={`Modify your filter criteria to get results.`}
+                    >
+                      <button
+                        className="btn btn-link btn-lg"
+                        type="button"
+                        onClick={() => filterClearValues([])}
+                      >
+                        Clear All Filters
+                      </button>
+                    </EmptyState>
+                  ||
+                    <DependencyListView
+                      className="cmpsr-blueprint__dependencies"
+                      listItems={dependencies}
+                      handleRemoveComponent={handleRemoveComponent}
+                      handleComponentDetails={handleComponentDetails}
+                      noEditComponent={noEditComponent}
+                    />
+                  }
+                </Tab>
+              </Tabs>
+            )
+          )
+        }
       </div>
     );
   }
@@ -110,6 +128,10 @@ BlueprintContents.propTypes = {
   handleRemoveComponent: PropTypes.func,
   noEditComponent: PropTypes.bool,
   filterClearValues: PropTypes.func,
+  filterValues: PropTypes.array,
+  errorState: PropTypes.object,
+  fetchingState: PropTypes.bool,
+  children: PropTypes.node,
 };
 
 export default BlueprintContents;

--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -9,11 +9,6 @@ class BlueprintListView extends React.PureComponent {
     super();
   }
 
-  handleCreateImage(blueprint) {
-    this.setState({ blueprint });
-    $('#cmpsr-modal-crt-image').modal('show');
-  }
-
   render() {
     const { blueprints } = this.props; // eslint-disable-line no-use-before-define
     return (
@@ -39,16 +34,24 @@ class BlueprintListView extends React.PureComponent {
                   <button
                     type="button"
                     className="btn btn-default"
-                    onClick={() => this.handleCreateImage(blueprint.name)}
+                    onClick={(e) => this.props.handleShowModalCreateImage(e, blueprint)}
                   >
                     Create Image
                   </button>
                 }
                 <div className="dropdown pull-right dropdown-kebab-pf">
-                  <button
-                    className="btn btn-default"
-                    onClick={(e) => this.props.handleShowModalCreateImage(e, blueprint)}
-                  >
+                   <button
+                     className="btn btn-link dropdown-toggle"
+                     type="button"
+                     id="dropdownKebabRight9"
+                     data-toggle="dropdown"
+                     aria-haspopup="true"
+                     aria-expanded="true"
+                   ><span className="fa fa-ellipsis-v"></span></button>
+                   <ul
+                     className="dropdown-menu dropdown-menu-right"
+                     aria-labelledby="dropdownKebabRight9"
+                   >
                     {(blueprint.modules.length === 0 && blueprint.packages.length === 0) &&
                       <li className="disabled"><a aria-disabled="true">Export</a></li>
                       ||
@@ -73,90 +76,71 @@ class BlueprintListView extends React.PureComponent {
                     <div
                       className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
                     >
-                      <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e, blueprint.name)}>Export</a></li>
-                      <li><a href="#" onClick={(e) => this.props.handleShowModalDelete(e, blueprint)}>Delete</a></li>
-                    </ul>
-                  </div>
-                </div>
-                <div className="list-view-pf-main-info">
-                  <span className="pficon pficon-template list-pf-icon-small"></span>
-                  <div className="list-view-pf-body">
-                    <div className="list-view-pf-description">
-                      <div className="list-group-item-heading">
-                        <Link to={`/blueprint/${blueprint.name}`}>{blueprint.name}</Link>
-                      </div>
-                      <div className="list-group-item-text">
-                        {blueprint.description}
-                      </div>
+                      Test<strong>2</strong></div>
+                    <div
+                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
+                    >
+                      Development<strong>0</strong>
                     </div>
-                    <div className="list-view-pf-additional-info hidden">
-                      <div
-                        className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
-                      >
-                        Test<strong>2</strong></div>
-                      <div
-                        className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
-                      >
-                        Development<strong>0</strong>
-                      </div>
-                      <div
-                        className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
-                      >
-                        Production<strong>1</strong>
-                      </div>
+                    <div
+                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
+                    >
+                      Production<strong>1</strong>
                     </div>
                   </div>
                 </div>
               </div>
-              <div className="list-group-item-container container-fluid hidden">
-                <div className="close hidden">
-                  <span className="pficon pficon-close"></span>
-                </div>
-                <div className="row">
-                  <div className="col-sm-12">
-                    <div className="list-group list-view-pf list-view-pf-view">
-                      <div className="list-group-item">
-                        <div className="list-view-pf-checkbox">
-                          <input type="checkbox" />
+            </div>
+
+            <div className="list-group-item-container container-fluid hidden">
+              <div className="close hidden">
+                <span className="pficon pficon-close"></span>
+              </div>
+              <div className="row">
+                <div className="col-sm-12">
+                  <div className="list-group list-view-pf list-view-pf-view">
+                    <div className="list-group-item">
+
+                      <div className="list-view-pf-checkbox">
+                        <input type="checkbox" />
+                      </div>
+                      <div className="list-view-pf-actions">
+                        <button className="btn btn-default">View Blueprint</button>
+                        <button className="btn btn-default">Download</button>
+                        <div className="dropdown pull-right dropdown-kebab-pf">
+                          <button
+                            className="btn btn-link dropdown-toggle"
+                            type="button"
+                            id="dropdownKebabRight12"
+                            data-toggle="dropdown"
+                            aria-haspopup="true"
+                            aria-expanded="true"
+                          >
+                            <span className="fa fa-ellipsis-v"></span>
+                          </button>
+                          <ul
+                            className="dropdown-menu dropdown-menu-right"
+                            aria-labelledby="dropdownKebabRight12"
+                          >
+                            <li><a >Action</a></li>
+                            <li><a >Another action</a></li>
+                            <li><a >Something else here</a></li>
+                            <li role="separator" className="divider"></li>
+                            <li><a >Separated link</a></li>
+                          </ul>
                         </div>
-                        <div className="list-view-pf-actions">
-                          <button className="btn btn-default">View Blueprint</button>
-                          <button className="btn btn-default">Download</button>
-                          <div className="dropdown pull-right dropdown-kebab-pf">
-                            <button
-                              className="btn btn-link dropdown-toggle"
-                              type="button"
-                              id="dropdownKebabRight12"
-                              data-toggle="dropdown"
-                              aria-haspopup="true"
-                              aria-expanded="true"
-                            >
-                              <span className="fa fa-ellipsis-v"></span>
-                            </button>
-                            <ul
-                              className="dropdown-menu dropdown-menu-right"
-                              aria-labelledby="dropdownKebabRight12"
-                            >
-                              <li><a >Action</a></li>
-                              <li><a >Another action</a></li>
-                              <li><a >Something else here</a></li>
-                              <li role="separator" className="divider"></li>
-                              <li><a >Separated link</a></li>
-                            </ul>
-                          </div>
+                      </div>
+                      <div className="list-view-pf-main-info">
+                        <div className="list-view-pf-left">
+                          <span className="fa fa-linux list-view-pf-icon-sm"></span>
                         </div>
-                        <div className="list-view-pf-main-info">
-                          <div className="list-view-pf-left">
-                            <span className="fa fa-linux list-view-pf-icon-sm"></span>
-                          </div>
-                          <div className="list-view-pf-body">
-                            <div className="list-view-pf-description">
-                              <div className="list-group-item-heading">
-                                Image 1
-                              </div>
-                              <div className="list-group-item-text">
-                                Created from Version 1
-                              </div>
+                        <div className="list-view-pf-body">
+                          <div className="list-view-pf-description">
+                            <div className="list-group-item-heading">
+                              Image 1
+                            </div>
+                            <div className="list-group-item-text">
+                              Created from Version 1
                             </div>
                           </div>
                         </div>

--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -27,7 +27,7 @@ class BlueprintListView extends React.PureComponent {
               <div className="list-view-pf-checkbox">
                 <input type="checkbox" />
               </div>
-              <div className="list-view-pf-actions">n
+              <div className="list-view-pf-actions">
                 <Link to={`/edit/${blueprint.name}`} className="btn btn-default">
                   Edit Blueprint
                 </Link>

--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -40,18 +40,18 @@ class BlueprintListView extends React.PureComponent {
                   </button>
                 }
                 <div className="dropdown pull-right dropdown-kebab-pf">
-                   <button
-                     className="btn btn-link dropdown-toggle"
-                     type="button"
-                     id="dropdownKebabRight9"
-                     data-toggle="dropdown"
-                     aria-haspopup="true"
-                     aria-expanded="true"
-                   ><span className="fa fa-ellipsis-v"></span></button>
-                   <ul
-                     className="dropdown-menu dropdown-menu-right"
-                     aria-labelledby="dropdownKebabRight9"
-                   >
+                  <button
+                    className="btn btn-link dropdown-toggle"
+                    type="button"
+                    id="dropdownKebabRight9"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="true"
+                  ><span className="fa fa-ellipsis-v"></span></button>
+                  <ul
+                    className="dropdown-menu dropdown-menu-right"
+                    aria-labelledby="dropdownKebabRight9"
+                  >
                     {(blueprint.modules.length === 0 && blueprint.packages.length === 0) &&
                       <li className="disabled"><a aria-disabled="true">Export</a></li>
                       ||

--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -9,86 +9,69 @@ class BlueprintListView extends React.PureComponent {
     super();
   }
 
-  // The following enables the expand/collapse interaction
-  // componentDidMount() {
-  //   this.bindExpand();
-  // }
-  //
-  // componentDidUpdate() {
-  //   this.unbind();
-  //   this.bindExpand();
-  // }
-  //
-  // componentWillUnmount() {
-  //   this.unbind();
-  // }
-
-  //   bindExpand() {
-  //   // click the list-view heading then expand a row
-  //   $('.list-group-item-header').click(function (event) {
-  //     if (!$(event.target).is('button, a, input, .fa-ellipsis-v')) {
-  //       $(this).find('.fa-angle-right')
-  //         .toggleClass('fa-angle-down')
-  //         .end()
-  //         .parent()
-  //         .toggleClass('list-view-pf-expand-active')
-  //         .find('.list-group-item-container')
-  //         .toggleClass('hidden');
-  //     }
-  //   });
-  //
-  //   // click the close button, hide the expand row and remove the active status
-  //   $('.list-group-item-container .close').on('click', function () {
-  //     $(this).parent()
-  //       .addClass('hidden')
-  //       .parent()
-  //       .removeClass('list-view-pf-expand-active')
-  //       .find('.fa-angle-right')
-  //       .removeClass('fa-angle-down');
-  //   });
-  // }
-  //
-  // unbind() {
-  //   $('.list-group-item-header').off('click');
-  //   $('.list-group-item-container .close').off('click');
-  // }
+  handleCreateImage(blueprint) {
+    this.setState({ blueprint });
+    $('#cmpsr-modal-crt-image').modal('show');
+  }
 
   render() {
     const { blueprints } = this.props; // eslint-disable-line no-use-before-define
     return (
       <div className="list-group list-view-pf list-view-pf-view">
         {blueprints.map((blueprint, i) =>
-          <div>
-            <div className="list-group-item" key={i}>
-              <div className="list-group-item-header">
-                <div className="list-view-pf-expand hidden">
-                  <span className="fa fa-angle-right"></span>
-                </div>
-                <div className="list-view-pf-checkbox">
-                  <input type="checkbox" />
-                </div>
-                <div className="list-view-pf-actions">
-                  <Link to={`/edit/${blueprint.name}`}>
-                    <button className="btn btn-default" type="button">Edit Blueprint</button>
-                  </Link>
+          <div className="list-group-item" key={i}>
+            <div className="list-group-item-header">
+              <div className="list-view-pf-expand hidden">
+                <span className="fa fa-angle-right"></span>
+              </div>
+              <div className="list-view-pf-checkbox">
+                <input type="checkbox" />
+              </div>
+              <div className="list-view-pf-actions">n
+                <Link to={`/edit/${blueprint.name}`} className="btn btn-default">
+                  Edit Blueprint
+                </Link>
+                {(blueprint.modules.length === 0 && blueprint.packages.length === 0) &&
+                  <button type="button" className="btn btn-default" disabled="disabled">
+                    Create Image
+                  </button>
+                ||
+                  <button
+                    type="button"
+                    className="btn btn-default"
+                    onClick={() => this.handleCreateImage(blueprint.name)}
+                  >
+                    Create Image
+                  </button>
+                }
+                <div className="dropdown pull-right dropdown-kebab-pf">
                   <button
                     className="btn btn-default"
                     onClick={(e) => this.props.handleShowModalCreateImage(e, blueprint)}
                   >
-                    Create Image
-                  </button>
-                  <div className="dropdown pull-right dropdown-kebab-pf">
-                    <button
-                      className="btn btn-link dropdown-toggle"
-                      type="button"
-                      id="dropdownKebabRight9"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="true"
-                    ><span className="fa fa-ellipsis-v"></span></button>
-                    <ul
-                      className="dropdown-menu dropdown-menu-right"
-                      aria-labelledby="dropdownKebabRight9"
+                    {(blueprint.modules.length === 0 && blueprint.packages.length === 0) &&
+                      <li className="disabled"><a aria-disabled="true">Export</a></li>
+                      ||
+                      <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e, blueprint.name)}>Export</a></li>
+                    }
+                    <li><a href="#" onClick={(e) => this.props.handleShowModalDelete(e, blueprint)}>Delete</a></li>
+                  </ul>
+                </div>
+              </div>
+              <div className="list-view-pf-main-info">
+                <span className="pficon pficon-template list-pf-icon-small"></span>
+                <div className="list-view-pf-body">
+                  <div className="list-view-pf-description">
+                    <div className="list-group-item-heading">
+                      <Link to={`/blueprint/${blueprint.name}`}>{blueprint.name}</Link>
+                    </div>
+                    <div className="list-group-item-text">
+                      {blueprint.description}
+                    </div>
+                  </div>
+                  <div className="list-view-pf-additional-info hidden">
+                    <div
+                      className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked hidden"
                     >
                       <li><a href="#" onClick={(e) => this.props.handleShowModalExport(e, blueprint.name)}>Export</a></li>
                       <li><a href="#" onClick={(e) => this.props.handleShowModalDelete(e, blueprint)}>Delete</a></li>

--- a/components/Loading/Loading.js
+++ b/components/Loading/Loading.js
@@ -1,10 +1,35 @@
 import React from 'react';
 
-const Loading = () => (
-  <div className="cmpsr-loading">
-    <div className="spinner spinner-md"></div>
-    <p className="lead">Loading</p>
-  </div>
-);
+class Loading extends React.Component {
+  constructor(props) {
+    super(props);
+    this.enableLoadingState = this.enableLoadingState.bind(this);
+    this.state = {
+      displayLoadingState: false,
+    };
+    this.timer = setTimeout(this.enableLoadingState, 500);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timer);
+  }
+
+  enableLoadingState() {
+    this.setState({displayLoadingState: true});
+  }
+
+  render() {
+    const {displayLoadingState} = this.state;
+    if (!displayLoadingState) {
+      return null;
+    }
+    return (
+      <div className="cmpsr-loading">
+        <div className="spinner spinner-md"></div>
+        <p className="lead">Loading</p>
+      </div>
+    );
+  }
+}
 
 export default Loading;

--- a/components/Toolbar/BlueprintsToolbar.js
+++ b/components/Toolbar/BlueprintsToolbar.js
@@ -24,7 +24,13 @@ const BlueprintsToolbar = props => (
     </div>
     <div className="toolbar-pf-action-right">
       <div className="form-group">
-        <button className="btn btn-default" type="button" data-toggle="modal" data-target="#cmpsr-modal-crt-blueprint">
+        <button
+          className="btn btn-default"
+          type="button"
+          data-toggle="modal"
+          data-target="#cmpsr-modal-crt-blueprint"
+          disabled={props.errorState}
+        >
           Create Blueprint
         </button>
       </div>
@@ -34,6 +40,7 @@ const BlueprintsToolbar = props => (
 
 BlueprintsToolbar.propTypes = {
   sortSetValue: PropTypes.func,
+  errorState: PropTypes.bool,
 };
 
 export default BlueprintsToolbar;

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -136,6 +136,14 @@ export const blueprintsFailure = (error) => ({
     error,
   },
 });
+export const BLUEPRINT_CONTENTS_FAILURE = 'BLUEPRINT_CONTENTS_FAILURE';
+export const blueprintContentsFailure = (error, blueprintId) => ({
+  type: BLUEPRINT_CONTENTS_FAILURE,
+  payload: {
+    error,
+    blueprintId
+  },
+});
 
 export const UNDO = 'UNDO';
 export const undo = (blueprintId) => ({

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -20,6 +20,11 @@ export const fetchingBlueprints = () => ({
   type: FETCHING_BLUEPRINTS,
 });
 
+export const FETCHING_BLUEPRINT_NAMES_SUCCEEDED = 'FETCHING_BLUEPRINT_NAMES_SUCCEEDED';
+export const fetchingBlueprintNamesSucceeded = () => ({
+  type: FETCHING_BLUEPRINT_NAMES_SUCCEEDED,
+});
+
 export const FETCHING_BLUEPRINTS_SUCCEEDED = 'FETCHING_BLUEPRINTS_SUCCEEDED';
 export const fetchingBlueprintsSucceeded = (blueprint, pendingChanges) => ({
   type: FETCHING_BLUEPRINTS_SUCCEEDED,

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -5,7 +5,7 @@ import {
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   ADD_BLUEPRINT_COMPONENT_SUCCEEDED, REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
   SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION, SET_BLUEPRINT_COMMENT,
-  DELETING_BLUEPRINT_SUCCEEDED, BLUEPRINTS_FAILURE,
+  DELETING_BLUEPRINT_SUCCEEDED, BLUEPRINTS_FAILURE, BLUEPRINT_CONTENTS_FAILURE,
   FETCHING_IMAGE_STATUS_SUCCEEDED,
 } from '../actions/blueprints';
 
@@ -46,7 +46,7 @@ const blueprints = (state = [], action) => {
       : state;
     case BLUEPRINTS_FAILURE:
       return Object.assign({}, state, {
-        errorMessage: action.payload.error,
+        errorState: action.payload.error,
         fetchingBlueprints: false,
       });
     case FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED:
@@ -60,6 +60,20 @@ const blueprints = (state = [], action) => {
           ]
         }
       );
+    case BLUEPRINT_CONTENTS_FAILURE:
+      return Object.assign({}, state, {
+        blueprintList: [
+          ...state.blueprintList.map(blueprint => {
+            if (blueprint.present.id === action.payload.blueprintId) {
+              return Object.assign({}, blueprint, {
+                  errorState: action.payload.error,
+                });
+              }
+              return blueprint;
+            }
+          ),
+        ]
+      });
     case ADD_BLUEPRINT_COMPONENT_SUCCEEDED:
       return Object.assign({}, state, {
           blueprintList: [

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -12,92 +12,26 @@ import {
 const blueprints = (state = [], action) => {
   switch (action.type) {
     case CREATING_BLUEPRINT_SUCCEEDED:
-      return [
-        ...state.filter(blueprint => blueprint.present.id !== action.payload.blueprint.id), {
-          past: [],
-          present: Object.assign({}, action.payload.blueprint,  {
-            localPendingChanges: [],
-            workspacePendingChanges: {addedChanges: [], deletedChanges: []},
-            images: [],
-          }),
-          future: [],
+      return Object.assign({}, state, {
+          blueprintList: [...state.blueprintList.filter(blueprint => blueprint.present.id !== action.payload.blueprint.id), {
+              past: [],
+              present: Object.assign({}, action.payload.blueprint,  {
+                localPendingChanges: [],
+                workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+              }),
+              future: [],
+            }
+          ]
         }
-      ];
+      );
     // The following reducers filter the blueprint out of the state and add the new version if
     // the blueprint contains component data or is not found in the state
     case FETCHING_BLUEPRINTS_SUCCEEDED:
       return action.payload.blueprint.components !== undefined
-      || !state.some(blueprint => blueprint.present.id === action.payload.blueprint.id)
-      ? [...state.filter(blueprint => blueprint.present.id !== action.payload.blueprint.id), {
-          past: [],
-          present: Object.assign({}, action.payload.blueprint, {
-            localPendingChanges: [],
-            workspacePendingChanges: {addedChanges: [], deletedChanges: []},
-            images: [],
-          }),
-          future: [],
-        }]
-      : state;
-    case FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED:
-      return [
-        ...state.filter(blueprint => blueprint.present.id !== action.payload.blueprintPresent.id), {
-          past: action.payload.blueprintPast,
-          present: action.payload.blueprintPresent,
-          future: [],
-        }
-      ];
-    case ADD_BLUEPRINT_COMPONENT_SUCCEEDED:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprintId) {
-            return Object.assign(
-              {}, blueprint, {
-              past: blueprint.past.concat([blueprint.present]),
-              present: Object.assign({}, blueprint.present, {
-                components: action.payload.components,
-                packages: action.payload.packages,
-                localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
-                  return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
-                  || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
-                }) ? blueprint.present.localPendingChanges.filter((component) => {
-                  return component.componentNew != action.payload.pendingChange.componentOld
-                  || component.componentOld != action.payload.pendingChange.componentNew
-                }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
-              }),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprintId) {
-            return Object.assign(
-              {}, blueprint, {
-              past: blueprint.past.concat([blueprint.present]),
-              present: Object.assign({}, blueprint.present, {
-                components: action.payload.components,
-                packages: action.payload.packages,
-                localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
-                  return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
-                   || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
-                }) ? blueprint.present.localPendingChanges.filter((component) => {
-                  return component.componentNew != action.payload.pendingChange.componentOld
-                  || component.componentOld != action.payload.pendingChange.componentNew
-                }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
-              }),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case SET_BLUEPRINT:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprint.id) {
-            return Object.assign(
-              {}, blueprint, {
+      || !state.blueprintList.some(blueprint => blueprint.present.id === action.payload.blueprint.id)
+      ? Object.assign({}, state, {
+          fetchingBlueprints: false,
+          blueprintList: [...state.blueprintList.filter(blueprint => blueprint.present.id !== action.payload.blueprint.id), {
               past: [],
               present: Object.assign({}, action.payload.blueprint, {
                 localPendingChanges: [],
@@ -105,96 +39,199 @@ const blueprints = (state = [], action) => {
                 images: [],
               }),
               future: [],
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case SET_BLUEPRINT_COMMENT:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprint.id) {
-            return Object.assign(
-              {}, blueprint, {
-              present: Object.assign({}, blueprint.present, { comment: action.payload.comment }),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case SET_BLUEPRINT_DESCRIPTION:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprint.id) {
-            return Object.assign(
-              {}, blueprint, {
-              past: blueprint.past.concat([blueprint.present]),
-              present: Object.assign({}, blueprint.present, { description: action.payload.description }),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case DELETING_BLUEPRINT_SUCCEEDED:
-      return state.filter(blueprint => blueprint.present.id !== action.payload.blueprintId);
-    case FETCHING_IMAGE_STATUS_SUCCEEDED:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.name === action.payload.blueprintName) {
-            return Object.assign(
-              {}, blueprint, {
-              present: Object.assign({}, blueprint.present, {
-                images: blueprint.present.images.filter(image => image.id !== action.payload.imageInfo.id)
-                  .concat([action.payload.imageInfo]),
-              }),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case UNDO:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprintId) {
-            return Object.assign(
-              {}, blueprint, {
-              future: blueprint.future.concat([blueprint.present]),
-              present: blueprint.past.pop(),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case REDO:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprintId) {
-            return Object.assign(
-              {}, blueprint, {
-              past: blueprint.past.concat([blueprint.present]),
-              present: blueprint.future.pop(),
-            });
-          }
-          return blueprint;
-        }),
-      ];
-    case DELETE_HISTORY:
-      return [
-        ...state.map(blueprint => {
-          if (blueprint.present.id === action.payload.blueprintId) {
-            return Object.assign(
-              {}, blueprint, {
-              present: Object.assign({}, blueprint.past.shift(),  {
-                localPendingChanges: [],
-                workspacePendingChanges: {addedChanges: [], deletedChanges: []}
-              }),
-              past: [],
+            }
+          ]
+        }
+      )
+      : state;
+    case FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.filter(blueprint => blueprint.present.id !== action.payload.blueprintPresent.id), {
+              past: action.payload.blueprintPast,
+              present: action.payload.blueprintPresent,
               future: [],
-            });
-          }
-          return blueprint;
-        }),
-      ];
+            }
+          ]
+        }
+      );
+    case ADD_BLUEPRINT_COMPONENT_SUCCEEDED:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprintId) {
+                return Object.assign(
+                  {}, blueprint, {
+                  past: blueprint.past.concat([blueprint.present]),
+                  present: Object.assign({}, blueprint.present, {
+                    components: action.payload.components,
+                    packages: action.payload.packages,
+                    localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
+                      return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
+                      || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
+                    }) ? blueprint.present.localPendingChanges.filter((component) => {
+                      return component.componentNew != action.payload.pendingChange.componentOld
+                      || component.componentOld != action.payload.pendingChange.componentNew
+                    }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
+                  }),
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprintId) {
+                return Object.assign(
+                  {}, blueprint, {
+                  past: blueprint.past.concat([blueprint.present]),
+                  present: Object.assign({}, blueprint.present, {
+                    components: action.payload.components,
+                    packages: action.payload.packages,
+                    localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
+                      return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
+                       || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
+                    }) ? blueprint.present.localPendingChanges.filter((component) => {
+                      return component.componentNew != action.payload.pendingChange.componentOld
+                      || component.componentOld != action.payload.pendingChange.componentNew
+                    }) : [action.payload.pendingChange].concat(blueprint.present.localPendingChanges),
+                  }),
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case SET_BLUEPRINT:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprint.id) {
+                return Object.assign(
+                  {}, blueprint, {
+                  past: [],
+                  present: Object.assign({}, action.payload.blueprint, {
+                    localPendingChanges: [],
+                    workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+                  }),
+                  future: [],
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case SET_BLUEPRINT_COMMENT:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprint.id) {
+                return Object.assign(
+                  {}, blueprint, {
+                  present: Object.assign({}, blueprint.present, { comment: action.payload.comment }),
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case SET_BLUEPRINT_DESCRIPTION:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprint.id) {
+                return Object.assign(
+                  {}, blueprint, {
+                  past: blueprint.past.concat([blueprint.present]),
+                  present: Object.assign({}, blueprint.present, { description: action.payload.description }),
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case DELETING_BLUEPRINT_SUCCEEDED:
+      return Object.assign({}, state, {
+        blueprintList: state.blueprintList.filter(blueprint => blueprint.present.id !== action.payload.blueprintId)
+      });
+    case FETCHING_IMAGE_STATUS_SUCCEEDED:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.map(blueprint => {
+              if (blueprint.present.name === action.payload.blueprintName) {
+                return Object.assign(
+                  {}, blueprint, {
+                  present: Object.assign({}, blueprint.present, {
+                    images: blueprint.present.images.filter(image => image.id !== action.payload.imageInfo.id)
+                      .concat([action.payload.imageInfo]),
+                  }),
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case UNDO:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprintId) {
+                return Object.assign(
+                  {}, blueprint, {
+                  future: blueprint.future.concat([blueprint.present]),
+                  present: blueprint.past.pop(),
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case REDO:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprintId) {
+                return Object.assign(
+                  {}, blueprint, {
+                  past: blueprint.past.concat([blueprint.present]),
+                  present: blueprint.future.pop(),
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
+    case DELETE_HISTORY:
+      return Object.assign({}, state, {
+          blueprintList: [
+            ...state.blueprintList.map(blueprint => {
+              if (blueprint.present.id === action.payload.blueprintId) {
+                return Object.assign(
+                  {}, blueprint, {
+                  present: Object.assign({}, blueprint.past.shift(),  {
+                    localPendingChanges: [],
+                    workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+                  }),
+                  past: [],
+                  future: [],
+                });
+              }
+              return blueprint;
+            }),
+          ]
+        }
+      );
     default:
       return state;
   }

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -5,7 +5,7 @@ import {
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   ADD_BLUEPRINT_COMPONENT_SUCCEEDED, REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
   SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION, SET_BLUEPRINT_COMMENT,
-  DELETING_BLUEPRINT_SUCCEEDED,
+  DELETING_BLUEPRINT_SUCCEEDED, BLUEPRINTS_FAILURE,
   FETCHING_IMAGE_STATUS_SUCCEEDED,
 } from '../actions/blueprints';
 
@@ -44,6 +44,10 @@ const blueprints = (state = [], action) => {
         }
       )
       : state;
+    case BLUEPRINTS_FAILURE:
+      return Object.assign({}, state, {
+        errorMessage: action.payload.error
+      });
     case FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED:
       return Object.assign({}, state, {
           blueprintList: [

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -72,8 +72,10 @@ const blueprints = (state = [], action) => {
                     components: action.payload.components,
                     packages: action.payload.packages,
                     localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
-                      return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
-                      || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
+                      return (component.componentNew === action.payload.pendingChange.componentOld
+                        && component.componentNew !== null)
+                      || (component.componentOld === action.payload.pendingChange.componentNew
+                        && component.componentOld !== null)
                     }) ? blueprint.present.localPendingChanges.filter((component) => {
                       return component.componentNew != action.payload.pendingChange.componentOld
                       || component.componentOld != action.payload.pendingChange.componentNew
@@ -98,8 +100,10 @@ const blueprints = (state = [], action) => {
                     components: action.payload.components,
                     packages: action.payload.packages,
                     localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
-                      return (component.componentNew === action.payload.pendingChange.componentOld && component.componentNew !== null)
-                       || (component.componentOld === action.payload.pendingChange.componentNew && component.componentOld !== null)
+                      return (component.componentNew === action.payload.pendingChange.componentOld
+                        && component.componentNew !== null)
+                       || (component.componentOld === action.payload.pendingChange.componentNew
+                         && component.componentOld !== null)
                     }) ? blueprint.present.localPendingChanges.filter((component) => {
                       return component.componentNew != action.payload.pendingChange.componentOld
                       || component.componentOld != action.payload.pendingChange.componentNew

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -46,7 +46,8 @@ const blueprints = (state = [], action) => {
       : state;
     case BLUEPRINTS_FAILURE:
       return Object.assign({}, state, {
-        errorMessage: action.payload.error
+        errorMessage: action.payload.error,
+        fetchingBlueprints: false,
       });
     case FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED:
       return Object.assign({}, state, {

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -17,7 +17,8 @@ const blueprints = (state = [], action) => {
               past: [],
               present: Object.assign({}, action.payload.blueprint,  {
                 localPendingChanges: [],
-                workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+                workspacePendingChanges: {addedChanges: [], deletedChanges: []},
+                images: [],
               }),
               future: [],
             }
@@ -140,7 +141,8 @@ const blueprints = (state = [], action) => {
                   past: [],
                   present: Object.assign({}, action.payload.blueprint, {
                     localPendingChanges: [],
-                    workspacePendingChanges: {addedChanges: [], deletedChanges: []}
+                    workspacePendingChanges: {addedChanges: [], deletedChanges: []},
+                    images: [],
                   }),
                   future: [],
                 });

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -1,7 +1,7 @@
 import {
   UNDO, REDO, DELETE_HISTORY,
   CREATING_BLUEPRINT_SUCCEEDED,
-  FETCHING_BLUEPRINTS_SUCCEEDED,
+  FETCHING_BLUEPRINTS_SUCCEEDED, FETCHING_BLUEPRINT_NAMES_SUCCEEDED,
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   ADD_BLUEPRINT_COMPONENT_SUCCEEDED, REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
   SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION, SET_BLUEPRINT_COMMENT,
@@ -23,6 +23,11 @@ const blueprints = (state = [], action) => {
               future: [],
             }
           ]
+        }
+      );
+    case FETCHING_BLUEPRINT_NAMES_SUCCEEDED:
+      return Object.assign({}, state, {
+          fetchingBlueprints: false,
         }
       );
     // The following reducers filter the blueprint out of the state and add the new version if

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -9,7 +9,7 @@ import {
   startComposeApi, fetchImageStatusApi,
 } from '../apiCalls';
 import {
-  fetchingBlueprintsSucceeded,
+  fetchingBlueprintsSucceeded, fetchingBlueprintNamesSucceeded,
   FETCHING_BLUEPRINT_CONTENTS, fetchingBlueprintContentsSucceeded,
   fetchingImageStatusSucceeded,
   CREATING_BLUEPRINT, creatingBlueprintSucceeded,
@@ -31,6 +31,7 @@ function* fetchBlueprintsFromName(blueprintName) {
 function* fetchBlueprints() {
   try {
     const blueprintNames = yield call(fetchBlueprintNamesApi);
+    yield put(fetchingBlueprintNamesSucceeded());
     yield* blueprintNames.map(blueprintName => fetchBlueprintsFromName(blueprintName));
   } catch (error) {
     console.log('errorloadBlueprintsSaga');

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -19,7 +19,7 @@ import {
   DELETING_BLUEPRINT, deletingBlueprintSucceeded,
   COMMIT_TO_WORKSPACE,
   START_COMPOSE,
-  blueprintsFailure,
+  blueprintsFailure, blueprintContentsFailure,
 } from '../actions/blueprints';
 import { makeGetBlueprintById } from '../selectors';
 
@@ -84,7 +84,7 @@ function* fetchBlueprintContents(action) {
     yield put(fetchingBlueprintContentsSucceeded(blueprintPast, blueprintPresent, workspacePendingChanges));
   } catch (error) {
     console.log('Error in fetchBlueprintContentsSaga');
-    yield put(blueprintsFailure(error));
+    yield put(blueprintContentsFailure(error, action.payload.blueprintId));
   }
 }
 

--- a/core/selectors.js
+++ b/core/selectors.js
@@ -21,7 +21,7 @@ export const makeGetFutureLength = () => createSelector(
 );
 
 const getBlueprintById = (state, blueprintId) => {
-  const blueprintById = state.blueprints.find(blueprint => blueprint.present.id === blueprintId);
+  const blueprintById = state.blueprints.blueprintList.find(blueprint => blueprint.present.id === blueprintId);
   return blueprintById;
 };
 
@@ -105,7 +105,7 @@ export const makeGetFilteredComponents = () => createSelector(
 );
 
 const getSortedBlueprints = (state) => {
-  const sortedBlueprints = state.blueprints;
+  const sortedBlueprints = state.blueprints.blueprintList;
   const key = state.sort.blueprints.key;
   const value = state.sort.blueprints.value;
   sortedBlueprints.sort((a, b) => {

--- a/core/store.js
+++ b/core/store.js
@@ -30,7 +30,11 @@ const initialState = {
         value: '',
     },
   },
-  blueprints: [],
+  blueprints: {
+    errorMessage: null,
+    fetchingBlueprints: true,
+    blueprintList: [],
+  },
   modals: {
     createImage: {
       name: '',

--- a/core/store.js
+++ b/core/store.js
@@ -31,7 +31,7 @@ const initialState = {
     },
   },
   blueprints: {
-    errorMessage: null,
+    errorState: null,
     fetchingBlueprints: true,
     blueprintList: [],
   },

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -9,7 +9,6 @@ import ComponentDetailsView from '../../components/ListView/ComponentDetailsView
 import CreateImage from '../../components/Modal/CreateImage';
 import ExportBlueprint from '../../components/Modal/ExportBlueprint';
 import EmptyState from '../../components/EmptyState/EmptyState';
-import Loading from '../../components/Loading/Loading';
 import BlueprintToolbar from '../../components/Toolbar/BlueprintToolbar';
 import ListView from '../../components/ListView/ListView';
 import ListItemImages from '../../components/ListView/ListItemImages';
@@ -272,28 +271,29 @@ class BlueprintPage extends React.Component {
                     componentsSortSetValue={this.props.componentsSortSetValue}
                     dependenciesSortSetValue={this.props.dependenciesSortSetValue}
                   />
-                  {(blueprint.components === undefined &&
-                    <Loading />) ||
-                    ((selectedComponents === undefined || selectedComponents.length === 0) &&
-                      componentsFilters.filterValues.length === 0) &&
-                      <EmptyState
-                        title={'Empty Blueprint'}
-                        message={'There are no components listed in the blueprint. Edit the blueprint to add components.'}
-                      >
-                        <Link to={`/edit/${this.props.route.params.blueprint}`}>
-                          <button className="btn btn-default btn-primary" type="button">
-                            Edit Blueprint
-                          </button>
-                        </Link>
-                      </EmptyState> ||
-                    <BlueprintContents
-                      components={selectedComponents}
-                      dependencies={dependencies}
-                      noEditComponent
-                      handleComponentDetails={this.handleComponentDetails}
-                      filterClearValues={this.props.componentsFilterClearValues}
-                    />}
-                </div>) ||
+                  <BlueprintContents
+                    components={selectedComponents}
+                    dependencies={dependencies}
+                    noEditComponent
+                    handleComponentDetails={this.handleComponentDetails}
+                    filterClearValues={this.props.componentsFilterClearValues}
+                    filterValues={componentsFilters.filterValues}
+                    errorState={this.props.blueprintContentsError}
+                    fetchingState={this.props.blueprintContentsFetching}
+                  >
+                    <EmptyState
+                      title={'Empty Blueprint'}
+                      message={'There are no components listed in the blueprint. Edit the blueprint to add components.'}
+                    >
+                      <Link to={`/edit/${this.props.route.params.blueprint}`}>
+                        <button className="btn btn-default btn-primary" type="button">
+                          Edit Blueprint
+                        </button>
+                      </Link>
+                    </EmptyState>
+                  </BlueprintContents>
+                </div>)
+                ||
                 <div className="col-sm-12 cmpsr-component-details--view">
                   <h3 className="cmpsr-panel__title cmpsr-panel__title--main">Component Details</h3>
                   <ComponentDetailsView
@@ -303,7 +303,8 @@ class BlueprintPage extends React.Component {
                     status={activeComponentStatus}
                     handleComponentDetails={this.handleComponentDetails}
                   />
-                </div>}
+                </div>
+              }
             </div>
           </Tab>
           <Tab tabTitle="Images" active={activeTab === 'Images'}>
@@ -387,6 +388,8 @@ BlueprintPage.propTypes = {
   setModalCreateImageBlueprintName: PropTypes.func,
   startCompose: PropTypes.func,
   fetchingImageStatus: PropTypes.func,
+  blueprintContentsError: PropTypes.object,
+  blueprintContentsFetching: PropTypes.bool,
 };
 
 const makeMapStateToProps = () => {
@@ -407,6 +410,10 @@ const makeMapStateToProps = () => {
         componentsSortKey: state.sort.components.key,
         componentsSortValue: state.sort.components.value,
         componentsFilters: state.filter.components,
+        blueprintContentsError: fetchedBlueprint.errorState,
+        blueprintContentsFetching:
+          fetchedBlueprint.present.components === undefined &&
+          fetchedBlueprint.errorState === undefined ? true : false,
       };
     }
     return {
@@ -419,6 +426,7 @@ const makeMapStateToProps = () => {
       componentsSortKey: state.sort.components.key,
       componentsSortValue: state.sort.components.value,
       componentsFilters: state.filter.components,
+      blueprintContentsError: {},
     };
   };
   return mapStateToProps;

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -542,21 +542,24 @@ class EditBlueprintPage extends React.Component {
               futureLength={futureLength}
             />
           }
-          {(blueprint.components === undefined &&
-            <Loading />) ||
-          (selectedComponents !== undefined && selectedComponents.length === 0 && componentsFilters.filterValues.length === 0 &&
-            <EmptyState
-              title={'Add Blueprint Components'}
-              message={'Browse or search for components, then add them to the blueprint.'}
-            />) ||
             <BlueprintContents
               components={selectedComponents}
               dependencies={dependencies}
               handleRemoveComponent={this.handleRemoveComponent}
               handleComponentDetails={this.handleComponentDetails}
               filterClearValues={this.props.componentsFilterClearValues}
-            />}
-          </div>) ||
+              filterValues={componentsFilters.filterValues}
+              errorState={this.props.blueprintContentsError}
+              fetchingState={this.props.blueprintContentsFetching}
+            >
+              <EmptyState
+                title={'Add Blueprint Components'}
+                message={'Browse or search for components, then add them to the blueprint.'}
+              />
+            </BlueprintContents>
+          </div>
+          )
+        ||
         inputs.selectedInput !== undefined &&
           <ComponentDetailsView
             parent={blueprintDisplayName}
@@ -567,8 +570,8 @@ class EditBlueprintPage extends React.Component {
             handleAddComponent={this.handleAddComponent}
             handleUpdateComponent={this.handleUpdateComponent}
             handleRemoveComponent={this.handleRemoveComponent}
-          />}
-
+          />
+        }
         <h3 className="cmpsr-panel__title cmpsr-panel__title--sidebar">Available Components</h3>
         {inputs.inputComponents !== undefined &&
           <div className="cmpsr-panel__body cmpsr-panel__body--sidebar">
@@ -711,6 +714,8 @@ EditBlueprintPage.propTypes = {
   commitToWorkspace: PropTypes.func,
   deleteHistory: PropTypes.func,
   startCompose: PropTypes.func,
+  blueprintContentsError: PropTypes.object,
+  blueprintContentsFetching: PropTypes.bool,
 };
 
 const makeMapStateToProps = () => {
@@ -736,6 +741,10 @@ const makeMapStateToProps = () => {
         modalActive: state.modals.modalActive,
         pastLength: getPastLength(fetchedBlueprint),
         futureLength: getFutureLength(fetchedBlueprint),
+        blueprintContentsError: fetchedBlueprint.errorState,
+        blueprintContentsFetching:
+          fetchedBlueprint.present.components === undefined &&
+          fetchedBlueprint.errorState === undefined ? true : false,
       };
     }
     return {
@@ -751,6 +760,7 @@ const makeMapStateToProps = () => {
       modalActive: state.modals.modalActive,
       pastLength: 0,
       futureLength: 0,
+      blueprintContentsError: {},
     };
   };
   return mapStateToProps;

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -247,7 +247,7 @@ const makeMapStateToProps = () => {
         blueprintSortKey: state.sort.blueprints.key,
         blueprintSortValue: state.sort.blueprints.value,
         blueprintFilters: state.filter.blueprints,
-        blueprintsError: state.blueprints.errorMessage,
+        blueprintsError: state.blueprints.errorState,
         blueprintsLoading: state.blueprints.fetchingBlueprints,
       };
     }
@@ -259,7 +259,7 @@ const makeMapStateToProps = () => {
       blueprintSortKey: state.sort.blueprints.key,
       blueprintSortValue: state.sort.blueprints.value,
       blueprintFilters: state.filter.blueprints,
-      blueprintsError: state.blueprints.errorMessage,
+      blueprintsError: state.blueprints.errorState,
       blueprintsLoading: state.blueprints.fetchingBlueprints,
     };
   };

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -7,6 +7,7 @@ import ExportBlueprint from '../../components/Modal/ExportBlueprint';
 import DeleteBlueprint from '../../components/Modal/DeleteBlueprint';
 import CreateImage from '../../components/Modal/CreateImage';
 import EmptyState from '../../components/EmptyState/EmptyState';
+import Loading from '../../components/Loading/Loading';
 import BlueprintsToolbar from '../../components/Toolbar/BlueprintsToolbar';
 import { connect } from 'react-redux';
 import { deletingBlueprint, startCompose } from '../../core/actions/blueprints';
@@ -108,7 +109,8 @@ class BlueprintsPage extends React.Component {
     const {
       blueprints, exportBlueprint, deleteBlueprint, createImage,
       blueprintSortKey, blueprintSortValue, blueprintsSortSetValue, blueprintFilters,
-      blueprintsFilterAddValue, blueprintsFilterRemoveValue, blueprintsFilterClearValues
+      blueprintsFilterAddValue, blueprintsFilterRemoveValue, blueprintsFilterClearValues,
+      blueprintsError, blueprintsLoading
     } = this.props;
     return (
       <Layout className="container-fluid" ref="layout">
@@ -122,45 +124,56 @@ class BlueprintsPage extends React.Component {
           sortValue={blueprintSortValue}
           sortSetValue={blueprintsSortSetValue}
         />
-      {blueprints.length === 0 && blueprintFilters.filterValues.length === 0 &&
-        <EmptyState
-          title="No Blueprints"
-          message={`Create a blueprint to define the contents that will be included
-            in the images you create. Images can be produced in a variety of
-            output formats.`}
-        >
-          <button
-            className="btn btn-primary btn-lg"
-            type="button"
-            data-toggle="modal"
-            data-target="#cmpsr-modal-crt-blueprint"
-          >
-            Create Blueprint
-          </button>
-        </EmptyState>
-      }
-      {blueprints.length === 0 && blueprintFilters.filterValues.length > 0 &&
-        <EmptyState
-          title="No Results Match the Filter Criteria"
-          message={`Modify your filter criteria to get results.`}
-        >
-          <button
-            className="btn btn-link btn-lg"
-            type="button"
-            onClick={blueprintsFilterClearValues}
-          >
-            Clear All Filters
-          </button>
-        </EmptyState>
-      }
-      {createImage.imageTypes !== undefined &&
-        <BlueprintListView
-          blueprints={blueprints.map(blueprint => blueprint.present)}
-          setNotifications={this.setNotifications}
-          handleShowModalExport={this.handleShowModalExport}
-          handleShowModalDelete={this.handleShowModalDelete}
-          handleShowModalCreateImage={this.handleShowModalCreateImage}
-        />
+      {blueprintsLoading === true &&
+        <Loading />
+        ||
+        (blueprintsError !== null &&
+          <EmptyState
+            title="An Error Occurred"
+            message="An error occurred while trying to get blueprints."
+          />
+          ||
+          (blueprints.length > 0 &&
+            <BlueprintListView
+              blueprints={blueprints.map(blueprint => blueprint.present)}
+              setNotifications={this.setNotifications}
+              handleShowModalExport={this.handleShowModalExport}
+              handleShowModalDelete={this.handleShowModalDelete}
+              handleShowModalCreateImage={this.handleShowModalCreateImage}
+            />
+            ||
+            (blueprintFilters.filterValues.length === 0 &&
+              <EmptyState
+                title="No Blueprints"
+                message={`Create a blueprint to define the contents that will be included
+                  in the images you create. Images can be produced in a variety of
+                  output formats.`}
+              >
+                <button
+                  className="btn btn-primary btn-lg"
+                  type="button"
+                  data-toggle="modal"
+                  data-target="#cmpsr-modal-crt-blueprint"
+                >
+                  Create Blueprint
+                </button>
+              </EmptyState>
+              ||
+              <EmptyState
+                title="No Results Match the Filter Criteria"
+                message={`Modify your filter criteria to get results.`}
+              >
+                <button
+                  className="btn btn-link btn-lg"
+                  type="button"
+                  onClick={blueprintsFilterClearValues}
+                >
+                  Clear All Filters
+                </button>
+              </EmptyState>
+            )
+          )
+        )
       }
         <CreateBlueprint blueprintNames={blueprints.map(blueprint => blueprint.present.id)} />
         {(exportBlueprint !== undefined && exportBlueprint.visible)
@@ -215,6 +228,8 @@ BlueprintsPage.propTypes = {
   blueprintsFilterAddValue: PropTypes.func,
   blueprintsFilterRemoveValue: PropTypes.func,
   blueprintsFilterClearValues: PropTypes.func,
+  blueprintsError: PropTypes.object,
+  blueprintsLoading: PropTypes.bool,
   startCompose: PropTypes.func,
 };
 
@@ -231,6 +246,8 @@ const makeMapStateToProps = () => {
         blueprintSortKey: state.sort.blueprints.key,
         blueprintSortValue: state.sort.blueprints.value,
         blueprintFilters: state.filter.blueprints,
+        blueprintsError: state.blueprints.errorMessage,
+        blueprintsLoading: state.blueprints.fetchingBlueprints,
       };
     }
     return {
@@ -241,6 +258,8 @@ const makeMapStateToProps = () => {
       blueprintSortKey: state.sort.blueprints.key,
       blueprintSortValue: state.sort.blueprints.value,
       blueprintFilters: state.filter.blueprints,
+      blueprintsError: state.blueprints.errorMessage,
+      blueprintsLoading: state.blueprints.fetchingBlueprints,
     };
   };
 

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -116,6 +116,7 @@ class BlueprintsPage extends React.Component {
       <Layout className="container-fluid" ref="layout">
         <BlueprintsToolbar
           emptyState={blueprints.length === 0 && blueprintFilters.filterValues.length === 0}
+          errorState={blueprintsError !== null}
           filters={blueprintFilters}
           filterRemoveValue={blueprintsFilterRemoveValue}
           filterClearValues={blueprintsFilterClearValues}

--- a/test/end-to-end/pages/blueprints.js
+++ b/test/end-to-end/pages/blueprints.js
@@ -22,7 +22,7 @@ module.exports = class BlueprintsPage extends MainPage {
     this.itemsBlueprint = '.container-fluid .list-view-pf-view .list-group-item .list-group-item-header';
 
     // Button - Edit Blueprint
-    this.btnEditBlueprint = '.list-view-pf-actions a button';
+    this.btnEditBlueprint = '.list-view-pf-actions a';
 
     // More Action dropdown menu list
     this.moreActionList = {

--- a/test/unit/index.norecipes.spec.js
+++ b/test/unit/index.norecipes.spec.js
@@ -59,7 +59,9 @@ describe('Home page', () => {
   });
 
   test('blank slate without blueprints', () => {
-    const component = mount(<Provider store={mockStore}><BlueprintsPage blueprints={mockState.blueprints.blueprintList} /></Provider>);
+    const component = mount(
+      <Provider store={mockStore}><BlueprintsPage blueprints={mockState.blueprints.blueprintList} /></Provider>
+    );
     const blankSlate = component.find('.blank-slate-pf');
 
     expect(blankSlate.text()).toContain('Create a blueprint');

--- a/test/unit/index.norecipes.spec.js
+++ b/test/unit/index.norecipes.spec.js
@@ -8,7 +8,11 @@ describe('Home page', () => {
     imageTypes: [{ name: 'qcow2', enabled: true }],
   };
   const mockState = {
-    blueprints: [],
+    blueprints: {
+      errorState: null,
+      fetchingBlueprints: false,
+      blueprintList: [],
+    },
     sort: {
       blueprints: {
         key: 'name',
@@ -37,7 +41,7 @@ describe('Home page', () => {
   const mockStore = { subscribe: () => null, dispatch: () => null, state: mockState, getState: () => mockState };
 
   test('Home page render', () => {
-    const wrapper = shallow(<BlueprintsPage store={mockStore} blueprints={mockState.blueprints} />);
+    const wrapper = shallow(<BlueprintsPage store={mockStore} blueprints={mockState.blueprints.blueprintList} />);
     const nodeName = wrapper.name();
     const container = wrapper.first('div');
 
@@ -47,7 +51,7 @@ describe('Home page', () => {
 
   test('calls componentDidMount() lifecycle method', () => {
     const componentDidMountSpy = jest.spyOn(BlueprintsPage.prototype, 'componentDidMount');
-    mount(<Provider store={mockStore}><BlueprintsPage blueprints={mockState.blueprints} /></Provider>);
+    mount(<Provider store={mockStore}><BlueprintsPage blueprints={mockState.blueprints.blueprintList} /></Provider>);
 
     expect(componentDidMountSpy).toHaveBeenCalledTimes(1);
 
@@ -55,7 +59,7 @@ describe('Home page', () => {
   });
 
   test('blank slate without blueprints', () => {
-    const component = mount(<Provider store={mockStore}><BlueprintsPage blueprints={mockState.blueprints} /></Provider>);
+    const component = mount(<Provider store={mockStore}><BlueprintsPage blueprints={mockState.blueprints.blueprintList} /></Provider>);
     const blankSlate = component.find('.blank-slate-pf');
 
     expect(blankSlate.text()).toContain('Create a blueprint');


### PR DESCRIPTION
The updates included in this PR:

- Refactor the state for `blueprints` to include:
  - fetchingBlueprints to indicate when blueprints are being fetched, so that we can display a Loading message on the Blueprints page while this is happening (closes #258)
  - errorState for fetching blueprints, so that we can display an error message on the Blueprints page
  - errorState for fetching blueprint contents, so that we can display an error message on the Blueprint page > Selected Components tab or Edit Blueprint page
- Display a loading message when fetching blueprint contents
- Update loading component so that it doesn't display immediately
- On Blueprints page, disable actions Create Image and Export when a blueprint has no contents (closes #255)
- On Blueprints page, disable Create Blueprint action if an error occurred fetching blueprints

Updates not covered in this PR:
- Refactoring the Available Components panel to show loading and error states (noted in issue #249)
- Refactoring Blueprint page > Images tab to show loading and error states (noted in issue #280)
- On Blueprint page > Images tab, disable action Create Image in the Empty State message  (noted in issue #280)