### PR TITLE
Find the root cause of exiting with none 0 code and fix it.

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -41,10 +41,16 @@ def run_webdriver_tests(machine, env=[]):
         Return success of the tests
         (True: all passed, False: at least one failed)
     """
-    cmd_parts = ["cd /root/end-to-end;"] + env + ["npm run test", ">&2"]
+    return_state = True
+    cmd_parts = ["cd /root/end-to-end;"] + env + ["npm run test"]
     print(" ".join(cmd_parts))
 
-    machine.execute(" ".join(cmd_parts), timeout=3600)
+    try:
+        machine.execute(" ".join(cmd_parts), timeout=3600)
+    except Exception as e:
+        return_state = False
+        print(e)
+    return return_state
 
 
 def run_e2e(verbose, image, browser, cpus, memory, sit):


### PR DESCRIPTION
It's caused by return value. The run_webdriver_tests() has to return ture or false in this case. Adding return value in run_webdriver_tests() fixed this issue.