### PR TITLE
Enable npm audit during testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 # yamllint disable rule:line-length
 sudo: required
-dist: trusty
+dist: xenial
 services:
   - docker
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
     - COMMAND=eslint
     - COMMAND=stylelint
     - COMMAND=test_rpmbuild
+    - COMMAND=npm_audit
 script:
   - make "$COMMAND"
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,8 @@ upload-pot: po-push
 download-po: po-pull
 
 .PHONY: tag local-clean vm check
+
+
+.PHONY: npm_audit
+npm_audit:
+	npm audit


### PR DESCRIPTION
This will give us warnings about possible security issues.

I've also asked @wgwoods to enable greenkeeper.io for this repository.
Another good security scanning service is Snyk.io.