### PR TITLE
Domain socket support in UI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
     - COMMAND=eslint
     - COMMAND=stylelint
     - COMMAND=unit-test
-    - COMMAND=end-to-end-test
+    # - COMMAND=end-to-end-test
     - COMMAND=cockpit-test
 script:
   - make "$COMMAND"

--- a/test/end-to-end/entrypoint.sh
+++ b/test/end-to-end/entrypoint.sh
@@ -18,5 +18,10 @@ fi
 echo "Running with config.json settings:"
 cat ./wdio.conf.js
 
+until curl --unix-socket /run/weldr/api.socket http://localhost/api/status | grep 'db_supported":true'; do \
+    sleep 1; \
+    echo "Waiting for backend API to become ready before testing ..."; \
+done;
+
 # Execute the CMD
 exec "$@"

--- a/test/end-to-end/pages/editBlueprint.js
+++ b/test/end-to-end/pages/editBlueprint.js
@@ -72,7 +72,7 @@ module.exports = class EditBlueprintPage extends MainPage {
     this.totalComponentCount = `${this.blueprintInputRootElement} .cmpsr-blueprint__inputs__pagination span`;
 
     // filter input
-    this.inputFilter = `${this.blueprintInputRootElement} .toolbar-pf .toolbar-pf-actions .toolbar-pf-filter .input-group
+    this.inputFilter = `${this.blueprintInputRootElement} .toolbar-pf .toolbar-pf-actions .toolbar-pf-filter
       input[id="cmpsr-blueprint-input-filter"]`;
 
     // filter type

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -82,7 +82,7 @@ exports.config = {
   baseUrl: 'http://localhost:3000/',
   //
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 30000,
+  waitforTimeout: 60000,
   //
   // Default timeout in milliseconds for request
   // if Selenium Grid doesn't send response


### PR DESCRIPTION
1. Remove Welder-web stand-alone UI test.
2. Add domain socket support for Cockpit integrated welder-web.
3. Add domain socket support for end to end test.
4. Fix a page element.
5. Increase wait time to 60 seconds.