### PR TITLE
test: Support Cockpit test scenario (actually enable testing on Chrome)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,9 @@
 VERSION=$(shell $(CURDIR)/rpmversion.sh | cut -d - -f 1)
 RELEASE=$(shell $(CURDIR)/rpmversion.sh | cut -d - -f 2)
 PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' package.json)
-ifeq ($(TEST_OS),)
-TEST_OS = rhel-7-6
-endif
-ifeq ($(BROWSER),)
-BROWSER = firefox
-endif
-export TEST_OS BROWSER CURDIR
+TEST_OS ?= rhel-7-6
+BROWSER ?= firefox
+export TEST_OS BROWSER
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 ifneq (,$(wildcard ~/.config/codecov-token))
 BUILD_RUN = node run build --with-coverage

--- a/test/run
+++ b/test/run
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 # This is the expected entry point for Cockpit CI; will be called without
-# arguments but with an appropriate $TEST_OS
+# arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
+
+if [ -n "${TEST_SCENARIO}" ]; then
+    export BROWSER="$TEST_SCENARIO"
+fi
 
 make check


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/10194 introduces test
scenarios in Cockpit CI, and defines two scenarios "chrome" and
"firefox". These directly map to the Makefile's `$BROWSER` variable.

- [x] land Cockpit CI test support for scenarios: https://github.com/cockpit-project/cockpit/pull/10191
- [x] fix failing tests when running with chrome: PR #389