### PR TITLE
Creates user-friendly labels to display for image types

### DIFF
--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -138,7 +138,7 @@ class CreateImage extends React.Component {
                   <div className="col-sm-9">
                     <select className="form-control" value={this.state.imageType} onChange={this.handleChange}>
                       {this.props.imageTypes !== undefined && this.props.imageTypes.map((type, i) =>
-                        <option key={i} value={type.name} disabled={!type.enabled}>{type.name}</option>
+                        <option key={i} value={type.name} disabled={!type.enabled}>{type.label}</option>
                       )}
                     </select>
                   </div>

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -65,8 +65,22 @@ export function fetchBlueprintInfoApi(blueprintName) {
 }
 
 export function fetchModalCreateImageTypesApi() {
+  const imageTypeLabels = {
+    'ami': 'Amazon Machine Image Disk (.ami)',
+    'ext4-filesystem': 'Ext4 File System Image (.img)',
+    'live-iso': 'Live Bootable ISO (.iso)',
+    'partitioned-disk': 'Raw Partitioned Disk Image (.img)',
+    'qcow2': 'QEMU QCOW2 Image (.qcow2)',
+    'tar': 'TAR Archive (.tar)',
+    'vhd': 'Azure Disk Image (.vhd)',
+    'vmdk': 'VMware Virtual Machine Disk (.vmdk)'
+  };
   const imageTypes = utils.apiFetch(constants.get_image_types)
-    .then(data => data.types)
+    .then(data => data.types.map(type => {
+      return Object.assign({}, type,
+        {label: imageTypeLabels[type.name] || type.name}
+      );
+    }))
     .catch(e => console.log('Error getting component types', e));
   return imageTypes;
 }

--- a/test/end-to-end/pages/createImage.js
+++ b/test/end-to-end/pages/createImage.js
@@ -2,9 +2,10 @@
 const MainPage = require('./main');
 
 module.exports = class CreateImagePage extends MainPage {
-  constructor(type, arch) {
+  constructor(type, label, arch) {
     super('Create Image');
     this.imageType = type;
+    this.imageTypeLabel = label;
     this.imageArch = arch;
 
     // ---- Root element selector ---- //

--- a/test/end-to-end/specs/test_viewBlueprint.js
+++ b/test/end-to-end/specs/test_viewBlueprint.js
@@ -117,7 +117,7 @@ describe('View Blueprint Page', () => {
       });
 
       describe('Create Image Tests', () => {
-        const createImagePage = new CreateImagePage(images[0].type, images[0].arch);
+        const createImagePage = new CreateImagePage(images[0].type, images[0].label, images[0].arch);
 
         it('should pop up Create Image window by clicking Create Image button', () => {
           browser
@@ -130,7 +130,7 @@ describe('View Blueprint Page', () => {
 
         images.forEach((image) => {
           it(`should have toast notification pop up for image ${image.type}/${image.arch}`, () => {
-            const createImagePage2 = new CreateImagePage(image.type, image.arch);
+            const createImagePage2 = new CreateImagePage(image.type, image.label, image.arch);
             const toastNotifPage = new ToastNotifPage(testData.blueprint.simple.name);
 
             browser
@@ -141,7 +141,7 @@ describe('View Blueprint Page', () => {
               .waitForVisible(createImagePage2.selectImageType);
 
             browser
-              .selectByVisibleText(createImagePage2.selectImageType, createImagePage2.imageType)
+              .selectByVisibleText(createImagePage2.selectImageType, createImagePage2.imageTypeLabel)
               .selectByVisibleText(createImagePage2.selectImageArch, createImagePage2.imageArch)
               .click(createImagePage2.btnCreate)
               .waitForVisible(toastNotifPage.iconCreating);

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -200,7 +200,7 @@ exports.testData = {
   // if/when the backend decides to really build a compose. So leave testing
   // only with the tar compose type b/c it should be relatively fast
   image: [
-    { type: 'tar', arch: 'x86_64' },
+    { type: 'tar', arch: 'x86_64', label: 'TAR Archive (.tar)' },
   ],
 
   // cockpit authentication username and password


### PR DESCRIPTION
Closes #371 

Adds user-friendly labels to display in the Create Image dialog, as shown below. 

![image](https://user-images.githubusercontent.com/21063328/46510572-d3527680-c817-11e8-962f-19f4fedb391a.png)

Please note - Labels are provided for new images types added in https://github.com/weldr/lorax/pull/475, but are not shown in the example above since I am currently only running the latest version of lorax-composer that is available to install.
