### PR TITLE
Display warning messages to the user in Create Image modal

### DIFF
--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -20,19 +20,13 @@ class BlueprintListView extends React.PureComponent {
               <Link to={`/edit/${blueprint.name}`} className="btn btn-default">
                 <FormattedMessage defaultMessage="Edit Blueprint" />
               </Link>
-              {(blueprint.modules.length === 0 && blueprint.packages.length === 0) &&
-                <button type="button" className="btn btn-default" disabled="disabled">
-                  <FormattedMessage defaultMessage="Create Image" />
-                </button>
-              ||
-                <button
-                  type="button"
-                  className="btn btn-default"
-                  onClick={(e) => this.props.handleShowModalCreateImage(e, blueprint)}
-                >
-                  <FormattedMessage defaultMessage="Create Image" />
-                </button>
-              }
+              <button
+                type="button"
+                className="btn btn-default"
+                onClick={(e) => this.props.handleShowModalCreateImage(e, blueprint)}
+              >
+                <FormattedMessage defaultMessage="Create Image" />
+              </button>
               <div className="dropdown pull-right dropdown-kebab-pf">
                 <button
                   className="btn btn-link dropdown-toggle"

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -221,7 +221,7 @@ class CreateBlueprint extends React.Component {
                   type="button"
                   className="btn btn-primary"
                   onClick={(e) => this.showInlineError(e)}
-                >Create</button>
+                ><FormattedMessage defaultMessage="Create" /></button>
                 ||
                 <button
                   type="button"

--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -4,12 +4,17 @@ import React from 'react';
 import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import NotificationsApi from '../../data/NotificationsApi';
-import { Alert } from 'patternfly-react';
 import BlueprintApi from '../../data/BlueprintApi';
+import { Button, OverlayTrigger, Popover, Icon, Alert } from 'patternfly-react';
 import { connect } from 'react-redux';
 import { setBlueprint } from '../../core/actions/blueprints';
+import { fetchingQueue, clearQueue } from '../../core/actions/composes';
 
 const messages = defineMessages({
+  infotip: {
+    defaultMessage: "This process can take a while. " +
+      "Images are built in the order they are started."
+  },
   warningUnsaved: {
     defaultMessage: "This blueprint has changes that are not committed. " +
       "These changes will be committed before the image is created."
@@ -27,12 +32,19 @@ class CreateImage extends React.Component {
 
   componentWillMount() {
     this.setState({ imageType: this.props.imageTypes[0].name });
+    if (this.props.composeQueueFetched === false) {
+      this.props.fetchingQueue();
+    }
   }
 
   componentDidMount() {
     $(this.modal).modal('show');
     if (this.props.handleHideModal)
       $(this.modal).on('hidden.bs.modal', this.props.handleHideModal);
+  }
+
+  componentWillUnmount() {
+    this.props.clearQueue();
   }
 
   handleCreateImage() {
@@ -77,6 +89,10 @@ class CreateImage extends React.Component {
 
   render() {
     const { formatMessage } = this.props.intl;
+    const running = this.props.composeQueue.filter(compose => compose.queue_status === "RUNNING").length;
+    const waiting = this.props.composeQueue.filter(compose => compose.queue_status === "WAITING").length;
+    // const running = 1;
+    // const waiting = 2;
     return (
       <div
         className="modal fade"
@@ -142,6 +158,35 @@ class CreateImage extends React.Component {
               </form>
             </div>
             <div className="modal-footer">
+              <div className="pull-left">
+                <OverlayTrigger
+                  overlay={
+                    <Popover id="CreateImageInfotip">
+                      <p>{formatMessage(messages.infotip)}</p>
+                      {(running >= 1) && 
+                        <FormattedMessage defaultMessage="1 build is in progress" tagName="p" />
+                      }
+                      {(waiting >= 1) && 
+                        <FormattedMessage 
+                          defaultMessage="{builds, plural,
+                            one   {# build is waiting}
+                            other {# builds are waiting}
+                          }"
+                          tagName="p"
+                          values={{
+                            builds: waiting
+                          }} 
+                        />
+                      }
+                    </Popover>
+                    }
+                  placement="right"
+                  trigger={["click"]}
+                  rootClose
+                >
+                  <Button bsStyle="link"><Icon type="pf" name="pficon pficon-help" /></Button>
+                </OverlayTrigger>
+              </div>
               <button type="button" className="btn btn-default" data-dismiss="modal">
                 <FormattedMessage defaultMessage="Cancel" />
               </button>
@@ -164,7 +209,11 @@ class CreateImage extends React.Component {
 
 CreateImage.propTypes = {
   blueprint: PropTypes.object,
+  composeQueue: PropTypes.array,
+  composeQueueFetched: PropTypes.bool,
   handleStartCompose: PropTypes.func,
+  fetchingQueue: PropTypes.func,
+  clearQueue: PropTypes.func,
   handleHideModal: PropTypes.func,
   setNotifications: PropTypes.func,
   imageTypes: PropTypes.array,
@@ -174,10 +223,22 @@ CreateImage.propTypes = {
   intl: intlShape.isRequired,
 };
 
+
+const mapStateToProps = state => ({
+  composeQueue: state.composes.queue,
+  composeQueueFetched: state.composes.queueFetched,
+});
+
 const mapDispatchToProps = (dispatch) => ({
   setBlueprint: blueprint => {
     dispatch(setBlueprint(blueprint));
   },
+  fetchingQueue: () => {
+    dispatch(fetchingQueue());
+  },
+  clearQueue: () => {
+    dispatch(clearQueue());
+  },
 });
 
-export default connect(null, mapDispatchToProps)(injectIntl(CreateImage));
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(CreateImage));

--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -1,9 +1,17 @@
 /* global $ */
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, defineMessages, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import NotificationsApi from '../../data/NotificationsApi';
+import { Alert } from 'patternfly-react';
+
+const messages = defineMessages({
+  warningUnsaved: {
+    defaultMessage: "This blueprint has changes that are not committed. " +
+                    "These changes will not be included in the image."
+  }
+});
 
 class CreateImage extends React.Component {
   constructor() {
@@ -37,6 +45,7 @@ class CreateImage extends React.Component {
   }
 
   render() {
+    const { formatMessage } = this.props.intl;
     return (
       <div
         className="modal fade"
@@ -56,6 +65,16 @@ class CreateImage extends React.Component {
               <h4 className="modal-title" id="myModalLabel"><FormattedMessage defaultMessage="Create Image" /></h4>
             </div>
             <div className="modal-body">
+              {this.props.warningEmpty === true &&
+                <Alert type="warning">
+                  <FormattedMessage defaultMessage="This blueprint is empty." />
+                </Alert>
+              }
+              {this.props.warningUnsaved === true &&
+                <Alert type="warning">
+                  {formatMessage(messages.warningUnsaved)}
+                </Alert>
+              }
               <form className="form-horizontal">
                 <div className="form-group">
                   <label
@@ -112,6 +131,9 @@ CreateImage.propTypes = {
   handleHideModal: PropTypes.func,
   setNotifications: PropTypes.func,
   imageTypes: PropTypes.array,
+  warningEmpty: PropTypes.bool,
+  warningUnsaved: PropTypes.bool,
+  intl: intlShape.isRequired,
 };
 
-export default CreateImage;
+export default injectIntl(CreateImage);

--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -32,11 +32,11 @@ class CreateImage extends React.Component {
   }
 
   handleCreateImage() {
-    NotificationsApi.displayNotification(this.props.blueprint, 'imageWaiting');
+    NotificationsApi.displayNotification(this.props.blueprint.name, 'imageWaiting');
     if (this.props.setNotifications)
       this.props.setNotifications();
     if (this.props.handleStartCompose)
-      this.props.handleStartCompose(this.props.blueprint, this.state.imageType);
+      this.props.handleStartCompose(this.props.blueprint.name, this.state.imageType);
     $('#cmpsr-modal-crt-image').modal('hide');
   }
 
@@ -81,7 +81,7 @@ class CreateImage extends React.Component {
                     className="col-sm-3 control-label"
                   ><FormattedMessage defaultMessage="Blueprint" /></label>
                   <div className="col-sm-9">
-                    <p className="form-control-static">{this.props.blueprint}</p>
+                    <p className="form-control-static">{this.props.blueprint.name}</p>
                   </div>
                 </div>
                 <div className="form-group">
@@ -126,7 +126,7 @@ class CreateImage extends React.Component {
 }
 
 CreateImage.propTypes = {
-  blueprint: PropTypes.string,
+  blueprint: PropTypes.object,
   handleStartCompose: PropTypes.func,
   handleHideModal: PropTypes.func,
   setNotifications: PropTypes.func,

--- a/core/actions/composes.js
+++ b/core/actions/composes.js
@@ -21,6 +21,10 @@ export const fetchingComposes = () => ({
   type: FETCHING_COMPOSES,
 });
 
+export const FETCHING_QUEUE = 'FETCHING_QUEUE';
+export const fetchingQueue = () => ({
+  type: FETCHING_QUEUE,
+});
 
 export const FETCHING_COMPOSE_SUCCEEDED = 'FETCHING_COMPOSE_SUCCEEDED';
 export const fetchingComposeSucceeded = (compose) => ({
@@ -36,6 +40,18 @@ export const fetchingComposeStatusSucceeded = (compose) => ({
   payload: {
     compose,
   },
+});
+
+export const FETCHING_QUEUE_SUCCEEDED = 'FETCHING_QUEUE_SUCCEEDED';
+export const fetchingQueueSucceeded = (queue) => ({
+  type: FETCHING_QUEUE_SUCCEEDED,
+  payload: {
+    queue,
+  },
+});
+export const CLEAR_QUEUE = 'CLEAR_QUEUE';
+export const clearQueue = () => ({
+  type: CLEAR_QUEUE,
 });
 
 export const COMPOSES_FAILURE = 'COMPOSES_FAILURE';

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -138,23 +138,20 @@ export function setModalDeleteBlueprintVisible(visible) {
   };
 }
 
-export const SET_MODAL_CREATE_IMAGE_BLUEPRINT_NAME = 'SET_MODAL_CREATE_IMAGE_BLUEPRINT_NAME';
-export function setModalCreateImageBlueprintName(blueprintName) {
+export const SET_MODAL_CREATE_IMAGE_VISIBLE = 'SET_MODAL_CREATE_IMAGE_VISIBLE';
+export function setModalCreateImageVisible(blueprint) {
   return {
-    type: SET_MODAL_CREATE_IMAGE_BLUEPRINT_NAME,
+    type: SET_MODAL_CREATE_IMAGE_VISIBLE,
     payload: {
-      blueprintName,
+      blueprint,
     },
   };
 }
 
-export const SET_MODAL_CREATE_IMAGE_VISIBLE = 'SET_MODAL_CREATE_IMAGE_VISIBLE';
-export function setModalCreateImageVisible(visible) {
+export const SET_MODAL_CREATE_IMAGE_HIDDEN = 'SET_MODAL_CREATE_IMAGE_HIDDEN';
+export function setModalCreateImageHidden() {
   return {
-    type: SET_MODAL_CREATE_IMAGE_VISIBLE,
-    payload: {
-      visible,
-    },
+    type: SET_MODAL_CREATE_IMAGE_HIDDEN,
   };
 }
 

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -65,6 +65,7 @@ export function fetchBlueprintInfoApi(blueprintName) {
     .then(blueprintdata => {
       if (blueprintdata.blueprints.length > 0) {
         let blueprint = blueprintdata.blueprints[0];
+        blueprint.changed = blueprintdata.changes[0].changed;
         blueprint.id = blueprintName;
         return blueprint;
       }

--- a/core/reducers/composes.js
+++ b/core/reducers/composes.js
@@ -1,6 +1,7 @@
 import {
   FETCHING_COMPOSE_SUCCEEDED, FETCHING_COMPOSE_STATUS_SUCCEEDED, COMPOSES_FAILURE, DELETING_COMPOSE_SUCCEEDED,
   DELETING_COMPOSE_FAILURE, CANCELLING_COMPOSE, CANCELLING_COMPOSE_SUCCEEDED, CANCELLING_COMPOSE_FAILURE,
+  FETCHING_QUEUE_SUCCEEDED, CLEAR_QUEUE,
 } from '../actions/composes';
 
 function removeCompose(array, composeId) {
@@ -21,6 +22,17 @@ const compose = (state = [], action) => {
       return Object.assign({}, state, {
         fetchingComposes: false,
         composeList: removeCompose(state.composeList, action.payload.compose.id).concat(action.payload.compose),
+      });
+    case FETCHING_QUEUE_SUCCEEDED:
+      // Replace any existing queue with new queue
+      return Object.assign({}, state, {
+        queue: action.payload.queue,
+        queueFetched: true,
+      });
+    case CLEAR_QUEUE:
+      return Object.assign({}, state, {
+        queue: [],
+        queueFetched: false,
       });
     case COMPOSES_FAILURE:
       return Object.assign({}, state, {

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -4,7 +4,7 @@ import {
   SET_MODAL_DELETE_BLUEPRINT_NAME, SET_MODAL_DELETE_BLUEPRINT_ID, SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
   SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE, SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE,
   SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE, SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS, SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT,
-  SET_MODAL_CREATE_IMAGE_BLUEPRINT_NAME, SET_MODAL_CREATE_IMAGE_VISIBLE, 
+  SET_MODAL_CREATE_IMAGE_VISIBLE, SET_MODAL_CREATE_IMAGE_HIDDEN,
   SET_MODAL_DELETE_IMAGE_VISIBLE, SET_MODAL_DELETE_IMAGE_STATE, SET_MODAL_STOP_BUILD_VISIBLE, 
   SET_MODAL_STOP_BUILD_STATE, FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS,
   SET_MODAL_MANAGE_SOURCES_VISIBLE, SET_MODAL_MANAGE_SOURCES_CONTENTS, MODAL_MANAGE_SOURCES_FAILURE,
@@ -54,18 +54,35 @@ const modalCreateImage = (state = [], action) => {
   switch (action.type) {
     case FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS:
       return Object.assign(
-          {}, state,
-          { createImage: Object.assign({}, state.createImage, { imageTypes: action.payload.imageTypes }) }
-      );
-    case SET_MODAL_CREATE_IMAGE_BLUEPRINT_NAME:
-      return Object.assign(
-          {}, state,
-          { createImage: Object.assign({}, state.createImage, { name: action.payload.blueprintName }) }
+        {}, state,
+        { createImage: Object.assign({}, state.createImage, { imageTypes: action.payload.imageTypes }) }
       );
     case SET_MODAL_CREATE_IMAGE_VISIBLE:
       return Object.assign(
+        {}, state,
+        { createImage: Object.assign(
+          {}, state.createImage, {
+            visible: true,
+            name: action.payload.blueprint.name,
+            warningEmpty: action.payload.blueprint.packages.length === 0 && action.payload.blueprint.modules.length === 0,
+            warningUnsaved: (
+              action.payload.blueprint.changed === true ||
+              action.payload.blueprint.localPendingChanges.length > 0
+            )
+          })
+        }
+      );
+      case SET_MODAL_CREATE_IMAGE_HIDDEN:
+        return Object.assign(
           {}, state,
-          { createImage: Object.assign({}, state.createImage, { visible: action.payload.visible }) }
+          { createImage: Object.assign(
+            {}, state.createImage, {
+              visible: false,
+              name: '',
+              warningEmpty: undefined,
+              warningUnsaved: undefined
+            })
+          }
       );
     default:
       return state;
@@ -204,9 +221,9 @@ const modals = (state = [], action) => {
       return modalDeleteBlueprint(state, action);
     case FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS:
       return modalCreateImage(state, action);
-    case SET_MODAL_CREATE_IMAGE_BLUEPRINT_NAME:
-      return modalCreateImage(state, action);
     case SET_MODAL_CREATE_IMAGE_VISIBLE:
+      return modalCreateImage(state, action);
+    case SET_MODAL_CREATE_IMAGE_HIDDEN:
       return modalCreateImage(state, action);
     case SET_MODAL_STOP_BUILD_STATE:
       return modalStopBuild(state, action);

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -63,7 +63,7 @@ const modalCreateImage = (state = [], action) => {
         { createImage: Object.assign(
           {}, state.createImage, {
             visible: true,
-            name: action.payload.blueprint.name,
+            blueprint: action.payload.blueprint,
             warningEmpty: action.payload.blueprint.packages.length === 0 && action.payload.blueprint.modules.length === 0,
             warningUnsaved: (
               action.payload.blueprint.changed === true ||

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -10,7 +10,8 @@ import {
    fetchingComposeStatusSucceeded,
    FETCHING_COMPOSES, fetchingComposeSucceeded,
    composesFailure, CANCELLING_COMPOSE, DELETING_COMPOSE, deletingComposeSucceeded, 
-   deletingComposeFailure, cancellingComposeSucceeded, cancellingComposeFailure
+   deletingComposeFailure, cancellingComposeSucceeded, cancellingComposeFailure,
+   FETCHING_QUEUE, fetchingQueueSucceeded
 } from '../actions/composes';
 
 
@@ -90,9 +91,20 @@ function* cancelCompose(action) {
   }
 }
 
+function* fetchQueue() {
+  try {
+    const queue = yield call(fetchComposeQueueApi);
+    yield put(fetchingQueueSucceeded(queue));
+  } catch (error) {
+    console.log('fetchQueueError');
+    yield put(composesFailure(error));
+  }
+}
+
 export default function* () {
   yield takeEvery(START_COMPOSE, startCompose);
   yield takeEvery(FETCHING_COMPOSES, fetchComposes);
   yield takeEvery(DELETING_COMPOSE, deleteCompose);
   yield takeEvery(CANCELLING_COMPOSE, cancelCompose);
+  yield takeEvery(FETCHING_QUEUE, fetchQueue);
 }

--- a/core/store.js
+++ b/core/store.js
@@ -37,6 +37,8 @@ const initialState = {
   },
   composes: {
     composeList: [],
+    queue: [],
+    queueFetched: false,
     fetchingComposes: true,
     errorState: null,
   },

--- a/core/store.js
+++ b/core/store.js
@@ -42,7 +42,7 @@ const initialState = {
   },
   modals: {
     createImage: {
-      name: '',
+      blueprint: {},
       imageTypes: [],
       visible: false,
     },

--- a/data/BlueprintApi.js
+++ b/data/BlueprintApi.js
@@ -145,6 +145,7 @@ class BlueprintApi {
         resolve();
       }).catch(e => {
         console.log(`Error committing blueprint: ${e}`);
+        NotificationsApi.closeNotification(undefined, 'committing');
         NotificationsApi.displayNotification(this.blueprint.name, 'commitFailed');
         reject();
       });

--- a/data/BlueprintApi.js
+++ b/data/BlueprintApi.js
@@ -128,15 +128,7 @@ class BlueprintApi {
     }).catch((e) => { console.log(`Error creating blueprint: ${e}`); });
   }
 
-  handleCommitBlueprint() {
-    // create blueprint and post it
-    const blueprint = {
-      name: this.blueprint.name,
-      description: this.blueprint.description,
-      version: this.blueprint.version,
-      modules: this.blueprint.modules,
-      packages: this.blueprint.packages,
-    };
+  handleCommitBlueprint(blueprint) {
     const p = new Promise((resolve, reject) => {
       this.postBlueprint(blueprint)
       .then(() => {

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -404,7 +404,7 @@ class BlueprintPage extends React.Component {
         </Tabs>
         {createImage.visible
           ? <CreateImage
-            blueprint={blueprint.name}
+            blueprint={blueprint}
             imageTypes={createImage.imageTypes}
             setNotifications={this.setNotifications}
             handleStartCompose={this.handleStartCompose}

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -27,7 +27,7 @@ import {
   fetchingComposes, startCompose,
 } from '../../core/actions/composes';
 import {
-  setModalExportBlueprintVisible, setModalCreateImageVisible, setModalCreateImageBlueprintName,
+  setModalExportBlueprintVisible, setModalCreateImageVisible, setModalCreateImageHidden,
   setModalStopBuildVisible, setModalStopBuildState, setModalDeleteImageVisible, setModalDeleteImageState,
 } from '../../core/actions/modals';
 import {
@@ -148,13 +148,11 @@ class BlueprintPage extends React.Component {
   }
 
   handleHideModalCreateImage() {
-    this.props.setModalCreateImageVisible(false);
-    this.props.setModalCreateImageBlueprintName('');
+    this.props.setModalCreateImageHidden();
   }
 
   handleShowModalCreateImage(e, blueprint) {
-    this.props.setModalCreateImageBlueprintName(blueprint.name);
-    this.props.setModalCreateImageVisible(true);
+    this.props.setModalCreateImageVisible(blueprint);
     e.preventDefault();
     e.stopPropagation();
   }
@@ -238,7 +236,7 @@ class BlueprintPage extends React.Component {
               </li>
               <li>
                 <button
-                  className={`btn btn-default ${selectedComponents.length ? '' : 'disabled'}`}
+                  className="btn btn-default"
                   id="cmpsr-btn-crt-image"
                   data-toggle="modal"
                   data-target="#cmpsr-modal-crt-image"
@@ -411,6 +409,8 @@ class BlueprintPage extends React.Component {
             setNotifications={this.setNotifications}
             handleStartCompose={this.handleStartCompose}
             handleHideModal={this.handleHideModalCreateImage}
+            warningEmpty={createImage.warningEmpty}
+            warningUnsaved={createImage.warningUnsaved}
           />
           : null}
         {exportModalVisible
@@ -472,7 +472,7 @@ BlueprintPage.propTypes = {
   componentsSortKey: PropTypes.string,
   componentsSortValue: PropTypes.string,
   setModalCreateImageVisible: PropTypes.func,
-  setModalCreateImageBlueprintName: PropTypes.func,
+  setModalCreateImageHidden: PropTypes.func,
   setModalStopBuildVisible: PropTypes.func,
   setModalStopBuildState: PropTypes.func,
   setModalDeleteImageVisible: PropTypes.func,
@@ -563,11 +563,11 @@ const mapDispatchToProps = (dispatch) => ({
   setModalExportBlueprintVisible: (visible) => {
     dispatch(setModalExportBlueprintVisible(visible));
   },
-  setModalCreateImageBlueprintName: modalBlueprintName => {
-    dispatch(setModalCreateImageBlueprintName(modalBlueprintName));
-  },
   setModalCreateImageVisible: modalVisible => {
     dispatch(setModalCreateImageVisible(modalVisible));
+  },
+  setModalCreateImageHidden: () => {
+    dispatch(setModalCreateImageHidden());
   },
   setModalStopBuildState: (composeId, blueprintName) => {
     dispatch(setModalStopBuildState(composeId, blueprintName));

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -660,7 +660,7 @@ class EditBlueprintPage extends React.Component {
                 />
               </div>
             </div>
-            {(blueprint.components.length === 0 || blueprint.components === undefined ) &&
+            {(blueprint.components === undefined || blueprint.components.length === 0) &&
               <div className="alert alert-info alert-dismissable">
                 <button type="button" className="close" data-dismiss="alert" aria-hidden="true" aria-label="Dismiss Message">
                   <span className="pficon pficon-close" />
@@ -702,7 +702,7 @@ class EditBlueprintPage extends React.Component {
         }
         {modalActive === 'modalCreateImage'
           ? <CreateImage
-            blueprint={createImage.name}
+            blueprint={createImage.blueprint}
             imageTypes={createImage.imageTypes}
             handleStartCompose={this.handleStartCompose}
             handleHideModal={this.handleHideModalCreateImage}

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -26,7 +26,8 @@ import {
   fetchingInputs, setInputComponents, setSelectedInputPage,
   setSelectedInput, setSelectedInputStatus, setSelectedInputParent, deleteFilter,
 } from '../../core/actions/inputs';
-import { setModalActive } from '../../core/actions/modals';
+import { setModalActive, setModalCreateImageVisible, setModalCreateImageHidden,
+} from '../../core/actions/modals';
 import {
   componentsSortSetKey, componentsSortSetValue, dependenciesSortSetKey, dependenciesSortSetValue,
 } from '../../core/actions/sort';
@@ -65,6 +66,7 @@ class EditBlueprintPage extends React.Component {
     this.handleUpdateComponent = this.handleUpdateComponent.bind(this);
     this.handleRemoveComponent = this.handleRemoveComponent.bind(this);
     this.handleComponentDetails = this.handleComponentDetails.bind(this);
+    this.handleHideModalCreateImage = this.handleHideModalCreateImage.bind(this);
     this.handleHideModal = this.handleHideModal.bind(this);
     this.handleShowModal = this.handleShowModal.bind(this);
     this.handleHistory = this.handleHistory.bind(this);
@@ -384,6 +386,10 @@ class EditBlueprintPage extends React.Component {
   handleHideModal() {
     this.props.setModalActive(null);
   }
+  handleHideModalCreateImage() {
+    this.props.setModalActive(null);
+    this.props.setModalCreateImageHidden();
+  }
   handleShowModal(e, modalType) {
     switch (modalType) {
       case 'modalPendingChanges':
@@ -394,6 +400,7 @@ class EditBlueprintPage extends React.Component {
         this.props.setModalActive('modalExportBlueprint');
         break;
       case 'modalCreateImage':
+        this.props.setModalCreateImageVisible(this.props.blueprint);
         this.props.setModalActive('modalCreateImage');
         break;
       default:
@@ -499,7 +506,7 @@ class EditBlueprintPage extends React.Component {
               }
               <li className="list__subgroup-item--first">
                 <button
-                  className={`btn btn-default ${selectedComponents.length ? '' : 'disabled'}`}
+                  className="btn btn-default"
                   id="cmpsr-btn-crt-image"
                   data-toggle="modal"
                   data-target="#cmpsr-modal-crt-image"
@@ -695,11 +702,13 @@ class EditBlueprintPage extends React.Component {
         }
         {modalActive === 'modalCreateImage'
           ? <CreateImage
-            blueprint={blueprint.name}
-            setNotifications={this.setNotifications}
-            handleStartCompose={this.handleStartCompose}
+            blueprint={createImage.name}
             imageTypes={createImage.imageTypes}
-            handleHideModal={this.handleHideModal}
+            handleStartCompose={this.handleStartCompose}
+            handleHideModal={this.handleHideModalCreateImage}
+            setNotifications={this.setNotifications}
+            warningEmpty={createImage.warningEmpty}
+            warningUnsaved={createImage.warningUnsaved}
           />
           : null}
         {modalActive === 'modalExportBlueprint'
@@ -742,6 +751,8 @@ EditBlueprintPage.propTypes = {
   deleteFilter: PropTypes.func,
   addBlueprintComponent: PropTypes.func,
   setModalActive: PropTypes.func,
+  setModalCreateImageVisible: PropTypes.func,
+  setModalCreateImageHidden: PropTypes.func,
   dependenciesSortSetValue: PropTypes.func,
   componentsSortSetValue: PropTypes.func,
   selectedComponents: PropTypes.array,
@@ -851,6 +862,12 @@ const mapDispatchToProps = (dispatch) => ({
   },
   setModalActive: (modalActive) => {
     dispatch(setModalActive(modalActive));
+  },
+  setModalCreateImageVisible: modalVisible => {
+    dispatch(setModalCreateImageVisible(modalVisible));
+  },
+  setModalCreateImageHidden: () => {
+    dispatch(setModalCreateImageHidden());
   },
   componentsSortSetKey: key => {
     dispatch(componentsSortSetKey(key));

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -17,7 +17,7 @@ import {
   fetchingModalExportBlueprintContents,
   setModalExportBlueprintName, setModalExportBlueprintContents, setModalExportBlueprintVisible,
   setModalDeleteBlueprintName, setModalDeleteBlueprintId, setModalDeleteBlueprintVisible,
-  setModalCreateImageBlueprintName, setModalCreateImageVisible,
+  setModalCreateImageVisible, setModalCreateImageHidden,
   setModalManageSourcesVisible, fetchingModalManageSourcesContents,
 } from '../../core/actions/modals';
 import { blueprintsSortSetKey, blueprintsSortSetValue } from '../../core/actions/sort';
@@ -125,13 +125,11 @@ class BlueprintsPage extends React.Component {
   }
 
   handleHideModalCreateImage() {
-    this.props.setModalCreateImageVisible(false);
-    this.props.setModalCreateImageBlueprintName('');
+    this.props.setModalCreateImageHidden();
   }
 
   handleShowModalCreateImage(e, blueprint) {
-    this.props.setModalCreateImageBlueprintName(blueprint.name);
-    this.props.setModalCreateImageVisible(true);
+    this.props.setModalCreateImageVisible(blueprint);
     e.preventDefault();
     e.stopPropagation();
   }
@@ -240,6 +238,8 @@ class BlueprintsPage extends React.Component {
             handleStartCompose={this.handleStartCompose}
             handleHideModal={this.handleHideModalCreateImage}
             setNotifications={this.setNotifications}
+            warningEmpty={createImage.warningEmpty}
+            warningUnsaved={createImage.warningUnsaved}
           />
           : null}
         {(manageSources !== undefined && manageSources.visible)
@@ -256,7 +256,7 @@ class BlueprintsPage extends React.Component {
 BlueprintsPage.propTypes = {
   deletingBlueprint: PropTypes.func,
   setModalCreateImageVisible: PropTypes.func,
-  setModalCreateImageBlueprintName: PropTypes.func,
+  setModalCreateImageHidden: PropTypes.func,
   setModalDeleteBlueprintVisible: PropTypes.func,
   setModalDeleteBlueprintName: PropTypes.func,
   setModalDeleteBlueprintId: PropTypes.func,
@@ -349,11 +349,11 @@ const mapDispatchToProps = dispatch => ({
   setModalDeleteBlueprintVisible: modalVisible => {
     dispatch(setModalDeleteBlueprintVisible(modalVisible));
   },
-  setModalCreateImageBlueprintName: modalBlueprintName => {
-    dispatch(setModalCreateImageBlueprintName(modalBlueprintName));
-  },
   setModalCreateImageVisible: modalVisible => {
     dispatch(setModalCreateImageVisible(modalVisible));
+  },
+  setModalCreateImageHidden: () => {
+    dispatch(setModalCreateImageHidden());
   },
   fetchingModalManageSourcesContents: () => {
     dispatch(fetchingModalManageSourcesContents());

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -233,7 +233,7 @@ class BlueprintsPage extends React.Component {
           : null}
         {(createImage !== undefined && createImage.visible)
           ? <CreateImage
-            blueprint={createImage.name}
+            blueprint={createImage.blueprint}
             imageTypes={createImage.imageTypes}
             handleStartCompose={this.handleStartCompose}
             handleHideModal={this.handleHideModalCreateImage}

--- a/test/end-to-end/pages/viewBlueprint.js
+++ b/test/end-to-end/pages/viewBlueprint.js
@@ -40,7 +40,7 @@ module.exports = class ViewBlueprintPage extends MainPage {
 
     // Create Image button
     this.varCreateImage = 'Create Image';
-    this.btnCreateImage = '#cmpsr-btn-crt-image[class="btn btn-default "]';
+    this.btnCreateImage = '#cmpsr-btn-crt-image';
 
     // More action button
     this.btnMore = 'button[id="dropdownKebab"]';

--- a/test/unit/create.image.spec.js
+++ b/test/unit/create.image.spec.js
@@ -1,90 +1,138 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import {IntlProvider} from 'react-intl';
+import { shallow, mount } from 'enzyme';
 import faker from 'faker';
 import CreateImage from '../../components/Modal/CreateImage';
-
-const typeList = [
-  { name: 'ami', enabled: true },
-  { name: 'disk-image', enabled: false },
-  { name: 'fs-image', enabled: false },
-  { name: 'iso', enabled: true },
-  { name: 'live-ostree', enabled: false },
-  { name: 'live-pxe', enabled: false },
-  { name: 'oci', enabled: false },
-  { name: 'ostree', enabled: true },
-  { name: 'qcow2', enabled: true },
-  { name: 'tar', enabled: false },
-  { name: 'vagrant', enabled: false },
-  { name: 'vhdx', enabled: true },
-  { name: 'vmdk', enabled: false },
-];
-
-jest.mock('../../core/utils', () => ({ apiFetch: jest.fn().mockImplementation(() => {
-  const p = new Promise((resolve, reject) => {
-    resolve({
-      types: typeList,
-    });
-    reject(new Error('fail'));
-  });
-  return p;
-}),
-}));
+import { Provider } from 'react-redux';
 
 describe('CreateImage', () => {
-  const createImage = (props) => {
-    return shallow(
-      <CreateImage {...Object.assign({ imageTypes: typeList }, props)} />
-    );
+  const fakeBlueprintName = faker.lorem.words();
+  const mockState = {
+    composes: {
+      composeList: [],
+      queue: [],
+      queueFetched: false,
+      fetchingComposes: true,
+      errorState: null,
+    },
+    modals: {
+      createImage: {
+        blueprint: {
+          name: fakeBlueprintName,
+        },
+        imageTypes: [
+          { name: 'ami', enabled: true },
+          { name: 'disk-image', enabled: false },
+          { name: 'fs-image', enabled: false },
+          { name: 'iso', enabled: true },
+          { name: 'live-ostree', enabled: false },
+          { name: 'live-pxe', enabled: false },
+          { name: 'oci', enabled: false },
+          { name: 'ostree', enabled: true },
+          { name: 'qcow2', enabled: true },
+          { name: 'tar', enabled: false },
+          { name: 'vagrant', enabled: false },
+          { name: 'vhdx', enabled: true },
+          { name: 'vmdk', enabled: false },
+        ],
+        visible: true,
+      },
+    },
   };
+  const typeList = mockState.modals.createImage.imageTypes;
+  const createImage = mockState.modals.createImage;
+  const mockStore = { subscribe: () => null, dispatch: () => null, state: mockState, getState: () => mockState };
 
   test('always renders a div', () => {
-    const divs = createImage().find('div');
+    const wrapper = shallow(
+      <CreateImage
+        store={mockStore}
+        blueprint={createImage.blueprint}
+        imageTypes={typeList}
+        warningEmpty={createImage.warningEmpty}
+        warningUnsaved={createImage.warningUnsaved}
+      />
+    );
+    const container = wrapper.first('div');
 
-    expect(divs.length).toBeGreaterThan(0);
+    expect(container.length).toBeGreaterThan(0);
   });
 
-  describe('the rendered div', () => {
-    test('contains everything else that gets rendered', () => {
-      const wrapper = createImage();
-      const divs = wrapper.find('div');
-      const wrappingDiv = divs.first();
+  test('contains everything else that gets rendered', () => {
+    const wrapper = shallow(
+      <CreateImage
+        store={mockStore}
+        blueprint={createImage.blueprint}
+        imageTypes={typeList}
+        warningEmpty={createImage.warningEmpty}
+        warningUnsaved={createImage.warningUnsaved}
+      />
+    );
+    const divs = wrapper.find('div');
+    const wrappingDiv = divs.first();
 
-      expect(wrappingDiv.children()).toEqual(wrapper.children());
-    });
+    expect(wrappingDiv.children()).toEqual(wrapper.children());
   });
 
-  describe('props test', () => {
-    test('should render correct Blueprint name passed by props', () => {
-      const fakeBlueprintName = faker.lorem.words();
-      const wrapper = createImage({ blueprint: fakeBlueprintName });
+  test('should render correct Blueprint name passed by props', () => {
+    const component = mount(
+      <Provider store={mockStore}>
+        <IntlProvider locale='en'>
+          <CreateImage
+            store={mockStore}
+            blueprint={createImage.blueprint}
+            imageTypes={typeList}
+            warningEmpty={createImage.warningEmpty}
+            warningUnsaved={createImage.warningUnsaved}
+          />
+        </IntlProvider>
+      </Provider>
+    );
+    const blueprintName = component.find('.form-control-static');
 
-      const divs = wrapper.find('.form-control-static');
-
-      expect(divs.text()).toEqual(fakeBlueprintName);
-    });
-
-    test('setNofifications, passed by props, should be called by clicking Create button', () => {
-      const setNotificationsSpy = jest.fn();
-      const handleStartComposeSpy = jest.fn();
-
-      const wrapper = createImage({
-        setNotifications: setNotificationsSpy,
-        handleStartCompose: handleStartComposeSpy
-      });
-
-      wrapper.find('.btn-primary').simulate('click');
-
-      expect(setNotificationsSpy).toHaveBeenCalledTimes(1);
-      expect(handleStartComposeSpy).toHaveBeenCalledTimes(1);
-    });
+    expect(blueprintName.text()).toEqual(fakeBlueprintName);
   });
 
-  describe('state test', () => {
-    test('should have a correct type render', () => {
-      const wrapper = createImage();
-      const renderedType = wrapper.find('label[htmlFor="textInput-modal-markup"] + div select option');
+  test('setNofifications, passed by props, should be called by clicking Create button', () => {
+    const setNotificationsSpy = jest.fn();
+    const handleStartComposeSpy = jest.fn();
+    const component = mount(
+      <Provider store={mockStore}>
+        <IntlProvider locale='en'>
+          <CreateImage
+            store={mockStore}
+            blueprint={createImage.blueprint}
+            imageTypes={typeList}
+            warningEmpty={createImage.warningEmpty}
+            warningUnsaved={createImage.warningUnsaved}
+            setNotifications={setNotificationsSpy}
+            handleStartCompose={handleStartComposeSpy}
+          />
+        </IntlProvider>
+      </Provider>
+    );
 
-      expect(renderedType).toHaveLength(13);
-    });
+    component.find('.btn-primary').simulate('click');
+
+    expect(setNotificationsSpy).toHaveBeenCalledTimes(1);
+    expect(handleStartComposeSpy).toHaveBeenCalledTimes(1);
   });
+
+  test('should have a correct type render', () => {
+    const component = mount(
+      <Provider store={mockStore}>
+        <IntlProvider locale='en'>
+          <CreateImage
+            store={mockStore}
+            blueprint={createImage.blueprint}
+            imageTypes={typeList}
+          />
+        </IntlProvider>
+      </Provider>
+    );
+    const renderedType = component.find('label[htmlFor="textInput-modal-markup"] + div select option');
+
+    expect(renderedType).toHaveLength(13);
+  });
+
 });


### PR DESCRIPTION
These updates will display a warning message in the modal dialog to the user for the following cases:

- The blueprint is empty
- The blueprint has unsaved changes
  - This case required a small change to the data returned by fetchBlueprintInfoApi to also include the `changed` value. On the blueprints page, this is the only way we know if there are unsaved changes in the workspace, without fetching the blueprint contents.

![image](https://user-images.githubusercontent.com/21063328/43747670-65f5e31a-99b9-11e8-8e36-e84eb8ff66aa.png)

_Deleted the example of the second case. An updated example is included [below](https://github.com/weldr/welder-web/pull/330#issuecomment-416083737)_
