### PR TITLE
Adjust Images list layout to improve alignment

### DIFF
--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -20,10 +20,17 @@ class ListItemImages extends React.PureComponent {
                 <div className="list-pf-title text-overflow-pf">
                   {this.props.blueprint}-ver{listItem.version}-{listItem.compose_type}
                 </div>
-                <div className="list-pf-description">Based on Version {listItem.version}</div>
+                <div className="list-pf-description">
+                  <FormattedMessage
+                    defaultMessage="Based on Version {version}"
+                    values={{
+                      version: listItem.version
+                    }}
+                  />
+                </div>
               </div>
               <div className="list-pf-additional-content">
-                <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
+                <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked i18n">
                   <FormattedMessage
                     defaultMessage="Type {type}"
                     values={{
@@ -31,7 +38,7 @@ class ListItemImages extends React.PureComponent {
                     }}
                   />
                 </div>
-                <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
+                <div className="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked i18n">
                   <FormattedMessage
                     defaultMessage="Date Created {date}"
                     values={{
@@ -62,13 +69,13 @@ class ListItemImages extends React.PureComponent {
                 <FormattedMessage defaultMessage="Failed" />
               </div>
             }
-            {listItem.queue_status === 'FINISHED' &&
-              <div className="list-pf-actions">
+            <div className="list-pf-actions">
+              {listItem.queue_status === 'FINISHED' &&
                 <a className="btn btn-default" role="button" download href={this.props.downloadUrl}>
                   <FormattedMessage defaultMessage="Download" />
                 </a>
-              </div>
-            }
+              }
+            </div>
           </div>
         </div>
       </div>

--- a/public/custom.css
+++ b/public/custom.css
@@ -217,7 +217,11 @@
         -ms-flex-align: center;
             align-items: center;
   }
-  .cmpsr-list-pf .list-view-pf-additional-info-item-stacked {
+  .cmpsr-list-pf .list-view-pf-additional-info-item.i18n > span {
+    display: flex;
+  }
+  .cmpsr-list-pf .list-view-pf-additional-info-item-stacked,
+  .cmpsr-list-pf .list-view-pf-additional-info-item-stacked.i18n > span {
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
         -ms-flex-direction: column;


### PR DESCRIPTION
- Modifies css to accommodate extra `<span>` added for translated strings so that date and type values will wrap on wider screens.
- Adds `div.list-pf-actions` for list items that don't have actions since this div is required for flex layout and alignment across all the list items.

**Screencaps of expected layout
window width < 992px**
![image](https://user-images.githubusercontent.com/21063328/43679864-1ffb3578-97fb-11e8-9e88-35a9b4ca0864.png)
**window width > 992px**
![image](https://user-images.githubusercontent.com/21063328/43679868-529ff522-97fb-11e8-83a5-d15179fd3579.png)
