### PR TITLE
Build srpm together with rpm

### DIFF
--- a/Dockerfile.buildrpm
+++ b/Dockerfile.buildrpm
@@ -7,4 +7,4 @@ LABEL maintainer="Xiaofeng Wang" \
 RUN dnf install -y make cmake rpm-build which gnupg tar xz curl jq nodejs && dnf clean all
 
 WORKDIR /welder
-CMD ["make", "rpm"]
+CMD ["make", "rpm", "srpm"]

--- a/Dockerfile.cockpit
+++ b/Dockerfile.cockpit
@@ -9,7 +9,7 @@ RUN echo $'[Negotiate]\nCommand = /usr/libexec/cockpit-stub\n[WebService]\nShell
 RUN rm -rf /usr/share/cockpit/kubernetes/
 
 COPY welder-web*.rpm /tmp/
-RUN dnf -y install /tmp/welder-web*.rpm && rm -f /tmp/welder-web*.rpm
+RUN dnf -y install /tmp/welder-web*.x86_64.rpm
 
 CMD ["/usr/libexec/cockpit-ws", "--no-tls"]
 EXPOSE 9090


### PR DESCRIPTION
we don't really consume the src.rpm package for the moment but
at least build it so we can see if the build breaks.