### PR TITLE
Save cockpit and lorax-composer package version information.

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -151,6 +151,10 @@ def run_e2e(verbose, image, browser, cpus, memory, sit):
         report_dir = os.environ.get("TEST_ATTACHMENTS", os.getcwd())
         os.makedirs(report_dir, exist_ok=True)
         composer.download_dir("/root/end-to-end/wdio_report", report_dir)
+        # Save cockpit and lorax-composer package version information
+        cmd = 'rpm -qa name="cockpit*" "lorax*" > /tmp/composer.covered'
+        composer.execute(cmd, timeout=600)
+        composer.download("/tmp/composer.covered", report_dir)
 
         # Report code coverage result to codecov.io
         codecov_token_file = os.path.expanduser("~/.config/codecov-token")


### PR DESCRIPTION
It'll be easy to track tested package version.
Two steps:
1. Save version into /tmp/composer.covered.
2. Upload composer.covered into result server.