### PR TITLE
Remove inert 'Architecture' field in 'Create Image' dialog

### DIFF
--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -154,17 +154,6 @@ class CreateImage extends React.Component {
                     </select>
                   </div>
                 </div>
-                <div className="form-group">
-                  <label
-                    className="col-sm-3 control-label"
-                    htmlFor="textInput2-modal-markup"
-                  ><FormattedMessage defaultMessage="Architecture" /></label>
-                  <div className="col-sm-9">
-                    <select className="form-control">
-                      <FormattedMessage defaultMessage="x86_64" tagName="option" />
-                    </select>
-                  </div>
-                </div>
               </form>
             </div>
             <div className="modal-footer">

--- a/test/end-to-end/pages/createImage.js
+++ b/test/end-to-end/pages/createImage.js
@@ -2,11 +2,10 @@
 const MainPage = require('./main');
 
 module.exports = class CreateImagePage extends MainPage {
-  constructor(type, label, arch) {
+  constructor(type, label) {
     super('Create Image');
     this.imageType = type;
     this.imageTypeLabel = label;
-    this.imageArch = arch;
 
     // ---- Root element selector ---- //
     // Create Blueprint dialog root selector
@@ -23,9 +22,8 @@ module.exports = class CreateImagePage extends MainPage {
     // Blueprint Name label
     this.labelBlueprintName = `${this.dialogRootElement} p[class="form-control-static"]`;
 
-    // Image Type and Architecture select
+    // Image Type select
     this.selectImageType = `${this.dialogRootElement} label[for="textInput-modal-markup"] + div select`;
-    this.selectImageArch = `${this.dialogRootElement} label[for="textInput2-modal-markup"] + div select`;
 
     // Create and Cancel button
     this.btnCreate = `${this.dialogRootElement} .modal-footer .btn-primary`;

--- a/test/end-to-end/specs/test_blueprints.js
+++ b/test/end-to-end/specs/test_blueprints.js
@@ -30,7 +30,7 @@ describe('Blueprints Page', () => {
   });
 
   describe('Blueprint List', () => {
-    const createImagePage = new CreateImagePage(images[0].type, images[0].arch);
+    const createImagePage = new CreateImagePage(images[0].type);
     const btnCreateImage = BlueprintsPage.btnCreateImage(testData.blueprint.simple.name);
 
     const exportBlueprintPage = new ExportBlueprintPage();

--- a/test/end-to-end/specs/test_createImage.js
+++ b/test/end-to-end/specs/test_createImage.js
@@ -38,7 +38,7 @@ describe('Create Blueprint Image', () => {
   });
 
   describe('Create Image Tests', () => {
-    const createImagePage = new CreateImagePage(images[0].type, images[0].label, images[0].arch);
+    const createImagePage = new CreateImagePage(images[0].type, images[0].label);
 
     it('should pop up Create Image window by clicking Create Image button', () => {
       browser
@@ -51,7 +51,7 @@ describe('Create Blueprint Image', () => {
 
     images.forEach((image) => {
       it(`should build image ${image.type}/${image.arch}`, () => {
-        const createImagePage2 = new CreateImagePage(image.type, image.label, image.arch);
+        const createImagePage2 = new CreateImagePage(image.type, image.label);
         const toastNotifPage = new ToastNotifPage(testData.blueprint.simple.name);
 
         browser
@@ -63,7 +63,6 @@ describe('Create Blueprint Image', () => {
 
         browser
           .selectByVisibleText(createImagePage2.selectImageType, createImagePage2.imageTypeLabel)
-          .selectByVisibleText(createImagePage2.selectImageArch, createImagePage2.imageArch)
           .click(createImagePage2.btnCreate)
           .waitForVisible(toastNotifPage.iconCreating);
 

--- a/test/end-to-end/specs/test_editBlueprint.js
+++ b/test/end-to-end/specs/test_editBlueprint.js
@@ -74,7 +74,7 @@ describe('Given Edit Blueprint Page', () => {
       // note: functionality of image creation dialog is validated in test_viewBlueprints.js
       // here we only validate that the buttons placed on the main page still
       // trigger the same dialog
-      const createImagePage = new CreateImagePage(testData.image[0].type, testData.image[0].arch);
+      const createImagePage = new CreateImagePage(testData.image[0].type);
 
       browser
         .waitForEnabled(editBlueprintPage.btnCreateImage);


### PR DESCRIPTION
Composer creates images in the architecture of the system it
is running on, and based on the source of the RPMs it has
access to (at least for the forseeable future).

This means this field in the Create Image dialog doesn't
do anything. And seems to be filled with placeholder text.