### PR TITLE
Download images

### DIFF
--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -62,11 +62,11 @@ class ListItemImages extends React.PureComponent {
                 <FormattedMessage defaultMessage="Failed" />
               </div>
             }
-            {listItem.queue_status === 'READY' &&
+            {listItem.queue_status === 'FINISHED' &&
               <div className="list-pf-actions">
-                <button className="btn btn-default" type="button">
+                <a className="btn btn-default" role="button" download href={this.props.downloadUrl}>
                   <FormattedMessage defaultMessage="Download" />
-                </button>
+                </a>
               </div>
             }
           </div>

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -45,9 +45,9 @@ function* pollComposeStatus(compose) {
 
 function* fetchComposes() {
   try {
-    const queue = yield* call(fetchComposeQueueApi);
-    const finished = yield* call(fetchComposeFinishedApi);
-    const failed = yield* call(fetchComposeFailedApi);
+    const queue = yield call(fetchComposeQueueApi);
+    const finished = yield call(fetchComposeFinishedApi);
+    const failed = yield call(fetchComposeFailedApi);
     const composes = queue.concat(finished, failed);
     yield all(composes.map(compose => put(fetchingComposeSucceeded(compose))));
     yield all(queue.map(compose => pollComposeStatus(compose)));

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -1,5 +1,8 @@
+/* global welderApiPort:false */
+
 import React from 'react';
 import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
+import cockpit from 'cockpit'; // eslint-disable-line import/no-unresolved
 import PropTypes from 'prop-types';
 import Link from '../../components/Link';
 import Layout from '../../components/Layout';
@@ -73,6 +76,7 @@ class BlueprintPage extends React.Component {
     this.handleShowModalCreateImage = this.handleShowModalCreateImage.bind(this);
     this.handleChangeDescription = this.handleChangeDescription.bind(this);
     this.handleStartCompose = this.handleStartCompose.bind(this);
+    this.downloadUrl = this.downloadUrl.bind(this);
 
     this.state = {
       changes: [],
@@ -155,6 +159,19 @@ class BlueprintPage extends React.Component {
 
   handleStartCompose(blueprintName, composeType) {
     this.props.startCompose(blueprintName, composeType);
+  }
+
+  downloadUrl(compose) {
+    // NOTE: this only works when welderApiPort is a unix socket
+    const query = window.btoa(JSON.stringify({
+        payload: "http-stream2",
+        unix: welderApiPort,
+        method: 'GET',
+        path: `/api/v0/compose/image/${compose.id}`,
+        superuser: "try"
+    }));
+
+    return `/cockpit/channel/${cockpit.transport.csrf_token}?${query}`;
   }
 
   render() {
@@ -366,6 +383,7 @@ class BlueprintPage extends React.Component {
                       listItemParent="cmpsr-images"
                       blueprint={this.props.route.params.blueprint}
                       listItem={compose}
+                      downloadUrl={this.downloadUrl(compose)}
                       key={i}
                     />
                   ))}


### PR DESCRIPTION
Since images can become quite large, we don't want to load them into memory with `cockpit.http()`. Instead, use cockpit's special `cockpit/channel/` url to create a url which is backed by a cockpit http-stream2 channel.

Blocked on
- [x] #304 (this branch includes @jkozol's commits, but I'll rebase once his PR lands)
- [x] figure out why file size is not sent in the headers