### PR TITLE
Display modules in list of selected components

### DIFF
--- a/core/selectors.js
+++ b/core/selectors.js
@@ -31,7 +31,9 @@ export const makeGetBlueprintById = () => createSelector(
 );
 
 const getSortedSelectedComponents = (state, blueprint) => {
-  const selectedComponentNames = blueprint.packages.map(item => item.name);
+  const selectedPackages = blueprint.packages.map(item => item.name);
+  const selectedModules = blueprint.modules.map(item => item.name);
+  const selectedComponentNames = selectedPackages.concat(selectedModules);
 
   const components = blueprint.components;
   if (components === undefined) {
@@ -59,7 +61,9 @@ export const makeGetSortedSelectedComponents = () => createSelector(
 );
 
 const getSortedDependencies = (state, blueprint) => {
-  const selectedComponentNames = blueprint.packages.map(item => item.name);
+  const selectedPackages = blueprint.packages.map(item => item.name);
+  const selectedModules = blueprint.modules.map(item => item.name);
+  const selectedComponentNames = selectedPackages.concat(selectedModules);
   const dependencies = blueprint.components;
   if (dependencies === undefined) {
     return [];


### PR DESCRIPTION
This fixes a bug with how the list of Selected Components is created.

The list of Selected Components is created by filtering out the selected items from the list of everything (returned from the api as "dependencies"). But currently, only the selected items that are packages are being filtered out of this list. Instead, packages and modules that are selected for the blueprint should display in the list of Selected Components. 