### PR TITLE
Two updates for Tier-1 test

### DIFF
--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -16,10 +16,11 @@
   },
   "devDependencies": {
     "mochawesome": "^3.1.1",
+    "mochawesome-report-generator": "^3.1.4",
     "wdio-dot-reporter": "0.0.10",
+    "wdio-junit-reporter": "^0.4.4",
     "wdio-mocha-framework": "^0.6.4",
     "wdio-mochawesome-reporter": "^2.0.1",
-    "mochawesome-report-generator": "^3.1.4",
     "wdio-spec-reporter": "^0.1.5"
   }
 }

--- a/test/end-to-end/specs/editBlueprint2.test.js
+++ b/test/end-to-end/specs/editBlueprint2.test.js
@@ -199,7 +199,7 @@ describe("Edit Blueprint Page", function() {
   });
 
   describe("Component Details", function() {
-    const packageName = "sudo";
+    const packageName = "tmux";
     const bashComponent = new AvailableComponents();
     const componentDetails = new DetailsComponent(packageName);
 
@@ -251,7 +251,7 @@ describe("Edit Blueprint Page", function() {
     const CreateImagePage = require("../pages/CreateImage.page");
     const createImagePage = new CreateImagePage(name);
     const bashComponent = new AvailableComponents();
-    const packageName = "sudo";
+    const packageName = "tmux";
     const componentDetails = new DetailsComponent(packageName);
 
     before(function() {

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -143,11 +143,18 @@ exports.config = {
   // Test reporter for stdout.
   // The only one supported by default is 'dot'
   // see also: http://webdriver.io/guide/reporters/dot.html
-  reporters: ["dot", "spec", "mochawesome"],
+  reporters: ["dot", "spec", "mochawesome", "junit"],
 
   reporterOptions: {
     outputDir: "wdio_report", //json file will be written to this directory
-    mochawesome_filename: "report.json"
+    mochawesome_filename: "report.json",
+    junit: {
+      outputFileFormat: {
+        single: function(config) {
+          return "xunit_report.xml";
+        }
+      }
+    }
   },
   //
   // Options to be passed to Mocha.


### PR DESCRIPTION
1. Add xunit format report output to support tier-1 result dashboard
2. Change package name from bash to tmux. Package filter result for bash package has lots of matches in some scenarios. It's very hard for test to pick this package. Changing to tmux makes things easy.