### PR TITLE
core: Use escalated privileges to access Lorax API

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -15,6 +15,7 @@ function setupCockpitHttp() {
   cockpitHttp = cockpit.http(port, {
     address: welderApiHost,
     tls: useHttps ? {} : undefined,
+    superuser: 'try'
   });
 }
 


### PR DESCRIPTION
Update of @stefwalter's patch in #246. Always require sudo, as discussed on that pull request.