### PR TITLE
Propagate api errors

### DIFF
--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -47,7 +47,7 @@ export function fetchBlueprintInputsApi(filter, selectedInputPage, pageSize) {
         }).catch(e => console.log(`Error getting blueprint metadata: ${e}`));
       })
       .catch(e => {
-        console.log(`Failed to get inputs during blueprint edit: ${e}`);
+        console.log('Failed to get inputs during blueprint edit', e);
         reject();
       });
   });
@@ -76,7 +76,7 @@ export function fetchBlueprintInfoApi(blueprintName) {
 export function fetchModalCreateImageTypesApi() {
   const imageTypes = utils.apiFetch(constants.get_image_types)
     .then(data => data.types)
-    .catch(e => console.log(`Error getting component types: ${e}`));
+    .catch(e => console.log('Error getting component types', e));
   return imageTypes;
 }
 
@@ -107,7 +107,7 @@ export function fetchDiffWorkspaceApi(blueprintId) {
       resolve(data);
     })
     .catch(e => {
-      console.log(`Error fetching diff: ${e}`);
+      console.log('Error fetching diff', e);
       reject();
     });
   });
@@ -127,7 +127,7 @@ export function depsolveComponentsApi(packages) {
           resolve(dependencies);
         })
         .catch(e => {
-          console.log(`getBlueprint: Error getting component and dependency metadata: ${e}`);
+          console.log('getBlueprint: Error getting component and dependency metadata', e);
           reject();
         });
     } else {
@@ -156,7 +156,7 @@ export function startComposeApi(blueprintName, composeType) {
       resolve(JSON.parse(data));
     })
     .catch(e => {
-      console.log(`Error fetching diff: ${e}`);
+      console.log('Error fetching diff', e);
       reject();
     });
   });
@@ -170,7 +170,7 @@ export function fetchImageStatusApi(uuid) {
       resolve(data);
     })
     .catch(e => {
-      console.log(`Error fetching diff: ${e}`);
+      console.log('Error fetching diff', e);
       reject();
     });
   });

--- a/data/BlueprintApi.js
+++ b/data/BlueprintApi.js
@@ -58,7 +58,7 @@ class BlueprintApi {
         }
       })
       .catch(e => {
-        console.log(`Error fetching blueprint: ${e}`);
+        console.log('Error fetching blueprint', e);
         reject();
       });
     });
@@ -80,7 +80,7 @@ class BlueprintApi {
             resolve(blueprint);
           })
           .catch(e => {
-            console.log(`getBlueprint: Error getting component and component metadata: ${e}`);
+            console.log('getBlueprint: Error getting component and component metadata', e);
             reject();
           });
       } else {

--- a/data/MetadataApi.js
+++ b/data/MetadataApi.js
@@ -10,7 +10,7 @@ class MetadataApi {
           resolve(data);
         })
         .catch(e => {
-          console.log(`Failed to get ${api}${e}`);
+          console.log(`Failed to get ${api}`, e);
         });
     });
     return p;

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -131,7 +131,7 @@ class BlueprintsPage extends React.Component {
         (blueprintsError !== null &&
           <EmptyState
             title="An Error Occurred"
-            message="An error occurred while trying to get blueprints."
+            message={blueprintsError.message}
           />
           ||
           (blueprints.length > 0 &&


### PR DESCRIPTION
Propagate API errors, so that the UI doesn't show an infinite spinner when an error occurs. This was most visible when logging in with a user that's not root or in the `weldr` group.

See individual commits for details.

Fixes #293