### PR TITLE
test: Only install node if it isn't already available

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -8,35 +8,36 @@ NODE_VERSION="8.12.0"
 
 echo 'PATH=/usr/local/bin/:$PATH' >> /etc/bashrc
 
-# key 7E37093B: public key "Christopher Dickinson <christopher.s.dickinson@gmail.com>" imported
-# key DBE9B9C5: public key "Colin Ihrig <cjihrig@gmail.com>" imported
-# key D2306D93: public key "keybase.io/octetcloud <octetcloud@keybase.io>" imported
-# key 4EB7990E: public key "Jeremiah Senkpiel <fishrock123@rocketmail.com>" imported
-# key 7EDE3FC1: public key "keybase.io/jasnell <jasnell@keybase.io>" imported
-# key 7D83545D: public key "Rod Vagg <rod@vagg.org>" imported
-# key 4C206CA9: public key "Evan Lucas <evanlucas@me.com>" imported
-# key CC11F4C8: public key "Myles Borins <myles.borins@gmail.com>" imported
+if ! type node >/dev/null 2>&1; then
+    # key 7E37093B: public key "Christopher Dickinson <christopher.s.dickinson@gmail.com>" imported
+    # key DBE9B9C5: public key "Colin Ihrig <cjihrig@gmail.com>" imported
+    # key D2306D93: public key "keybase.io/octetcloud <octetcloud@keybase.io>" imported
+    # key 4EB7990E: public key "Jeremiah Senkpiel <fishrock123@rocketmail.com>" imported
+    # key 7EDE3FC1: public key "keybase.io/jasnell <jasnell@keybase.io>" imported
+    # key 7D83545D: public key "Rod Vagg <rod@vagg.org>" imported
+    # key 4C206CA9: public key "Evan Lucas <evanlucas@me.com>" imported
+    # key CC11F4C8: public key "Myles Borins <myles.borins@gmail.com>" imported
 
-for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-; do
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key";
-done
+    for key in \
+        9554F04D7259F04124DE6B476D5A82AC7E37093B \
+        94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+        0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+        FD3A5288F042B6850C66B31F09FE44734EB7990E \
+        71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+        DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+        B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+        C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    ; do
+        gpg --keyserver pool.sks-keyservers.net --recv-keys "$key";
+    done
 
-curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz"
-curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"
-gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
-grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c -
-tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1
-rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
-ln -s /usr/local/bin/node /usr/local/bin/nodejs
+    curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz"
+    curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+    grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c -
+    tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1
+    rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+fi
 
 # Allow cockpit port (9090) in INPUT chain
 # Do not reload firewall rule during image generation


### PR DESCRIPTION
Cockpit's rhel-7-6 image will soon pre-install node, as this is brittle
and time consuming when running for each test. As this code is not
reentrant, check if node is already installed before installing it.

With that we can update the cockpit image without breaking welder-web in
between. After that landed, this can go completely.