### PR TITLE
Capitalize OpenStack corrently in the image create dialog.

### DIFF
--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -71,6 +71,7 @@ export function fetchModalCreateImageTypesApi() {
     'live-iso': 'Live Bootable ISO (.iso)',
     'partitioned-disk': 'Raw Partitioned Disk Image (.img)',
     'qcow2': 'QEMU QCOW2 Image (.qcow2)',
+    'openstack': 'OpenStack Image (.qcow2)',
     'tar': 'TAR Archive (.tar)',
     'vhd': 'Azure Disk Image (.vhd)',
     'vmdk': 'VMware Virtual Machine Disk (.vmdk)'


### PR DESCRIPTION
OpenStack didn't have a proper name in the dropdown, but took it
directly from the API. This commit adds an entry that uses the
corrent capitalization of the product.

Fixes issue #399