### PR TITLE
Enables user to specify wildcard version value

### DIFF
--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -34,7 +34,8 @@ class ComponentDetailsView extends React.Component {
   constructor() {
     super();
     this.state = {
-      selectedBuildIndex: undefined
+      selectedBuildIndex: undefined,
+      savedVersion: undefined
     };
     this.setBuildIndex = this.setBuildIndex.bind(this);
     this.handleVersionSelect = this.handleVersionSelect.bind(this);
@@ -56,7 +57,6 @@ class ComponentDetailsView extends React.Component {
 
   componentDidUpdate(prevProps) {
     this.initializeBootstrapElements();
-    // this.setBuildIndex();
     if (this.props.component.name !== prevProps.component.name) {
       this.props.fetchingInputDetails(this.props.component);
       this.setState({ selectedBuildIndex: undefined }); // eslint-disable-line react/no-did-update-set-state
@@ -69,17 +69,22 @@ class ComponentDetailsView extends React.Component {
   }
 
   setBuildIndex() {
-    // filter available builds by component version/release to find object in array,
-    // then get index of that object
-    const { component } = this.props;
+    // if component is not in the blueprint, then default to the first option ("*")
+    // if component is in the blueprint, then set selectedBuildIndex to the object with the current selected version
+    const { component, selectedComponents } = this.props;
     let index = this.state.selectedBuildIndex;
     if (component.builds !== undefined && index === undefined) {
-      const selectedBuild = component.builds.filter(
-        obj => obj.version === component.version && obj.release === component.release
-      )[0];
-      index = component.builds.indexOf(selectedBuild);
-      this.setState({ selectedBuildIndex: index });
-      this.handleSelectedBuildDeps(index);
+      if (component.userSelected === true) {
+        const selectedVersion = selectedComponents.find(selected => selected.name === component.name).version;
+        const selectedBuild = component.builds.filter(obj => obj.version === selectedVersion)[0];
+        index = component.builds.indexOf(selectedBuild);
+        this.setState({ selectedBuildIndex: index });
+        this.setState({ savedVersion: selectedVersion });
+        this.handleSelectedBuildDeps(index);
+      } else {
+        this.setState({ selectedBuildIndex: 0 });
+        this.handleSelectedBuildDeps(0);
+      }
     }
   }
 
@@ -98,7 +103,7 @@ class ComponentDetailsView extends React.Component {
     // update dependencies for selected component build
     const selectedComponentBuild = Object.assign({}, component, {
       release: component.builds[index].release,
-      version: component.builds[index].version
+      version: component.builds[index].depsolveVersion
     });
     this.props.fetchingInputDeps(selectedComponentBuild);
   }
@@ -198,8 +203,7 @@ class ComponentDetailsView extends React.Component {
                   component.userSelected &&
                   component.builds !== undefined &&
                   selectedBuildIndex !== undefined &&
-                  (component.builds[selectedBuildIndex].version !== component.version ||
-                    component.builds[selectedBuildIndex].release !== component.release)) && (
+                  component.builds[selectedBuildIndex].version !== this.state.savedVersion) && (
                   <li>
                     <button
                       className="btn btn-primary"
@@ -262,7 +266,7 @@ class ComponentDetailsView extends React.Component {
             <form className="form-horizontal">
               <div className="form-group">
                 <label className="col-sm-3 col-md-2 control-label" htmlFor="cmpsr-compon__version-select">
-                  <FormattedMessage defaultMessage="Version" /> <FormattedMessage defaultMessage="Release" />
+                  <FormattedMessage defaultMessage="Version" />
                 </label>
                 <div className="col-sm-8 col-md-9">
                   <select
@@ -272,8 +276,8 @@ class ComponentDetailsView extends React.Component {
                     onChange={this.handleVersionSelect}
                   >
                     {component.builds.map((build, i) => (
-                      <option key={`${build.version}-${build.release}`} value={i}>
-                        {build.version}-{build.release}
+                      <option key={build.version} value={i}>
+                        {build.version} {build.version === "*" && "(latest version)"}
                       </option>
                     ))}
                   </select>
@@ -297,7 +301,7 @@ class ComponentDetailsView extends React.Component {
                 </dt>
                 {((component.builds === undefined || selectedBuildIndex === undefined) && (
                   <dd>{component.version}</dd>
-                )) || <dd>{component.builds[selectedBuildIndex].version}</dd>}
+                )) || <dd>{component.builds[selectedBuildIndex].depsolveVersion}</dd>}
                 <dt>
                   <FormattedMessage defaultMessage="Release" />
                 </dt>
@@ -362,6 +366,7 @@ ComponentDetailsView.propTypes = {
     userSelected: PropTypes.bool,
     version: PropTypes.string
   }),
+  selectedComponents: PropTypes.arrayOf(PropTypes.object),
   blueprint: PropTypes.string,
   componentParent: PropTypes.arrayOf(PropTypes.object),
   handleRemoveComponent: PropTypes.func,
@@ -379,6 +384,7 @@ ComponentDetailsView.propTypes = {
 
 ComponentDetailsView.defaultProps = {
   component: {},
+  selectedComponents: [],
   blueprint: "",
   componentParent: [],
   handleRemoveComponent: undefined,

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -169,7 +169,7 @@ class ComponentInputs extends React.Component {
                       data-original-title={`Add Component<br />
                             Version&nbsp;<strong>${component.version}</strong>
                             Release&nbsp;<strong>${component.release}</strong>`}
-                      onClick={e => this.props.handleAddComponent(e, component, component.version)}
+                      onClick={e => this.props.handleAddComponent(e, component, "*")}
                     >
                       <span className="fa fa-plus" />
                     </a>

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -10,6 +10,12 @@ const messages = defineMessages({
   },
   showDetails: {
     defaultMessage: "Show Details and More Options"
+  },
+  addComponent: {
+    defaultMessage: "Add latest version"
+  },
+  removeComponent: {
+    defaultMessage: "Remove Component from Blueprint"
   }
 });
 
@@ -152,7 +158,7 @@ class ComponentInputs extends React.Component {
                       data-html="true"
                       data-placement="top"
                       title=""
-                      data-original-title="Remove Component from Blueprint"
+                      data-original-title={formatMessage(messages.removeComponent)}
                       onClick={e => this.props.handleRemoveComponent(e, component.name)}
                     >
                       <span className="fa fa-minus" />
@@ -166,9 +172,8 @@ class ComponentInputs extends React.Component {
                       data-html="true"
                       data-placement="top"
                       title=""
-                      data-original-title={`Add Component<br />
-                            Version&nbsp;<strong>${component.version}</strong>
-                            Release&nbsp;<strong>${component.release}</strong>`}
+                      data-original-title={`${formatMessage(messages.addComponent)}<br />
+                            (${component.version})`}
                       onClick={e => this.props.handleAddComponent(e, component, "*")}
                     >
                       <span className="fa fa-plus" />

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -239,7 +239,8 @@ class EditBlueprintPage extends React.Component {
 
   handleUpdateComponent(event, name, version) {
     this.props.clearSelectedInput();
-    const oldVersion = this.props.blueprint.components.find(component => component.name === name).version;
+    const selectedComponents = this.props.blueprint.packages.concat(this.props.blueprint.modules);
+    const oldVersion = selectedComponents.find(component => component.name === name).version;
     const updatedPackage = {
       name: name,
       version: version
@@ -284,7 +285,8 @@ class EditBlueprintPage extends React.Component {
 
   handleRemoveComponent(event, name) {
     this.props.clearSelectedInput();
-    const version = this.props.blueprint.components.find(component => component.name === name).version;
+    const selectedComponents = this.props.blueprint.packages.concat(this.props.blueprint.modules);
+    const version = selectedComponents.find(component => component.name === name).version;
 
     let pendingChange = {
       componentOld: name + "-" + version,

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -583,6 +583,7 @@ class EditBlueprintPage extends React.Component {
           (inputs.selectedInput.set === true && (
             <ComponentDetailsView
               blueprint={blueprintDisplayName}
+              selectedComponents={blueprint.packages.concat(blueprint.modules)}
               component={inputs.selectedInput.component}
               dependencies={selectedInputDeps}
               componentParent={inputs.selectedInput.parent}


### PR DESCRIPTION
Originally, we had discussed adding the easiest fix for this issue, which was assumed to be always saving the version as "*". But after considering the following:

- Updates in #500 included the ability to select one out of a list of all available versions that are returned  
- The effort involved in removing all of that seemed more complicated than just adding on the ability to select a wildcard version
- In the cli, the user can specify a specific version or any variation of a wildcard version (e.g. 1.2.3, 1.2.*, 1.*, *)

It seemed like the easiest path was to just update the list of available versions to include wildcard variations of the versions.

Updates included in this PR:

- By default, the wildcard version "*" is selected/added to a blueprint. 
  - Previously, clicking the + icon in the list of available components would add the latest version. 
- The user can optionally view all versions that are available and choose a specific version or a
wildcard variation of a specific version (e.g. "10.*"). (see image below)
  - Previously, when viewing component details, the select menu options were version-release. 

![image](https://user-images.githubusercontent.com/21063328/52447335-771d9d00-2afe-11e9-9745-faacb51588b0.png)

