### PR TITLE
Updates Create Image modal to not have a default image type

### DIFF
--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -18,6 +18,9 @@ const messages = defineMessages({
   warningUnsaved: {
     defaultMessage: "This blueprint has changes that are not committed. " +
       "These changes will be committed before the image is created."
+  },
+  selectOne: {
+    defaultMessage: "Select one"
   }
 });
 
@@ -31,7 +34,6 @@ class CreateImage extends React.Component {
   }
 
   componentWillMount() {
-    this.setState({ imageType: this.props.imageTypes[0].name });
     if (this.props.composeQueueFetched === false) {
       this.props.fetchingQueue();
     }
@@ -132,11 +134,20 @@ class CreateImage extends React.Component {
                 </div>
                 <div className="form-group">
                   <label
-                    className="col-sm-3 control-label"
+                    className="col-sm-3 control-label required-pf"
                     htmlFor="textInput-modal-markup"
                   ><FormattedMessage defaultMessage="Image Type" /></label>
                   <div className="col-sm-9">
-                    <select className="form-control" value={this.state.imageType} onChange={this.handleChange}>
+                    <select 
+                      id="textInput-modal-markup" 
+                      className="form-control" 
+                      required 
+                      value={this.state.imageType} 
+                      onChange={this.handleChange}
+                    >
+                      <option value="" disabled hidden>
+                        {formatMessage(messages.selectOne)}  
+                      </option>
                       {this.props.imageTypes !== undefined && this.props.imageTypes.map((type, i) =>
                         <option key={i} value={type.name} disabled={!type.enabled}>{type.label}</option>
                       )}
@@ -189,13 +200,23 @@ class CreateImage extends React.Component {
               <button type="button" className="btn btn-default" data-dismiss="modal">
                 <FormattedMessage defaultMessage="Cancel" />
               </button>
-              {this.props.warningUnsaved === true &&
+              {(this.props.warningUnsaved === true && this.state.imageType !== "" && 
                 <button type="button" className="btn btn-primary" onClick={this.handleCommit}>
                   <FormattedMessage defaultMessage="Commit and Create" />
-                </button>
+                </button>) 
               ||
+              (this.state.imageType !== "" &&
                 <button type="button" className="btn btn-primary" onClick={this.handleCreateImage}>
                   <FormattedMessage defaultMessage="Create" />
+                </button>)
+              }
+              {this.state.imageType === "" && 
+                <button type="button" className="btn btn-primary" disabled>
+                  {this.props.warningUnsaved === true && 
+                    <FormattedMessage defaultMessage="Commit and Create" />
+                  ||
+                    <FormattedMessage defaultMessage="Create" />
+                  }
                 </button>
               }
             </div>

--- a/test/unit/create.image.spec.js
+++ b/test/unit/create.image.spec.js
@@ -112,6 +112,7 @@ describe('CreateImage', () => {
       </Provider>
     );
 
+    component.find('#textInput-modal-markup').simulate('change', {target: { value : 'tar'}});
     component.find('.btn-primary').simulate('click');
 
     expect(setNotificationsSpy).toHaveBeenCalledTimes(1);
@@ -132,7 +133,7 @@ describe('CreateImage', () => {
     );
     const renderedType = component.find('label[htmlFor="textInput-modal-markup"] + div select option');
 
-    expect(renderedType).toHaveLength(13);
+    expect(renderedType).toHaveLength(14);
   });
 
 });


### PR DESCRIPTION
Instead of defaulting to the first image type in the select menu, the select menu displays "Select one" by default. This is a disabled option which means it can't be selected in the menu.

This menu is also indicated as required to prompt the user to make a selection, and the submit button is disabled until an option is selected.

Example of modal when it first displays:
![image](https://user-images.githubusercontent.com/21063328/46634109-dd2cf000-cb1d-11e8-8185-ad8e75b5ff06.png)

Example of select menu when open:
![image](https://user-images.githubusercontent.com/21063328/46634132-ef0e9300-cb1d-11e8-9089-9f144eeb3d41.png)


Closes #374