### PR TITLE
Two updates to support nodejs 10 and Fedora 29.

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -18,10 +18,12 @@ done;
         machine.execute(script=WAIT_SELENIUM_RUNNING)
 
 
+# lorax-composer in Fedora retruns: "db_supported":true
+# lorax-composer in RHEL returns: "db_supported": true
 def wait_for_composer_running(machine):
     WAIT_COMPOSER_RUNNING = """#!/bin/sh
 until curl --unix-socket /run/weldr/api.socket \
-http://localhost:4000/api/status | grep '"db_supported": true'; do
+http://localhost:4000/api/status | grep '"db_supported": *true'; do
 sleep 1;
 done;
 """

--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -10,7 +10,7 @@
     "webdriverio": "^4.12.0",
     "pngjs": "^3.3.3",
     "wdio-html-format-reporter": "~0.2.7",
-    "wdio-mocha-framework": "^0.5.13",
+    "wdio-mocha-framework": "^0.6.4",
     "wdio-spec-reporter": "~0.0.1"
   }
 }

--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "faker": "^4.1.0",
-    "webdriverio": "^4.12.0",
+    "webdriverio": "^4.14.0",
     "pngjs": "^3.3.3",
     "wdio-html-format-reporter": "~0.2.7",
     "wdio-mocha-framework": "^0.6.4",

--- a/test/vm.install
+++ b/test/vm.install
@@ -13,6 +13,55 @@ fi
 # Set SELinux to permissive to make lorax-composer happy
 [[ $(uname -r) == 4* ]] && sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config && cat /etc/selinux/config
 
+# Add Fedora repos (base, modular and updates) in RHEL 7.6
+if [[ $(grep -ihs "Red Hat Enterprise Linux" /etc/redhat-release) == *Red*7* ]]; then
+    cat << EOF >> /etc/yum.repos.d/fedora.repo
+[fedora]
+name=Fedora 29 - \$basearch
+failovermethod=priority
+#baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/29/Everything/\$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-29&arch=\$basearch
+enabled=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-29-\$basearch
+skip_if_unavailable=False
+EOF
+
+    cat << EOF >> /etc/yum.repos.d/fedora-modular.repo 
+[fedora-modular]
+name=Fedora Modular 29 - \$basearch
+failovermethod=priority
+#baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/29/Modular/\$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-29&arch=\$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-29-\$basearch
+skip_if_unavailable=False
+EOF
+
+    cat << EOF >> /etc/yum.repos.d/fedora-updates.repo 
+[updates]
+name=Fedora 29 - \$basearch - Updates
+failovermethod=priority
+#baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/29/Everything/\$basearch/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f29&arch=\$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-29-\$basearch
+skip_if_unavailable=False
+EOF
+
+fi
+
 # mock compose creation calls to backend for testing purposes
 sed -i "s|\"/api/v0/compose\"|\"/api/v0/compose?test=2\"|" /usr/share/cockpit/welder/dist/main.*.js
 


### PR DESCRIPTION
1. Update wdio-mocha-framework to 0.6.4 to support nodejs 10.
2. Update grep regxp to support lorax-composer response on Fedora 29.