### PR TITLE
Hostname config

### DIFF
--- a/components/Form/TextInlineEdit.js
+++ b/components/Form/TextInlineEdit.js
@@ -51,7 +51,6 @@ class TextInlineEdit extends React.Component {
   }
 
   handleEdit(action) {
-    this.props.handleChange(this.textInput.current.value);
     this.props.handleEdit(action, this.textInput.current.value);
   }
 
@@ -117,7 +116,6 @@ class TextInlineEdit extends React.Component {
 TextInlineEdit.propTypes = {
   className: PropTypes.string,
   editVisible: PropTypes.bool,
-  handleChange: PropTypes.func,
   handleEdit: PropTypes.func,
   buttonLabel: PropTypes.string,
   inputLabel: PropTypes.string,
@@ -128,7 +126,6 @@ TextInlineEdit.propTypes = {
 TextInlineEdit.defaultProps = {
   className: "",
   editVisible: false,
-  handleChange: function() {},
   handleEdit: function() {},
   buttonLabel: "",
   inputLabel: "",

--- a/components/Form/TextInlineEdit.js
+++ b/components/Form/TextInlineEdit.js
@@ -1,0 +1,138 @@
+import React from "react";
+import { defineMessages, injectIntl, intlShape } from "react-intl";
+import PropTypes from "prop-types";
+
+const messages = defineMessages({
+  save: {
+    defaultMessage: "Save"
+  },
+  cancel: {
+    defaultMessage: "Cancel"
+  }
+});
+
+class TextInlineEdit extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { editValue: "" };
+    this.textInput = React.createRef();
+    this.textButton = React.createRef();
+    this.setEditValue = this.setEditValue.bind(this);
+    this.escFunction = this.escFunction.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleEdit = this.handleEdit.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener("keydown", this.escFunction, false);
+  }
+
+  componentDidUpdate(prevProps) {
+    this.setEditValue(prevProps);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.escFunction, false);
+  }
+
+  setEditValue(prevProps) {
+    if (prevProps.editVisible === false && this.props.editVisible === true && this.textInput.current) {
+      this.setState({ editValue: this.props.value });
+      this.textInput.current.select();
+    }
+    if (prevProps.editVisible === true && this.props.editVisible === false && this.textButton.current) {
+      this.textButton.current.focus();
+      this.setState({ editValue: this.props.value });
+    }
+  }
+
+  handleChange(event) {
+    this.setState({ editValue: event.target.value });
+  }
+
+  handleEdit(action) {
+    this.props.handleChange(this.textInput.current.value);
+    this.props.handleEdit(action, this.textInput.current.value);
+  }
+
+  escFunction(event) {
+    if (event.keyCode === 27 && this.textInput.current === document.activeElement) {
+      this.props.handleEdit("cancel");
+    }
+  }
+
+  render() {
+    const { formatMessage } = this.props.intl;
+    return (
+      <div className={this.props.className}>
+        {(this.props.editVisible && (
+          <div className="form-control-pf-editable form-control-pf-edit">
+            <span className="form-control-pf-value" />
+            <div className="form-control-pf-textbox">
+              <input
+                type="text"
+                className="form-control"
+                value={this.state.editValue}
+                onChange={this.handleChange}
+                aria-label={this.props.inputLabel}
+                ref={this.textInput}
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary form-control-pf-save"
+              aria-label={formatMessage(messages.save)}
+              onClick={() => this.handleEdit("commit")}
+            >
+              <span className="fa fa-check" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="btn btn-default form-control-pf-cancel"
+              aria-label={formatMessage(messages.cancel)}
+              onClick={() => this.handleEdit("cancel")}
+            >
+              <span className="fa fa-times" aria-hidden="true" />
+            </button>
+          </div>
+        )) || (
+          <div className="form-control-pf-editable">
+            <button
+              type="button"
+              className="form-control-pf-value"
+              onClick={() => this.props.handleEdit()}
+              ref={this.textButton}
+            >
+              <span className="sr-only">{this.props.buttonLabel}: </span>
+              {this.props.value !== "" && <span>{this.props.value}</span>}
+              <i className="pficon pficon-edit" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+TextInlineEdit.propTypes = {
+  className: PropTypes.string,
+  editVisible: PropTypes.bool,
+  handleChange: PropTypes.func,
+  handleEdit: PropTypes.func,
+  buttonLabel: PropTypes.string,
+  inputLabel: PropTypes.string,
+  value: PropTypes.string,
+  intl: intlShape.isRequired
+};
+
+TextInlineEdit.defaultProps = {
+  className: "",
+  editVisible: false,
+  handleChange: function() {},
+  handleEdit: function() {},
+  buttonLabel: "",
+  inputLabel: "",
+  value: ""
+};
+
+export default injectIntl(TextInlineEdit);

--- a/components/Form/TextInlineEdit.js
+++ b/components/Form/TextInlineEdit.js
@@ -48,6 +48,9 @@ class TextInlineEdit extends React.Component {
 
   handleChange(event) {
     this.setState({ editValue: event.target.value });
+    if (this.props.validateValue) {
+      this.props.validateValue(event.target.value);
+    }
   }
 
   handleEdit(action) {
@@ -56,56 +59,93 @@ class TextInlineEdit extends React.Component {
 
   escFunction(event) {
     if (event.keyCode === 27 && this.textInput.current === document.activeElement) {
+      this.props.validateValue(this.props.value);
       this.props.handleEdit("cancel");
     }
   }
 
   render() {
     const { formatMessage } = this.props.intl;
+    const inputAttributes = {
+      value: this.state.editValue,
+      onChange: this.handleChange,
+      "aria-label": this.props.inputLabel,
+      "aria-invalid": this.props.invalid,
+      ref: this.textInput,
+      maxLength: "253"
+    };
+    if (this.props.helpblock) {
+      inputAttributes["aria-describedby"] = `${this.props.inputLabel}-help`;
+    }
+    const buttonAttributes = {
+      onClick: () => this.props.handleEdit(),
+      ref: this.textButton
+    };
+    if (this.props.helpblockNoValue && this.props.value === "") {
+      buttonAttributes["aria-describedby"] = `${this.props.inputLabel}-help2`;
+    }
     return (
       <div className={this.props.className}>
         {(this.props.editVisible && (
-          <div className="form-control-pf-editable form-control-pf-edit">
-            <span className="form-control-pf-value" />
-            <div className="form-control-pf-textbox">
-              <input
-                type="text"
-                className="form-control"
-                value={this.state.editValue}
-                onChange={this.handleChange}
-                aria-label={this.props.inputLabel}
-                ref={this.textInput}
-              />
+          <div>
+            <div className="form-control-pf-editable form-control-pf-edit">
+              <span className="form-control-pf-value" />
+              <div className="form-control-pf-textbox">
+                <input type="text" className="form-control" {...inputAttributes} />
+              </div>
+              {(this.props.invalid && (
+                <button
+                  type="button"
+                  className="btn btn-primary form-control-pf-save"
+                  disabled
+                  aria-label={formatMessage(messages.save)}
+                >
+                  <span className="fa fa-check" aria-hidden="true" />
+                </button>
+              )) || (
+                <button
+                  type="submit"
+                  className="btn btn-primary form-control-pf-save"
+                  aria-label={formatMessage(messages.save)}
+                  onClick={() => this.handleEdit("commit")}
+                >
+                  <span className="fa fa-check" aria-hidden="true" />
+                </button>
+              )}
+              <button
+                type="button"
+                className="btn btn-default form-control-pf-cancel"
+                aria-label={formatMessage(messages.cancel)}
+                onClick={() => this.handleEdit("cancel")}
+              >
+                <span className="fa fa-times" aria-hidden="true" />
+              </button>
             </div>
-            <button
-              type="submit"
-              className="btn btn-primary form-control-pf-save"
-              aria-label={formatMessage(messages.save)}
-              onClick={() => this.handleEdit("commit")}
-            >
-              <span className="fa fa-check" aria-hidden="true" />
-            </button>
-            <button
-              type="button"
-              className="btn btn-default form-control-pf-cancel"
-              aria-label={formatMessage(messages.cancel)}
-              onClick={() => this.handleEdit("cancel")}
-            >
-              <span className="fa fa-times" aria-hidden="true" />
-            </button>
+            {this.props.helpblock && (
+              <span className="help-block" id={`${this.props.inputLabel}-help`}>
+                {this.props.helpblock}
+              </span>
+            )}
+            {this.props.helpblockNoValue && this.state.editValue === "" && (
+              <span className="help-block" id={`${this.props.inputLabel}-help2`}>
+                {this.props.helpblockNoValue}
+              </span>
+            )}
           </div>
         )) || (
-          <div className="form-control-pf-editable">
-            <button
-              type="button"
-              className="form-control-pf-value"
-              onClick={() => this.props.handleEdit()}
-              ref={this.textButton}
-            >
-              <span className="sr-only">{this.props.buttonLabel}: </span>
-              {this.props.value !== "" && <span>{this.props.value}</span>}
-              <i className="pficon pficon-edit" aria-hidden="true" />
-            </button>
+          <div>
+            <div className="form-control-pf-editable">
+              <button type="button" className="form-control-pf-value" {...buttonAttributes}>
+                <span className="sr-only">{this.props.buttonLabel}: </span>
+                {this.props.value !== "" && <span>{this.props.value}</span>}
+                <i className="pficon pficon-edit" aria-hidden="true" />
+              </button>
+            </div>
+            {this.props.helpblockNoValue && this.props.value === "" && (
+              <span className="help-block" id={`${this.props.inputLabel}-help2`}>
+                {this.props.helpblockNoValue}
+              </span>
+            )}
           </div>
         )}
       </div>
@@ -117,9 +157,13 @@ TextInlineEdit.propTypes = {
   className: PropTypes.string,
   editVisible: PropTypes.bool,
   handleEdit: PropTypes.func,
+  validateValue: PropTypes.func,
+  invalid: PropTypes.bool,
   buttonLabel: PropTypes.string,
   inputLabel: PropTypes.string,
   value: PropTypes.string,
+  helpblock: PropTypes.string,
+  helpblockNoValue: PropTypes.string,
   intl: intlShape.isRequired
 };
 
@@ -127,9 +171,13 @@ TextInlineEdit.defaultProps = {
   className: "",
   editVisible: false,
   handleEdit: function() {},
+  validateValue: function() {},
+  invalid: false,
   buttonLabel: "",
   inputLabel: "",
-  value: ""
+  value: "",
+  helpblock: "",
+  helpblockNoValue: ""
 };
 
 export default injectIntl(TextInlineEdit);

--- a/core/actions/blueprintPage.js
+++ b/core/actions/blueprintPage.js
@@ -14,6 +14,14 @@ export const setEditHostnameVisible = visible => ({
   }
 });
 
+export const SET_EDIT_HOSTNAME_INVALID = "SET_EDIT_HOSTNAME_INVALID";
+export const setEditHostnameInvalid = invalid => ({
+  type: SET_EDIT_HOSTNAME_INVALID,
+  payload: {
+    invalid
+  }
+});
+
 export const SET_ACTIVE_TAB = "SET_ACTIVE_TAB";
 export const setActiveTab = activeTab => ({
   type: SET_ACTIVE_TAB,

--- a/core/actions/blueprintPage.js
+++ b/core/actions/blueprintPage.js
@@ -6,14 +6,6 @@ export const setEditDescriptionVisible = visible => ({
   }
 });
 
-export const SET_EDIT_DESCRIPTION_VALUE = "SET_EDIT_DESCRIPTION_VALUE";
-export const setEditDescriptionValue = value => ({
-  type: SET_EDIT_DESCRIPTION_VALUE,
-  payload: {
-    value
-  }
-});
-
 export const SET_ACTIVE_TAB = "SET_ACTIVE_TAB";
 export const setActiveTab = activeTab => ({
   type: SET_ACTIVE_TAB,

--- a/core/actions/blueprintPage.js
+++ b/core/actions/blueprintPage.js
@@ -6,6 +6,14 @@ export const setEditDescriptionVisible = visible => ({
   }
 });
 
+export const SET_EDIT_HOSTNAME_VISIBLE = "SET_EDIT_HOSTNAME_VISIBLE";
+export const setEditHostnameVisible = visible => ({
+  type: SET_EDIT_HOSTNAME_VISIBLE,
+  payload: {
+    visible
+  }
+});
+
 export const SET_ACTIVE_TAB = "SET_ACTIVE_TAB";
 export const setActiveTab = activeTab => ({
   type: SET_ACTIVE_TAB,

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -75,6 +75,23 @@ export const setBlueprintComment = (blueprint, comment) => ({
   }
 });
 
+export const SET_BLUEPRINT_HOSTNAME = "SET_BLUEPRINT_HOSTNAME";
+export const setBlueprintHostname = (blueprint, hostname) => ({
+  type: SET_BLUEPRINT_HOSTNAME,
+  payload: {
+    blueprint,
+    hostname
+  }
+});
+
+export const SET_BLUEPRINT_HOSTNAME_SUCCEEDED = "SET_BLUEPRINT_HOSTNAME_SUCCEEDED";
+export const setBlueprintHostnameSucceeded = blueprint => ({
+  type: SET_BLUEPRINT_HOSTNAME_SUCCEEDED,
+  payload: {
+    blueprint
+  }
+});
+
 export const SET_BLUEPRINT_DESCRIPTION = "SET_BLUEPRINT_DESCRIPTION";
 export const setBlueprintDescription = (blueprint, description) => ({
   type: SET_BLUEPRINT_DESCRIPTION,

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -92,10 +92,6 @@ export function fetchModalCreateImageTypesApi() {
   return imageTypes;
 }
 
-export function setBlueprintDescriptionApi(blueprint, description) {
-  BlueprintApi.handleEditDescription(blueprint, description);
-}
-
 export function deleteBlueprintApi(blueprint) {
   const deletedBlueprint = Promise.all([BlueprintApi.deleteBlueprint(blueprint)]).then(() => blueprint);
   return deletedBlueprint;

--- a/core/reducers/blueprintPage.js
+++ b/core/reducers/blueprintPage.js
@@ -1,11 +1,9 @@
-import { SET_EDIT_DESCRIPTION_VISIBLE, SET_EDIT_DESCRIPTION_VALUE, SET_ACTIVE_TAB } from "../actions/blueprintPage";
+import { SET_EDIT_DESCRIPTION_VISIBLE, SET_ACTIVE_TAB } from "../actions/blueprintPage";
 
 const blueprintPage = (state = [], action) => {
   switch (action.type) {
     case SET_EDIT_DESCRIPTION_VISIBLE:
       return Object.assign({}, state, { editDescriptionVisible: action.payload.visible });
-    case SET_EDIT_DESCRIPTION_VALUE:
-      return Object.assign({}, state, { editDescriptionValue: action.payload.value });
     case SET_ACTIVE_TAB:
       return Object.assign({}, state, { activeTab: action.payload.activeTab });
     default:

--- a/core/reducers/blueprintPage.js
+++ b/core/reducers/blueprintPage.js
@@ -1,9 +1,11 @@
-import { SET_EDIT_DESCRIPTION_VISIBLE, SET_ACTIVE_TAB } from "../actions/blueprintPage";
+import { SET_EDIT_DESCRIPTION_VISIBLE, SET_EDIT_HOSTNAME_VISIBLE, SET_ACTIVE_TAB } from "../actions/blueprintPage";
 
 const blueprintPage = (state = [], action) => {
   switch (action.type) {
     case SET_EDIT_DESCRIPTION_VISIBLE:
       return Object.assign({}, state, { editDescriptionVisible: action.payload.visible });
+    case SET_EDIT_HOSTNAME_VISIBLE:
+      return Object.assign({}, state, { editHostnameVisible: action.payload.visible });
     case SET_ACTIVE_TAB:
       return Object.assign({}, state, { activeTab: action.payload.activeTab });
     default:

--- a/core/reducers/blueprintPage.js
+++ b/core/reducers/blueprintPage.js
@@ -1,4 +1,9 @@
-import { SET_EDIT_DESCRIPTION_VISIBLE, SET_EDIT_HOSTNAME_VISIBLE, SET_ACTIVE_TAB } from "../actions/blueprintPage";
+import {
+  SET_EDIT_DESCRIPTION_VISIBLE,
+  SET_EDIT_HOSTNAME_VISIBLE,
+  SET_EDIT_HOSTNAME_INVALID,
+  SET_ACTIVE_TAB
+} from "../actions/blueprintPage";
 
 const blueprintPage = (state = [], action) => {
   switch (action.type) {
@@ -6,6 +11,8 @@ const blueprintPage = (state = [], action) => {
       return Object.assign({}, state, { editDescriptionVisible: action.payload.visible });
     case SET_EDIT_HOSTNAME_VISIBLE:
       return Object.assign({}, state, { editHostnameVisible: action.payload.visible });
+    case SET_EDIT_HOSTNAME_INVALID:
+      return Object.assign({}, state, { editHostnameInvalid: action.payload.invalid });
     case SET_ACTIVE_TAB:
       return Object.assign({}, state, { activeTab: action.payload.activeTab });
     default:

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -8,6 +8,8 @@ import {
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   UPDATE_BLUEPRINT_COMPONENTS,
   SET_BLUEPRINT,
+  SET_BLUEPRINT_HOSTNAME,
+  SET_BLUEPRINT_HOSTNAME_SUCCEEDED,
   SET_BLUEPRINT_DESCRIPTION,
   SET_BLUEPRINT_DESCRIPTION_SUCCEEDED,
   SET_BLUEPRINT_COMMENT,
@@ -151,6 +153,57 @@ const blueprints = (state = [], action) => {
             if (blueprint.present.id === action.payload.blueprint.id) {
               return Object.assign({}, blueprint, {
                 present: Object.assign({}, blueprint.present, { comment: action.payload.comment })
+              });
+            }
+            return blueprint;
+          })
+        ]
+      });
+    case SET_BLUEPRINT_HOSTNAME:
+      return Object.assign({}, state, {
+        blueprintList: [
+          ...state.blueprintList.map(blueprint => {
+            if (blueprint.present.id === action.payload.blueprint.id) {
+              return Object.assign({}, blueprint, {
+                present: Object.assign({}, blueprint.present, {
+                  customizations: Object.assign({}, blueprint.present.customizations, {
+                    hostname: action.payload.hostname
+                  })
+                })
+              });
+            }
+            return blueprint;
+          })
+        ]
+      });
+    case SET_BLUEPRINT_HOSTNAME_SUCCEEDED:
+      return Object.assign({}, state, {
+        blueprintList: [
+          ...state.blueprintList.map(blueprint => {
+            if (blueprint.present.id === action.payload.blueprint.id) {
+              return Object.assign({}, blueprint, {
+                past: blueprint.past.map(pastBlueprint => {
+                  return Object.assign({}, pastBlueprint, {
+                    version: action.payload.blueprint.version,
+                    customizations: Object.assign({}, pastBlueprint.customizations, {
+                      hostname: action.payload.blueprint.customizations.hostname
+                    })
+                  });
+                }),
+                present: Object.assign({}, blueprint.present, {
+                  version: action.payload.blueprint.version,
+                  customizations: Object.assign({}, blueprint.present.customizations, {
+                    hostname: action.payload.blueprint.customizations.hostname
+                  })
+                }),
+                future: blueprint.future.map(futureBlueprint => {
+                  return Object.assign({}, futureBlueprint, {
+                    version: action.payload.blueprint.version,
+                    customizations: Object.assign({}, futureBlueprint.customizations, {
+                      hostname: action.payload.blueprint.customizations.hostname
+                    })
+                  });
+                })
               });
             }
             return blueprint;

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -8,6 +8,7 @@ import {
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   UPDATE_BLUEPRINT_COMPONENTS,
   SET_BLUEPRINT,
+  SET_BLUEPRINT_DESCRIPTION,
   SET_BLUEPRINT_DESCRIPTION_SUCCEEDED,
   SET_BLUEPRINT_COMMENT,
   DELETING_BLUEPRINT_SUCCEEDED,
@@ -150,6 +151,21 @@ const blueprints = (state = [], action) => {
             if (blueprint.present.id === action.payload.blueprint.id) {
               return Object.assign({}, blueprint, {
                 present: Object.assign({}, blueprint.present, { comment: action.payload.comment })
+              });
+            }
+            return blueprint;
+          })
+        ]
+      });
+    case SET_BLUEPRINT_DESCRIPTION:
+      return Object.assign({}, state, {
+        blueprintList: [
+          ...state.blueprintList.map(blueprint => {
+            if (blueprint.present.id === action.payload.blueprint.id) {
+              return Object.assign({}, blueprint, {
+                present: Object.assign({}, blueprint.present, {
+                  description: action.payload.description
+                })
               });
             }
             return blueprint;

--- a/core/store.js
+++ b/core/store.js
@@ -12,7 +12,8 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const initialState = {
   blueprintPage: {
     activeTab: "Details",
-    editDescriptionVisible: false
+    editDescriptionVisible: false,
+    editHostnameVisible: false
   },
   inputs: {
     selectedInputPage: 0,

--- a/data/BlueprintApi.js
+++ b/data/BlueprintApi.js
@@ -25,21 +25,6 @@ class BlueprintApi {
     return p;
   }
 
-  handleEditDescription(blueprint, description) {
-    const updatedBlueprint = Object.assign({}, blueprint, { description: description });
-    const p = new Promise((resolve, reject) => {
-      this.postBlueprint(this.postedBlueprintData(updatedBlueprint))
-        .then(() => {
-          resolve();
-        })
-        .catch(e => {
-          console.log(`Error updating blueprint description: ${e}`);
-          reject();
-        });
-    });
-    return p;
-  }
-
   postedBlueprintData(blueprint) {
     const blueprintData = {
       name: blueprint.name,

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -333,7 +333,11 @@ class BlueprintPage extends React.Component {
             <div className="tab-container row">
               <div className="col-sm-12">
                 <div className="form-horizontal">
-                  <form className="form-group" onSubmit={() => this.handleEditDescription("commit")}>
+                  <form
+                    className="form-group"
+                    data-form="description"
+                    onSubmit={() => this.handleEditDescription("commit")}
+                  >
                     <span className="col-sm-2 control-label">{formatMessage(messages.descriptionInputLabel)}</span>
                     <TextInlineEdit
                       className="col-sm-10"
@@ -344,7 +348,7 @@ class BlueprintPage extends React.Component {
                       value={blueprint.description}
                     />
                   </form>
-                  <form className="form-group" onSubmit={() => this.handleEditHostname("commit")}>
+                  <form className="form-group" data-form="hostname" onSubmit={() => this.handleEditHostname("commit")}>
                     <span className="col-sm-2 control-label">{formatMessage(messages.hostnameInputLabel)}</span>
                     <TextInlineEdit
                       className="col-sm-10"

--- a/public/custom.css
+++ b/public/custom.css
@@ -407,6 +407,11 @@ the "-" that would display instead of the sr-only "to" */
   padding-top: 40px;
 }
 
+/* inline edit */
+.form-control-pf-editable .sr-only + .pficon-edit {
+  margin-left: 0;
+}
+
 /* tables */
 .cmpsr-table-actions {
   width: 1%;

--- a/public/custom.css
+++ b/public/custom.css
@@ -412,6 +412,13 @@ the "-" that would display instead of the sr-only "to" */
   margin-left: 0;
 }
 
+.form-control-pf-editable > .form-control-pf-value {
+  text-align: left;
+}
+.form-control-pf-editable > .form-control-pf-value > span {
+  word-break: break-all;
+}
+
 /* tables */
 .cmpsr-table-actions {
   width: 1%;

--- a/test/end-to-end/pages/ViewBlueprint.page.js
+++ b/test/end-to-end/pages/ViewBlueprint.page.js
@@ -95,18 +95,8 @@ class ViewBlueprintPage {
     return $(selector);
   }
 
-  get detailsTabBlueprintNameLabel() {
-    const selector = `dd=${this.name}`;
-    browser.waitUntil(
-      () => browser.isExisting(selector),
-      timeout,
-      `blueprint name under "Details" tab in View Blueprint page cannot be found by selector ${selector}`
-    );
-    return $(selector);
-  }
-
   get detailsTabBlueprintDescriptionLabel() {
-    const selector = `dd=${this.description}`;
+    const selector = `span=${this.description}`;
     browser.waitUntil(
       () => browser.isExisting(selector),
       timeout,
@@ -117,15 +107,15 @@ class ViewBlueprintPage {
 
   updatedBlueprintDescriptionLabel(selector) {
     browser.waitUntil(
-      () => browser.isExisting(`dd=${selector}`),
+      () => browser.isExisting(`span=${selector}`),
       timeout,
       `blueprint description under "Details" tab in View Blueprint page cannot be found by selector ${selector}`
     );
-    return $(`dd=${selector}`);
+    return $(`span=${selector}`);
   }
 
   get editBlueprintDescriptionButton() {
-    const selector = ".pficon-edit";
+    const selector = '[data-form="description"] .pficon-edit';
     browser.waitUntil(
       () => browser.isExisting(selector),
       timeout,
@@ -135,7 +125,7 @@ class ViewBlueprintPage {
   }
 
   get descriptionInputBox() {
-    const selector = '[id="blueprint-tabs-pane-details"] .form-control';
+    const selector = '[data-form="description"] .form-control';
     browser.waitUntil(
       () => browser.isExisting(selector),
       timeout,
@@ -145,7 +135,7 @@ class ViewBlueprintPage {
   }
 
   get okButton() {
-    const selector = ".fa-check";
+    const selector = '[data-form="description"] .form-control-pf-save';
     browser.waitUntil(
       () => browser.isExisting(selector),
       timeout,
@@ -155,7 +145,7 @@ class ViewBlueprintPage {
   }
 
   get cancelButton() {
-    const selector = ".btn-link .pficon-close";
+    const selector = '[data-form="description"] .form-control-pf-cancel';
     browser.waitUntil(
       () => browser.isExisting(selector),
       timeout,

--- a/test/end-to-end/specs/viewBlueprint.test.js
+++ b/test/end-to-end/specs/viewBlueprint.test.js
@@ -53,10 +53,6 @@ describe("View Blueprint Page", function() {
     });
 
     describe('"Details" tab', function() {
-      it(`blueprint name under "Details" tab should be "${name}"`, function() {
-        expect(viewBlueprintPage.detailsTabBlueprintNameLabel.getText()).to.equal(name);
-      });
-
       it(`blueprint description under "Details" tab should be "${description}"`, function() {
         expect(viewBlueprintPage.detailsTabBlueprintDescriptionLabel.getText()).to.equal(description);
       });


### PR DESCRIPTION
Adds ability to edit the hostname defined for a blueprint, which is similar to the ability to edit the blueprint description.

Also refactors the edit blueprint description functionality:

- Uses inline edit css available from PF3
- Moves input value out of the redux store to the component state to avoid lagging during typing
- refactors the function to cause a version bump when description is updated (previously, version would not change)
- Improves the keyboard interaction of the inline edit functionality (e.g. places focus on the input when it becomes visible, enables Escape key to exit out of inline edit)

![image](https://user-images.githubusercontent.com/21063328/52890211-7e255a80-3151-11e9-851d-5fc20d486f87.png)
