### PR TITLE
 Add API response time and sanity functional test.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+# /node_modules/* and /bower_components/* in the project root are ignored by default
+**/node_modules
+**/wdio_report

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ bots
 .nyc_output
 screen_error
 wdio_report
+composer.covered

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "eslintConfig": {
     "globals": {
+      "cockpit": true,
       "browser": true,
       "expect": true,
       "timeout": true,

--- a/test/end-to-end/specs/api.test.js
+++ b/test/end-to-end/specs/api.test.js
@@ -1,0 +1,45 @@
+const commands = require("../utils/commands");
+
+// acceptable API response time
+// the 1 second comes from https://www.nngroup.com/articles/response-times-3-important-limits/
+const acceptable = 1000;
+
+describe("lorax-composer api sanity test", function() {
+  before(function() {
+    commands.login();
+    // Edge does not support the following command so have to keep default timeout(3 seconds)
+    // browser.timeouts({ script: timeout });
+  });
+
+  function apiFetchTest(endpoint, options = { body: "" }) {
+    options.path = endpoint;
+    return browser.executeAsync(
+      function(endpoint, options, done) {
+        const t0 = performance.now();
+        const testHttp = cockpit.http("/run/weldr/api.socket", { superuser: "try" });
+        testHttp
+          .request(options)
+          .then(data => done({ success: true, data: data, latency: performance.now() - t0 }))
+          .catch(err => done({ success: false, data: err }));
+      },
+      endpoint,
+      options
+    );
+  }
+
+  it("/api/v0/blueprints/list", function() {
+    const endpoint = "/api/v0/blueprints/list";
+    const result = apiFetchTest(endpoint).value;
+    if (result.success) {
+      console.log(`API - "/api/v0/blueprints/list" response time: ${result.latency} millisecond`);
+    } else {
+      console.log('Failed to access API - "/api/v0/blueprints/list" with error: ', result.data);
+    }
+    expect(result.success).to.be.true;
+    // there're 3 blueprints included in composer by default
+    expect(JSON.parse(result.data).total).to.equal(3);
+    expect(result.latency)
+      .to.match(/^\d*(\.?\d+|\d*)$/)
+      .and.be.below(acceptable);
+  });
+});

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -212,8 +212,9 @@ exports.config = {
    * Hook that gets executed before the suite starts
    * @param {Object} suite suite details
    */
-  // beforeSuite: function (suite) {
-  // },
+  beforeSuite: function(suite) {
+    browser.reload();
+  },
   /**
    * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
    * @param {Object} test test details


### PR DESCRIPTION
1. Update .gitignore and add .eslintignore 

- Make git ignore composer.covered.
- Do not run eslint on all node_modules and wdio_report. Eslint ignores node_modules folder in root folder by default, but does not ignore /test/end-to-end/node_modules. There's a app.js inside wdio_report. Eslint should ignore that.
2.  Add API response time and sanity functional test.

- Check API response time to find API issue ASAP.
- Reload browser before test suite starts to clear browser session.
- Add "cockpit" into eslintConfig global to avoid eslint error.