### PR TITLE
Fix issue with displaying Date Created in list of Images

### DIFF
--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -44,7 +44,7 @@ class ListItemImages extends React.Component {
 
   render() {
     const { listItem } = this.props;
-    const timestamp = new Date(listItem.timestamp * 1000);
+    const timestamp = new Date(listItem.job_created * 1000);
     const formattedTime = timestamp.toDateString();
     return (
       <div className="list-pf-item">


### PR DESCRIPTION
After the API updates to provide 3 timestamps, the property key for the Date Created value from the API no longer matched the property key expected in the UI. This updates the UI to use the new property key from the API so that the date displays as shown below.

![image](https://user-images.githubusercontent.com/21063328/44935018-1616bf80-ad3d-11e8-968a-9589187f88c6.png)
