### PR TITLE
pass blueprint data that's expected on save

### DIFF
--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -75,10 +75,9 @@ class CreateImage extends React.Component {
         // and call create image     
         Promise.all([BlueprintApi.reloadBlueprintDetails(this.props.blueprint)])
           .then(data => {
-            const blueprintToSet = this.props.blueprint;
-            blueprintToSet.name = data[0].name;
-            blueprintToSet.description = data[0].description;
-            blueprintToSet.version = data[0].version;
+            const blueprintToSet = Object.assign({}, this.props.blueprint, {
+              version: data[0].version,
+            });
             this.props.setBlueprint(blueprintToSet);
             this.handleCreateImage();
           })

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -78,6 +78,14 @@ export const setBlueprintDescription = (blueprint, description) => ({
   },
 });
 
+export const SET_BLUEPRINT_DESCRIPTION_SUCCEEDED = 'SET_BLUEPRINT_DESCRIPTION_SUCCEEDED';
+export const setBlueprintDescriptionSucceeded = (blueprint) => ({
+  type: SET_BLUEPRINT_DESCRIPTION_SUCCEEDED,
+  payload: {
+    blueprint,
+  },
+});
+
 export const ADD_BLUEPRINT_COMPONENT = 'ADD_BLUEPRINT_COMPONENT';
 export const addBlueprintComponent = (blueprint, component) => ({
   type: ADD_BLUEPRINT_COMPONENT,

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -82,7 +82,7 @@ export function fetchModalCreateImageTypesApi() {
 }
 
 export function setBlueprintDescriptionApi(blueprint, description) {
-  BlueprintApi.handleEditDescription(description);
+  BlueprintApi.handleEditDescription(blueprint, description);
 }
 
 export function deleteBlueprintApi(blueprint) {

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -4,7 +4,7 @@ import {
   FETCHING_BLUEPRINTS_SUCCEEDED, FETCHING_BLUEPRINT_NAMES_SUCCEEDED,
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   ADD_BLUEPRINT_COMPONENT_SUCCEEDED, REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
-  SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION, SET_BLUEPRINT_COMMENT,
+  SET_BLUEPRINT, SET_BLUEPRINT_DESCRIPTION_SUCCEEDED, SET_BLUEPRINT_COMMENT,
   DELETING_BLUEPRINT_SUCCEEDED, BLUEPRINTS_FAILURE, BLUEPRINT_CONTENTS_FAILURE,
 } from '../actions/blueprints';
 
@@ -168,22 +168,36 @@ const blueprints = (state = [], action) => {
           ]
         }
       );
-    case SET_BLUEPRINT_DESCRIPTION:
+    case SET_BLUEPRINT_DESCRIPTION_SUCCEEDED: 
       return Object.assign({}, state, {
-          blueprintList: [
-            ...state.blueprintList.map(blueprint => {
-              if (blueprint.present.id === action.payload.blueprint.id) {
-                return Object.assign(
-                  {}, blueprint, {
-                  past: blueprint.past.concat([blueprint.present]),
-                  present: Object.assign({}, blueprint.present, { description: action.payload.description }),
-                });
-              }
-              return blueprint;
-            }),
-          ]
-        }
-      );
+        blueprintList: [
+          ...state.blueprintList.map(blueprint => {
+            if (blueprint.present.id === action.payload.blueprint.id) {
+              return Object.assign(
+                {}, blueprint, {
+                past: blueprint.past.map(pastBlueprint => {
+                  return Object.assign({}, pastBlueprint, {
+                    version: action.payload.blueprint.version,
+                    description: action.payload.blueprint.description,
+                  })
+                }),
+                present: Object.assign({}, blueprint.present, { 
+                  version: action.payload.blueprint.version,
+                  description: action.payload.blueprint.description,
+                }),
+                future: blueprint.future.map(futureBlueprint => {
+                  return Object.assign({}, futureBlueprint, {
+                    version: action.payload.blueprint.version,
+                    description: action.payload.blueprint.description,
+                  })
+                }),
+              });
+            }
+            return blueprint;
+          }),
+        ]
+      }
+    );
     case DELETING_BLUEPRINT_SUCCEEDED:
       return Object.assign({}, state, {
         blueprintList: state.blueprintList.filter(blueprint => blueprint.present.id !== action.payload.blueprintId)

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -197,10 +197,9 @@ class EditBlueprintPage extends React.Component {
         // to get details that were updated during commit (i.e. version)
         Promise.all([BlueprintApi.reloadBlueprintDetails(this.props.blueprint)])
           .then(data => {
-            const blueprintToSet = this.props.blueprint;
-            blueprintToSet.name = data[0].name;
-            blueprintToSet.description = data[0].description;
-            blueprintToSet.version = data[0].version;
+            const blueprintToSet = Object.assign({}, this.props.blueprint, {
+              version: data[0].version,
+            });
             this.props.setBlueprint(blueprintToSet);
           })
           .catch(e => console.log(`Error in reload blueprint details: ${e}`));


### PR DESCRIPTION
This closes #337

The issue with saving changes made on the Edit Blueprint page was mostly addressed in #330. But these changes now only pass in data needed to post blueprint updates, and not _everything_ like before this PR. 

However, when editing the description on the blueprint page, the groups and customizations weren't being preserved, and the updated version number wasn't getting fetched and updated in the store. Edit Description action will now pass blueprint groups and customizations when posting the updated description and also reloads the updated version number.

Since the user could make changes to the blueprint and then edit the description before saving those changes, I decided to handle this use case by doing the following:

1.  When setting the updated description, the oldest blueprint object we have in the store is posted
2. All blueprint objects are then updated with the new description and new version number
3. The present blueprint object is posted to the workspace, since the workspace was cleared when saving the updated description