### PR TITLE
Temporarily support selenium images with and without -debug variants

### DIFF
--- a/test/selenium_start.sh
+++ b/test/selenium_start.sh
@@ -28,7 +28,17 @@ systemctl start docker
 
 docker run -d -p 4444:4444 --name selenium-hub selenium/hub:3
 wait_curl /grid/console "Grid Console"
-docker run -d --link selenium-hub:hub --shm-size=512M selenium/node-chrome:3
+# HACK: Try both variants until https://github.com/cockpit-project/cockpit/pull/10191 lands
+if docker image inspect selenium/node-chrome-debug:3 >/dev/null 2>&1; then
+    docker run -d --shm-size=512M --link selenium-hub:hub -p 5901:5900 -e VNC_NO_PASSWORD=1 selenium/node-chrome-debug:3
+else
+    docker run -d --link selenium-hub:hub --shm-size=512M selenium/node-chrome:3
+fi
 wait_curl /grid/console "browserName: chrome"
-docker run -d --link selenium-hub:hub --shm-size=512M selenium/node-firefox:3
+
+if docker image inspect selenium/node-firefox-debug:3 >/dev/null 2>&1; then
+    docker run -d --shm-size=512M --link selenium-hub:hub -p 5902:5900 -e VNC_NO_PASSWORD=1 selenium/node-firefox-debug:3
+else
+    docker run -d --link selenium-hub:hub --shm-size=512M selenium/node-firefox:3
+fi
 wait_curl /grid/console "browserName: firefox"


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/10191 will update
Cockpit's selenium image to have (only) the -debug variants of the
firefox and chromium containers. Temporarily support both, so that we
can run welder-web tests with both the current and that new image, and
never have to break tests.

This can be simplified to only using the -debug variants after landing
the above PR.