### PR TITLE
Update Discard Changes to delete workspace

### DIFF
--- a/components/Toolbar/BlueprintToolbar.js
+++ b/components/Toolbar/BlueprintToolbar.js
@@ -41,7 +41,7 @@ const BlueprintToolbar = props => (
     {props.undo !== undefined &&
       <div className="form-group">
       {props.pastLength > 0 &&
-        <button className="btn btn-link" type="button" onClick={() => {props.undo(props.blueprintId); props.handleHistory();}}>
+        <button className="btn btn-link" type="button" onClick={() => {props.undo()}}>
           <span className="fa fa-undo" aria-hidden="true" />
         </button>
       ||

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -190,3 +190,11 @@ export const commitToWorkspace = (blueprintId) => ({
     blueprintId,
   },
 });
+
+export const DELETE_WORKSPACE = 'DELETE_WORKSPACE';
+export const deleteWorkspace = (blueprintId) => ({
+  type: DELETE_WORKSPACE,
+  payload: {
+    blueprintId,
+  },
+});

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -18,16 +18,6 @@ export function fetchBlueprintContentsApi(blueprintName) {
   return blueprintContents;
 }
 
-export function fetchWorkspaceBlueprintContentsApi(blueprintRaw) {
-  const blueprintContents = Promise.all([BlueprintApi.getBlueprintWorkspace(blueprintRaw)])
-    .then(data => {
-      const blueprint = data[0];
-      return blueprint;
-    })
-    .catch(err => console.log(`Error in fetchModalBlueprintContents promise: ${err}`));
-  return blueprintContents;
-}
-
 export function fetchBlueprintInputsApi(filter, selectedInputPage, pageSize) {
   const page = selectedInputPage * pageSize;
   const p = new Promise((resolve, reject) => {
@@ -89,6 +79,13 @@ export function deleteBlueprintApi(blueprint) {
   const deletedBlueprint = Promise.all([BlueprintApi.deleteBlueprint(blueprint)])
     .then(() => blueprint);
   return deletedBlueprint;
+}
+
+export function deleteWorkspaceApi(blueprintId) {
+  return utils.apiFetch(constants.delete_workspace + blueprintId, {
+    method: 'DELETE',
+  }, true)
+  .catch (e => console.log('Error deleting workspace', e));
 }
 
 export function commitToWorkspaceApi(blueprint) {

--- a/core/constants.js
+++ b/core/constants.js
@@ -23,6 +23,7 @@ const constants = {
   post_blueprints_workspace: '/api/v0/blueprints/workspace',
   post_compose_start: '/api/v0/compose',
   delete_blueprint: '/api/v0/blueprints/delete/',
+  delete_workspace: '/api/v0/blueprints/workspace/',
   get_sources_list: '/api/v0/projects/source/list',
   get_sources_info: '/api/v0/projects/source/info/',
 

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -1,10 +1,11 @@
 import { call, put, takeEvery, select } from 'redux-saga/effects';
 import {
-  fetchBlueprintInfoApi, fetchBlueprintNamesApi, fetchBlueprintContentsApi, fetchWorkspaceBlueprintContentsApi,
+  fetchBlueprintInfoApi, fetchBlueprintNamesApi, fetchBlueprintContentsApi,
   deleteBlueprintApi, setBlueprintDescriptionApi,
   createBlueprintApi,
   depsolveComponentsApi,
   commitToWorkspaceApi, fetchDiffWorkspaceApi,
+  deleteWorkspaceApi,
 } from '../apiCalls';
 import {
   FETCHING_BLUEPRINTS, fetchingBlueprintsSucceeded, fetchingBlueprintNamesSucceeded,
@@ -14,7 +15,7 @@ import {
   REMOVE_BLUEPRINT_COMPONENT, REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED, removeBlueprintComponentSucceeded,
   SET_BLUEPRINT_DESCRIPTION, setBlueprintDescriptionSucceeded,
   DELETING_BLUEPRINT, deletingBlueprintSucceeded,
-  COMMIT_TO_WORKSPACE,
+  COMMIT_TO_WORKSPACE, DELETE_WORKSPACE,
   blueprintsFailure, blueprintContentsFailure,
 } from '../actions/blueprints';
 import { makeGetBlueprintById } from '../selectors';
@@ -38,43 +39,35 @@ function* fetchBlueprints() {
 function* fetchBlueprintContents(action) {
   try {
     const { blueprintId } = action.payload;
-    let blueprintPast = null;
+    let blueprintPast = [];
     let blueprintPresent = null;
-
-    const blueprintResponse = yield call(fetchBlueprintContentsApi, blueprintId);
-    const workspaceChanges = yield call(fetchDiffWorkspaceApi, blueprintId);
-    const addedChanges = workspaceChanges.diff.filter(componentUpdated => componentUpdated.old === null);
-    const deletedChanges = workspaceChanges.diff.filter(componentUpdated => componentUpdated.new === null);
-    const workspacePendingChanges = {
-      'addedChanges': addedChanges,
-      'deletedChanges': deletedChanges,
+    const blueprint = yield call(fetchBlueprintInfoApi, blueprintId);   
+    const blueprintResponse = yield call(fetchBlueprintContentsApi, blueprint.name);
+    let workspacePendingChanges = {
+      'addedChanges': [],
+      'deletedChanges': [],
     };
-
-    if ((addedChanges.length > 0 || deletedChanges.length > 0) ) {
-      //fetchBlueprintInfo will return the most recent blueprint version even if its from the workspace
-      const workspaceBlueprint = yield call(fetchBlueprintInfoApi, blueprintId);
-      const workspaceDepsolved = yield call(fetchWorkspaceBlueprintContentsApi, workspaceBlueprint);
+    if (blueprint.changed === true) {
+      const workspaceChanges = yield call(fetchDiffWorkspaceApi, blueprintId);
+      const addedChanges = workspaceChanges.diff.filter(componentUpdated => componentUpdated.old === null);
+      const deletedChanges = workspaceChanges.diff.filter(componentUpdated => componentUpdated.new === null);
+      workspacePendingChanges = {
+        'addedChanges': addedChanges,
+        'deletedChanges': deletedChanges,
+      };
       blueprintPast = [Object.assign(
         {}, blueprintResponse, {
           localPendingChanges: [],
           workspacePendingChanges: {addedChanges: [], deletedChanges: []},
         }
       )];
-      blueprintPresent = Object.assign(
-        {}, workspaceDepsolved, {
-          localPendingChanges: [],
-          workspacePendingChanges: workspacePendingChanges,
-        }
-      );
-    } else {
-      blueprintPast = [];
-      blueprintPresent = Object.assign(
-        {}, blueprintResponse, {
-          localPendingChanges: [],
-          workspacePendingChanges: workspacePendingChanges,
-        }
-      );
     }
+    blueprintPresent = Object.assign(
+      {}, blueprintResponse, {
+        localPendingChanges: [],
+        workspacePendingChanges: workspacePendingChanges,
+      }
+    );
     yield put(fetchingBlueprintContentsSucceeded(blueprintPast, blueprintPresent, workspacePendingChanges));
   } catch (error) {
     console.log('Error in fetchBlueprintContentsSaga');
@@ -182,6 +175,31 @@ function* commitToWorkspace(action) {
   }
 }
 
+function* deleteWorkspace(action) {
+  try {
+    const { blueprintId } = action.payload;
+    yield call(deleteWorkspaceApi, blueprintId);
+    const blueprint = yield call(fetchBlueprintInfoApi, blueprintId);
+    let blueprintPast = [];
+    let blueprintPresent = null;
+    let workspacePendingChanges = {
+      'addedChanges': [],
+      'deletedChanges': [],
+    };
+    const blueprintDepsolved = yield call(fetchBlueprintContentsApi, blueprint.name);
+    blueprintPresent = Object.assign(
+      {}, blueprintDepsolved, {
+        localPendingChanges: [],
+        workspacePendingChanges: workspacePendingChanges,
+      }
+    );
+    yield put(fetchingBlueprintContentsSucceeded(blueprintPast, blueprintPresent, workspacePendingChanges));
+  } catch (error) {
+    console.log('deleteWorkspaceError');
+    yield put(blueprintsFailure(error));
+  }
+}
+
 export default function* () {
   yield takeEvery(CREATING_BLUEPRINT, createBlueprint);
   yield takeEvery(FETCHING_BLUEPRINT_CONTENTS, fetchBlueprintContents);
@@ -190,6 +208,7 @@ export default function* () {
   yield takeEvery(ADD_BLUEPRINT_COMPONENT_SUCCEEDED, commitToWorkspace);
   yield takeEvery(REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED, commitToWorkspace);
   yield takeEvery(COMMIT_TO_WORKSPACE, commitToWorkspace);
+  yield takeEvery(DELETE_WORKSPACE, deleteWorkspace);
   yield takeEvery(ADD_BLUEPRINT_COMPONENT, addComponent);
   yield takeEvery(REMOVE_BLUEPRINT_COMPONENT, removeComponent);
   yield takeEvery(FETCHING_BLUEPRINTS, fetchBlueprints);

--- a/data/BlueprintApi.js
+++ b/data/BlueprintApi.js
@@ -65,34 +65,6 @@ class BlueprintApi {
     return p;
   }
 
-  getBlueprintWorkspace(blueprintRaw) {
-    const p = new Promise((resolve, reject) => {
-      const blueprint = blueprintRaw;
-      const componentNames = blueprintRaw.packages.map(item => item.name);
-      if (componentNames.length > 0) {
-        utils.apiFetch(constants.get_projects_deps + componentNames)
-          .then(depData => {
-            // bdcs-api v0.3.0 includes module (component) and component NEVRAs
-            // tagging all components a "RPM" for now
-            let components = this.setType(depData.projects, 'RPM');
-            blueprint.components = components;
-            this.blueprint = blueprint;
-            resolve(blueprint);
-          })
-          .catch(e => {
-            console.log('getBlueprint: Error getting component and component metadata', e);
-            reject();
-          });
-      } else {
-        // there are no components, just a blueprint name and description
-        blueprint.components = [];
-        this.blueprint = blueprint;
-        resolve(blueprint);
-      }
-    });
-    return p;
-  }
-
   // set additional metadata for each of the components
   makeBlueprintSelectedComponents(data) {
     const modules = this.setType(data.blueprint.modules, 'Module');


### PR DESCRIPTION
This closes #327.

These updates will delete a workspace if one exists when the user selects an action to discard the changes in a workspace, using either the Discard Changes button or the Undo button.

After the workspace is deleted, an additional api call is made to get the blueprint so that we can load the correct blueprint contents in the UI.

A couple of things to note:
- I'd like for the user to be able to hit Redo to get changes back that were discarded. I think this could be a simple change, but will open a separate PR for that.
- While working on this, I noticed that there are other places where we don't handle components that are stored in the blueprint as 'modules' very well, like removing components that are modules, or reloading the blueprint when changes are made. I will open a separate PR for those updates.