### PR TITLE
Add support for Modules during Add/Remove

### DIFF
--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -201,7 +201,9 @@ class PendingChanges extends React.Component {
                             <ul className="list-unstyled">
                               {this.props.blueprint.workspacePendingChanges.addedChanges.map((componentUpdated, index) => (
                                 <li key={index}>
-                                  <strong>{componentUpdated.new.Package.name}-{componentUpdated.new.Package.version}</strong>
+                                  <strong>
+                                    {Object.values(componentUpdated.new)[0].name}-{Object.values(componentUpdated.new)[0].version}
+                                  </strong>
                                 </li>
                                 ))}
                             </ul>
@@ -216,7 +218,9 @@ class PendingChanges extends React.Component {
                             <ul className="list-unstyled">
                               {this.props.blueprint.workspacePendingChanges.deletedChanges.map((componentUpdated, index) => (
                                 <li key={index}>
-                                  <strong>{componentUpdated.old.Package.name}-{componentUpdated.old.Package.version}</strong>
+                                  <strong>
+                                    {Object.values(componentUpdated.old)[0].name}-{Object.values(componentUpdated.old)[0].version}
+                                  </strong>
                                 </li>
                               ))}
                             </ul>

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -96,12 +96,13 @@ export const addBlueprintComponent = (blueprint, component) => ({
 });
 
 export const ADD_BLUEPRINT_COMPONENT_SUCCEEDED = 'ADD_BLUEPRINT_COMPONENT_SUCCEEDED';
-export const addBlueprintComponentSucceeded = (blueprintId, components, packages, pendingChange) => ({
+export const addBlueprintComponentSucceeded = (blueprintId, components, packages, modules, pendingChange) => ({
   type: ADD_BLUEPRINT_COMPONENT_SUCCEEDED,
   payload: {
     blueprintId,
     components,
     packages,
+    modules,
     pendingChange,
   },
 });
@@ -116,12 +117,13 @@ export const removeBlueprintComponent = (blueprint, component) => ({
 });
 
 export const REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED = 'REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED';
-export const removeBlueprintComponentSucceeded = (blueprintId, components, packages, pendingChange) => ({
+export const removeBlueprintComponentSucceeded = (blueprintId, components, packages, modules, pendingChange) => ({
   type: REMOVE_BLUEPRINT_COMPONENT_SUCCEEDED,
   payload: {
     blueprintId,
     components,
     packages,
+    modules,
     pendingChange,
   },
 });

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -115,12 +115,14 @@ export function fetchDiffWorkspaceApi(blueprintId) {
   return p;
 }
 
-export function depsolveComponentsApi(packages) {
+export function depsolveComponentsApi(packages, modules) {
   const p = new Promise((resolve, reject) => {
     const packageNames = packages.map(item => item.name);
+    const moduleNames = modules.map(item => item.name);
+    const names = packageNames.concat(moduleNames);
     let dependencies = [];
-    if (packageNames.length > 0) {
-      utils.apiFetch(constants.get_projects_deps + packageNames)
+    if (names.length > 0) {
+      utils.apiFetch(constants.get_projects_deps + names)
         .then(depData => {
           // bdcs-api v0.3.0 includes module (component) and dependency NEVRAs
           // tagging all dependencies a "RPM" for now

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -88,6 +88,7 @@ const blueprints = (state = [], action) => {
                   present: Object.assign({}, blueprint.present, {
                     components: action.payload.components,
                     packages: action.payload.packages,
+                    modules: action.payload.modules,
                     localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
                       return (component.componentNew === action.payload.pendingChange.componentOld
                         && component.componentNew !== null)
@@ -116,6 +117,7 @@ const blueprints = (state = [], action) => {
                   present: Object.assign({}, blueprint.present, {
                     components: action.payload.components,
                     packages: action.payload.packages,
+                    modules: action.payload.modules,
                     localPendingChanges: blueprint.present.localPendingChanges.some((component) => {
                       return (component.componentNew === action.payload.pendingChange.componentOld
                         && component.componentNew !== null)

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -143,9 +143,10 @@ function* addComponent(action) {
     };
 
     const packages = blueprint.packages.concat(addedPackage);
-    const components = yield call(depsolveComponentsApi, packages);
+    const modules = blueprint.modules;
+    const components = yield call(depsolveComponentsApi, packages, modules);
 
-    yield put(addBlueprintComponentSucceeded(blueprint.id, components, packages, pendingChange));
+    yield put(addBlueprintComponentSucceeded(blueprint.id, components, packages, modules, pendingChange));
   } catch (error) {
     console.log('errorAddComponentSaga');
     yield put(blueprintsFailure(error));
@@ -161,9 +162,9 @@ function* removeComponent(action) {
       componentNew: null,
     };
     const packages = blueprint.packages.filter(pack => pack.name !== component.name);
-    const components = yield call(depsolveComponentsApi, packages);
-
-    yield put(removeBlueprintComponentSucceeded(blueprint.id, components, packages, pendingChange));
+    const modules = blueprint.modules.filter(module => module.name !== component.name);
+    const components = yield call(depsolveComponentsApi, packages, modules);
+    yield put(removeBlueprintComponentSucceeded(blueprint.id, components, packages, modules, pendingChange));
   } catch (error) {
     console.log('errorRemoveComponentSaga');
     yield put(blueprintsFailure(error));


### PR DESCRIPTION
Previously, the UI only handled packages during add/remove
and ignored modules, which resulted in odd behavior, like
modules disappearing from the UI during add, or not being
able to remove modules from a blueprint. These updates
add support for blueprints that have components listed as
modules in the blueprint contents.