### PR TITLE
tasks: Temporarily disable po-trigger

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -2,7 +2,8 @@
 
 # Open issues for things that need doing on a regular basis
 bots/npm-trigger
-bots/po-trigger
+# FIXME: currently gets stuck in a loop
+#bots/po-trigger
 
 # Find those issues and propose to do them
 bots/issue-scan


### PR DESCRIPTION
This currently wreaks havoc and creates a never-ending stream of
po-refresh tasks which get immediately closed again.