### PR TITLE
Remove browser-sync in devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-plugin-istanbul": "^5.1.0",
     "babel-plugin-react-intl": "^3.0.1",
     "babel-plugin-react-intl-auto": "^1.5.0",
-    "browser-sync": "^2.24.6",
     "clean-webpack-plugin": "^1.0.0",
     "connect-history-api-fallback": "^1.2.0",
     "copy-webpack-plugin": "^4.6.0",


### PR DESCRIPTION
Two reasons:
1. It is not used any more.
2. It caused severity vulnerability due to lower version.