### PR TITLE
Makefile: bots is not a phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,4 +142,4 @@ bots:
 	git checkout --force FETCH_HEAD -- bots/
 	git reset bots
 
-.PHONY: tag welder-web.spec cockpit-composer.spec local-clean vm check bots
+.PHONY: tag welder-web.spec cockpit-composer.spec local-clean vm check


### PR DESCRIPTION
bots/ is an actual directory and thus an intended make target. It should
*not* be checked out again if it already exists, as that breaks testing
a bots/ from a cockpit PR against welder-web.