### PR TITLE
Fix two dependencies issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "7.2.5",
-    "bootstrap": "3.4.0",
+    "bootstrap": "3.4.1",
     "classnames": "2.2.6",
     "fastclick": "1.0.6",
     "history": "3.3.0",
@@ -58,7 +58,6 @@
     "file-loader": "^0.9.0",
     "front-matter": "^2.1.0",
     "glob": "^6.0.4",
-    "highlight.js": "^9.5.0",
     "html-webpack-plugin": "^3.2.0",
     "jed": "^1.1.1",
     "jsel": "^1.1.6",


### PR DESCRIPTION
1. Remove hightlight.js because we do not need it any more and it has a bug which caused installation issue.
2. Update bootstrap to 3.4.1 to fix CVE-2019-8331.