### PR TITLE
Fixed bug where startComposeApi would not return start compose response

### DIFF
--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -156,8 +156,7 @@ export function startComposeApi(blueprintName, composeType) {
     compose_type: composeType,
     branch: "master"
   };
-
-  utils.apiFetch(constants.post_compose_start, {
+  return utils.apiFetch(constants.post_compose_start, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
When creating an image the console would log a startComposeError and our start composer saga wasn't getting a response, I fixed this by adding a missing return statement