### PR TITLE
Fix two issues imported by PR #469

### DIFF
--- a/test/end-to-end/components/AvailableComponents.component.js
+++ b/test/end-to-end/components/AvailableComponents.component.js
@@ -34,21 +34,25 @@ class AvailableComponents {
   }
 
   addPackageByName(name) {
+    const plusButton = `[data-input=${name}] .fa-plus`;
+    browser.waitForExist(plusButton, timeout);
     // browser.click() does not work with Edge due to "Element is Obscured" error.
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5238133/
-    browser.execute(plusButton => {
-      document.querySelector(plusButton).click();
+    browser.execute(button => {
+      document.querySelector(button).click();
       return true;
-    }, `[data-input=${name}] .fa-plus`);
+    }, plusButton);
   }
 
   removePackageByName(name) {
+    const minusButton = `[data-input=${name}] .fa-minus`;
+    browser.waitForExist(minusButton, timeout);
     // browser.click() does not work with Edge due to "Element is Obscured" error.
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5238133/
-    browser.execute(plusButton => {
-      document.querySelector(plusButton).click();
+    browser.execute(button => {
+      document.querySelector(button).click();
       return true;
-    }, `[data-input=${name}] .fa-minus`);
+    }, minusButton);
   }
 
   iconByName(name) {

--- a/test/end-to-end/specs/editBlueprint1.test.js
+++ b/test/end-to-end/specs/editBlueprint1.test.js
@@ -89,6 +89,14 @@ describe("Edit Blueprint Page", function() {
         editBlueprintPage.filterBox.setValue(filterContent);
         browser.keys("Enter");
         browser.waitForExist(editBlueprintPage.filterContentLabel, timeout);
+        browser.waitUntil(
+          () =>
+            $(editBlueprintPage.filterContentLabel)
+              .getText()
+              .includes(filterContent),
+          timeout,
+          `Cannot find package - ${filterContent}`
+        );
       });
 
       it(`Filtered package name should contain "${filterContent}" and should be cleared by clicking "Clear All Filter" link`, function() {

--- a/test/end-to-end/specs/editBlueprint2.test.js
+++ b/test/end-to-end/specs/editBlueprint2.test.js
@@ -44,6 +44,14 @@ describe("Edit Blueprint Page", function() {
         editBlueprintPage.filterBox.setValue(packageName);
         browser.keys("Enter");
         browser.waitForExist(editBlueprintPage.filterContentLabel, timeout);
+        browser.waitUntil(
+          () =>
+            $(editBlueprintPage.filterContentLabel)
+              .getText()
+              .includes(packageName),
+          timeout,
+          `Cannot find package - ${packageName}`
+        );
         // add package to blueprint
         availableComponent.addPackageByName(packageName);
         selectedComponents.loading();
@@ -131,6 +139,14 @@ describe("Edit Blueprint Page", function() {
         editBlueprintPage.filterBox.setValue(packageName);
         browser.keys("Enter");
         browser.waitForExist(editBlueprintPage.filterContentLabel, timeout);
+        browser.waitUntil(
+          () =>
+            $(editBlueprintPage.filterContentLabel)
+              .getText()
+              .includes(packageName),
+          timeout,
+          `Cannot find package - ${packageName}`
+        );
         // add package to blueprint
         const availableComponent = new AvailableComponents();
         availableComponent.addPackageByName(packageName);


### PR DESCRIPTION
Issues only impact tests on rhel-7-6 because composer UI on rhel-7-6 is slower than on RHEL-8 and Fedora. After some changes happened and before next action started, the page element has to be "wait for exist".
Issue 1: To wait until package filter done, the filter label content should be checked, not just filter label element.
Issue 2: To add or remove package from blueprint, wait until the + or - button exists.