### PR TITLE
Include ability to add a user to the blueprint

### DIFF
--- a/components/Form/Password.js
+++ b/components/Form/Password.js
@@ -1,0 +1,218 @@
+import React from "react";
+import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import PropTypes from "prop-types";
+import cockpit from "cockpit";
+
+const messages = defineMessages({
+  weakPassword: {
+    defaultMessage: "Password is too weak"
+  },
+  rejectedPassword: {
+    defaultMessage: "Password is not acceptable"
+  }
+});
+
+class Password extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      passwordOne: "",
+      passwordTwo: "",
+      displayWarningMatch: false,
+      passwordQuality: "",
+      warningQuality: "",
+      displayWarningQual: false
+    };
+    this.handleChangePasswordOne = this.handleChangePasswordOne.bind(this);
+    this.handleChangePasswordTwo = this.handleChangePasswordTwo.bind(this);
+    this.handleWarnings = this.handleWarnings.bind(this);
+    this.validateQuality = this.validateQuality.bind(this);
+    this.passwordQualityFail = this.passwordQualityFail.bind(this);
+    this.passwordQualityPass = this.passwordQualityPass.bind(this);
+  }
+
+  // password quality is only checked for passwordOne
+  // password match is checked on both
+  // messages only display during handleWarnings on blur
+  // but will be removed during handleChange... when warnings are no longer true
+
+  handleChangePasswordOne(event) {
+    this.setState({
+      passwordOne: event.target.value,
+      displayWarningQual: false
+    });
+    if (event.target.value !== "") {
+      this.validateQuality(event.target.value);
+      // if the password passes quality check, this function will also check
+      // if both values match, and will pass the password to the parent component
+    } else {
+      this.setState({
+        passwordQuality: "",
+        warningQuality: ""
+      });
+    }
+    if (event.target.value === this.state.passwordTwo) {
+      this.setState({ displayWarningMatch: false });
+    }
+  }
+
+  handleChangePasswordTwo(event) {
+    this.setState({ passwordTwo: event.target.value });
+    if (this.state.passwordOne === event.target.value) {
+      this.setState({ displayWarningMatch: false });
+    }
+    // if the passwords match, and there's no quality warning message defined
+    // then pass the password to the parent component, otherwise, the password values
+    // are invalid and the submit button will be disabled
+    if (this.state.passwordOne === event.target.value && this.state.warningQuality === "") {
+      this.props.setValidPassword(event.target.value);
+    } else {
+      this.props.setValidPassword();
+    }
+  }
+
+  handleWarnings(input) {
+    setTimeout(() => {
+      if (this.state.passwordOne !== "" && input === "one") {
+        this.setState({ displayWarningQual: true });
+      }
+      if (
+        this.state.passwordOne !== this.state.passwordTwo &&
+        this.state.passwordOne !== "" &&
+        this.state.passwordTwo !== ""
+      ) {
+        this.setState({ displayWarningMatch: true });
+      } else {
+        this.setState({ displayWarningMatch: false });
+      }
+    }, 300);
+  }
+
+  validateQuality(password) {
+    const dfd = cockpit.defer();
+    cockpit
+      .spawn("/usr/bin/pwscore", { err: "message" })
+      .input(password)
+      .done(content => {
+        const quality = parseInt(content, 10);
+        if (quality === 0) {
+          this.passwordQualityFail(this.props.intl.formatMessage(messages.weakPassword));
+          dfd.reject(new Error(this.props.intl.formatMessage(messages.weakPassword)));
+        } else if (quality <= 33) {
+          this.passwordQualityPass("weak", password);
+          dfd.resolve("weak");
+        } else if (quality <= 66) {
+          this.passwordQualityPass("okay", password);
+          dfd.resolve("okay");
+        } else if (quality <= 99) {
+          this.passwordQualityPass("good", password);
+          dfd.resolve("good");
+        } else {
+          this.passwordQualityPass("excellent", password);
+          dfd.resolve("excellent");
+        }
+      })
+      .fail(ex => {
+        this.passwordQualityFail(ex.message || this.props.intl.formatMessage(messages.rejectedPassword));
+        dfd.reject(new Error(ex.message || this.props.intl.formatMessage(messages.rejectedPassword)));
+      });
+    return dfd.promise();
+  }
+
+  passwordQualityFail(message) {
+    this.setState({ passwordQuality: "weak" });
+    this.setState({ warningQuality: message });
+    this.props.setValidPassword();
+  }
+
+  passwordQualityPass(quality, password) {
+    this.setState({
+      passwordQuality: quality,
+      warningQuality: ""
+    });
+    // if the passwords match then pass the password to the modal state,
+    // otherwise, the password values are invalid and the submit button will be disabled
+    if (this.state.passwordTwo === password) {
+      this.props.setValidPassword(password);
+    } else {
+      this.props.setValidPassword();
+    }
+  }
+
+  render() {
+    const passwordOneInvalid =
+      this.state.displayWarningMatch || (this.state.warningQuality !== "" && this.state.displayWarningQual);
+    return (
+      <div>
+        <div className={`form-group ${passwordOneInvalid ? "has-error" : ""}`}>
+          <label className="col-sm-3 control-label" htmlFor="textInput1-modal-password">
+            {this.props.labelOne}
+          </label>
+          <div className="col-sm-9">
+            <input
+              type="password"
+              id="textInput1-modal-password"
+              className="form-control"
+              aria-describedby="textInput2-modal-password-help textInput2-modal-password-help2"
+              aria-invalid={this.state.displayWarningMatch}
+              value={this.state.passwordOne}
+              onChange={e => this.handleChangePasswordOne(e)}
+              onBlur={() => this.handleWarnings("one")}
+            />
+          </div>
+        </div>
+        <div className={`form-group ${this.state.displayWarningMatch ? "has-error" : ""}`}>
+          <label className="col-sm-3 control-label" htmlFor="textInput2-modal-password">
+            {this.props.labelTwo}
+          </label>
+          <div className="col-sm-9">
+            <input
+              type="password"
+              id="textInput2-modal-password"
+              className="form-control"
+              aria-describedby="textInput2-modal-password-help textInput2-modal-password-help2"
+              aria-invalid={this.state.displayWarningMatch}
+              value={this.state.passwordTwo}
+              onChange={e => this.handleChangePasswordTwo(e)}
+              onBlur={this.handleWarnings}
+            />
+            <div
+              id="accounts-create-password-meter"
+              className={`progress password-strength-meter ${this.state.passwordQuality}`}
+            >
+              <div className="progress-bar" />
+              <div className="progress-bar" />
+              <div className="progress-bar" />
+              <div className="progress-bar" />
+            </div>
+            {this.state.warningQuality !== "" && this.state.displayWarningQual && (
+              <span className="help-block" id="textInput2-modal-password-help">
+                {this.state.warningQuality}
+              </span>
+            )}
+            {this.state.displayWarningMatch && (
+              <span className="help-block" id="textInput2-modal-password-help2">
+                <FormattedMessage defaultMessage="The values entered for password do not match." />
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+Password.propTypes = {
+  setValidPassword: PropTypes.func,
+  labelOne: PropTypes.string,
+  labelTwo: PropTypes.string,
+  intl: intlShape.isRequired
+};
+
+Password.defaultProps = {
+  setValidPassword: function() {},
+  labelOne: "",
+  labelTwo: ""
+};
+
+export default injectIntl(Password);

--- a/components/Modal/UserAccount.js
+++ b/components/Modal/UserAccount.js
@@ -1,0 +1,440 @@
+/* global $ */
+/* eslint-disable jsx-a11y/label-has-associated-control */
+
+import React from "react";
+import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import cockpit from "cockpit";
+import Password from "../Form/Password";
+import { setModalUserAccountData } from "../../core/actions/modals";
+
+const messages = defineMessages({
+  modalTitleCreate: {
+    defaultMessage: "Create User Account"
+  },
+  modalTitleEdit: {
+    defaultMessage: "Edit User Account"
+  },
+  sshKeyHelp: {
+    defaultMessage: "Paste the contents of your public SSH key file here. "
+  },
+  createPasswordOne: {
+    defaultMessage: "Password"
+  },
+  createPasswordTwo: {
+    defaultMessage: "Confirm password"
+  },
+  editPasswordOne: {
+    defaultMessage: "New password"
+  }
+});
+
+class UserAccount extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentUser: undefined,
+      setNewPassword: false
+    };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleHideModal = this.handleHideModal.bind(this);
+    this.handleValidateUser = this.handleValidateUser.bind(this);
+    this.handleSubmitUserAccount = this.handleSubmitUserAccount.bind(this);
+    this.encryptPassword = this.encryptPassword.bind(this);
+    this.setValidPassword = this.setValidPassword.bind(this);
+    this.handleRemovePassword = this.handleRemovePassword.bind(this);
+    this.makeUsername = this.makeUsername.bind(this);
+    this.removeDiacritics = this.removeDiacritics.bind(this);
+    this.isValidCharUsername = this.isValidCharUsername.bind(this);
+  }
+
+  componentDidMount() {
+    $(this.modal).modal("show");
+    $(this.modal).on("hidden.bs.modal", this.handleHideModal);
+    if (this.props.userAccount.editUser !== "") {
+      let currentUser = Object.assign({}, this.props.users.find(user => user.name === this.props.userAccount.name));
+      this.setState({ currentUser: currentUser });
+    }
+  }
+
+  setValidPassword(password) {
+    if (password === undefined) {
+      this.props.setModalUserAccountData({ showInvalidPassword: true });
+    } else {
+      this.props.setModalUserAccountData({ password: password });
+      this.props.setModalUserAccountData({ showInvalidPassword: false });
+    }
+  }
+
+  handleRemovePassword() {
+    this.props.setModalUserAccountData({ password: "" });
+    this.setState(prevState => {
+      const updatedUser = Object.assign({}, prevState.currentUser);
+      delete updatedUser.password;
+      return { currentUser: updatedUser };
+    });
+  }
+
+  handleHideModal() {
+    const data = {
+      name: "",
+      description: "",
+      password: "",
+      key: "",
+      groups: [],
+      showDuplicateUser: false,
+      showInvalidName: false,
+      dynamicName: true,
+      visible: false,
+      editUser: "",
+      disabledSubmit: true
+    };
+    this.props.setModalUserAccountData(data);
+  }
+
+  handleChange(e, prop) {
+    let data = {};
+    if (prop === "admin") {
+      data = {
+        groups: e.target.checked ? ["wheel"] : [""]
+      };
+    } else {
+      data = { [prop]: e.target.value };
+    }
+    this.props.setModalUserAccountData(data);
+    if (prop === "name") {
+      this.props.setModalUserAccountData({ dynamicName: false });
+      this.handleValidateUser(e.target.value);
+    }
+    if (prop === "description" && this.props.userAccount.dynamicName === true) {
+      const userName = this.makeUsername(e.target.value);
+      this.props.setModalUserAccountData({ name: userName });
+      this.handleValidateUser(userName);
+    }
+  }
+
+  handleValidateUser(name) {
+    let userNames = this.props.users.map(user => user.name);
+    if (this.props.userAccount.editUser !== "") {
+      userNames.filter(name => name !== this.state.currentUser.name);
+    }
+    const showDuplicateUser = !userNames.every(userName => userName.toLowerCase() !== name.toLowerCase());
+    this.props.setModalUserAccountData({ showDuplicateUser: showDuplicateUser });
+    const validCharacters = name.length === 0 || /^(\d|\w|-|_|\.){0,252}$/.test(name);
+    this.props.setModalUserAccountData({ showInvalidName: !validCharacters });
+  }
+
+  makeUsername(realname) {
+    let result = "";
+    const name = realname.split(" ");
+    if (name.length === 1) result = name[0].toLowerCase();
+    else if (name.length > 1) result = name[0][0].toLowerCase() + name[name.length - 1].toLowerCase();
+    return this.removeDiacritics(result);
+  }
+
+  removeDiacritics(str) {
+    const translate_table = {
+      a: "[àáâãäå]",
+      ae: "æ",
+      c: "[čç]",
+      d: "ď",
+      e: "[èéêë]",
+      i: "[íìïî]",
+      l: "[ĺľ]",
+      n: "[ňñ]",
+      o: "[òóôõö]",
+      oe: "œ",
+      r: "[ŕř]",
+      s: "š",
+      t: "ť",
+      u: "[ùúůûűü]",
+      y: "[ýÿ]",
+      z: "ž"
+    };
+    for (const i in translate_table) str = str.replace(new RegExp(translate_table[i], "g"), i);
+    for (let k = 0; k < str.length; ) {
+      if (!this.isValidCharUsername(str[k])) str = str.substr(0, k) + str.substr(k + 1);
+      else k++;
+    }
+    return str;
+  }
+
+  isValidCharUsername(c) {
+    return (
+      (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || (c >= "0" && c <= "9") || c == "." || c == "_" || c == "-"
+    );
+  }
+
+  handleSubmitUserAccount(e) {
+    // if creating a new user and password is defined, or editing a user and new password is defined,
+    // then encrypt the password
+    if (this.props.userAccount.password !== "") {
+      this.encryptPassword(this.props.userAccount.password)
+        .then(res => this.props.handlePostUser(res))
+        .catch(ex => console.error("failed to encrypt password:", ex));
+    } else {
+      const password = this.state.currentUser ? this.state.currentUser.password : "";
+      this.props.handlePostUser(password);
+    }
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  encryptPassword(password) {
+    return cockpit.spawn(["openssl", "passwd", "-6", "-stdin"], { err: "message" }).input(password);
+  }
+
+  render() {
+    const { userAccount } = this.props;
+    const { formatMessage } = this.props.intl;
+    const disabledSubmit =
+      userAccount.showDuplicateUser ||
+      userAccount.showInvalidName ||
+      userAccount.length === 0 ||
+      userAccount.showInvalidPassword;
+    return (
+      <div
+        className="modal fade"
+        id="cmpsr-modal-crt-blueprint"
+        ref={c => {
+          this.modal = c;
+        }}
+        tabIndex="-1"
+        role="dialog"
+        aria-labelledby="myModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog">
+          <form className="modal-content">
+            <div className="modal-header">
+              <button type="button" className="close" data-dismiss="modal">
+                <span className="pficon pficon-close" />
+              </button>
+              <h4 className="modal-title" id="myModalLabel">
+                {(userAccount.editUser !== "" && formatMessage(messages.modalTitleEdit)) ||
+                  formatMessage(messages.modalTitleCreate)}
+              </h4>
+            </div>
+            <div className="modal-body">
+              <div className="form-horizontal">
+                <p className="fields-status-pf">
+                  <FormattedMessage
+                    defaultMessage="The fields marked with {val} are required."
+                    values={{
+                      val: <span className="required-pf">*</span>
+                    }}
+                  />
+                </p>
+                <div className="form-group">
+                  <label className="col-sm-3 control-label" htmlFor="textInput2-modal-user">
+                    <FormattedMessage defaultMessage="Full name" />
+                  </label>
+                  <div className="col-sm-9">
+                    <input
+                      type="text"
+                      id="textInput2-modal-user"
+                      className="form-control"
+                      value={userAccount.description}
+                      onChange={e => this.handleChange(e, "description")}
+                    />
+                  </div>
+                </div>
+                <div
+                  className={`form-group ${
+                    userAccount.showDuplicateUser || userAccount.showInvalidName ? "has-error" : ""
+                  }`}
+                >
+                  <label className="col-sm-3 control-label required-pf" htmlFor="textInput1-modal-user">
+                    <FormattedMessage defaultMessage="User name" />
+                  </label>
+                  <div className="col-sm-9">
+                    <input
+                      type="text"
+                      id="textInput1-modal-user"
+                      className="form-control"
+                      aria-describedby="textInput1-modal-user-help1 textInput1-modal-user-help2"
+                      value={userAccount.name}
+                      onChange={e => this.handleChange(e, "name")}
+                      aria-required="true"
+                      aria-invalid={userAccount.showDuplicateUser || userAccount.showInvalidName}
+                    />
+                    {userAccount.showDuplicateUser && (
+                      <span className="help-block" id="textInput1-modal-user-help1">
+                        <FormattedMessage defaultMessage="This user name already exists." />
+                      </span>
+                    )}
+                    {!userAccount.showDuplicateUser && (
+                      <span className="help-block" id="textInput1-modal-user-help2">
+                        <FormattedMessage defaultMessage="The user name can only consist of letters from a-z, digits, dots, dashes and underscores." />
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="form-group">
+                  <label className="col-sm-3 control-label">
+                    <FormattedMessage defaultMessage="Role" />
+                  </label>
+                  <div className="col-sm-9 checkbox">
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={userAccount.groups.includes("wheel")}
+                        onChange={e => this.handleChange(e, "admin")}
+                      />
+                      <FormattedMessage defaultMessage="Server administrator" />
+                    </label>
+                  </div>
+                </div>
+                {((userAccount.editUser === "" ||
+                  (userAccount.editUser !== "" &&
+                    this.state.setNewPassword === true &&
+                    this.state.currentUser !== undefined &&
+                    this.state.currentUser.password === undefined)) && (
+                  <Password
+                    setValidPassword={this.setValidPassword}
+                    labelOne={formatMessage(messages.createPasswordOne)}
+                    labelTwo={formatMessage(messages.createPasswordTwo)}
+                  />
+                )) ||
+                  (this.state.currentUser !== undefined && this.state.currentUser.password === undefined && (
+                    <div className="form-group">
+                      <label className="col-sm-3 control-label">
+                        <FormattedMessage defaultMessage="Password" />
+                      </label>
+                      <div className="col-sm-9">
+                        <p className="form-control-static">
+                          <FormattedMessage defaultMessage="A password is not defined for this account." />
+                        </p>
+                        <button
+                          type="button"
+                          className="btn btn-default"
+                          onClick={() => this.setState({ setNewPassword: true })}
+                        >
+                          <FormattedMessage defaultMessage="Set Password" />
+                        </button>
+                      </div>
+                    </div>
+                  )) || (
+                    <div>
+                      <div className="form-group">
+                        <label className="col-sm-3 control-label">
+                          <FormattedMessage defaultMessage="Password" />
+                        </label>
+                        <div className="col-sm-9">
+                          <p className="form-control-static">
+                            <FormattedMessage defaultMessage="A password is defined for this account." />
+                          </p>
+                          {this.state.setNewPassword === false && (
+                            <div>
+                              <button
+                                type="button"
+                                className="btn btn-default"
+                                onClick={() => this.setState({ setNewPassword: true })}
+                              >
+                                <FormattedMessage defaultMessage="Set New Password" />
+                              </button>
+                              {` `}
+                              <button
+                                type="button"
+                                className="btn btn-default"
+                                onClick={() => this.handleRemovePassword()}
+                              >
+                                <FormattedMessage defaultMessage="Remove Password" />
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                      {this.state.setNewPassword === true && (
+                        <Password
+                          setValidPassword={this.setValidPassword}
+                          labelOne={formatMessage(messages.editPasswordOne)}
+                          labelTwo={formatMessage(messages.createPasswordTwo)}
+                        />
+                      )}
+                    </div>
+                  )}
+                <div className="form-group">
+                  <label className="col-sm-3 control-label" htmlFor="textInput5-modal-user">
+                    <FormattedMessage defaultMessage="SSH key" />
+                  </label>
+                  <div className="col-sm-9">
+                    <textarea
+                      type="text"
+                      id="textInput5-modal-user"
+                      className="form-control"
+                      aria-describedby="textInput5-modal-user-help"
+                      rows="8"
+                      value={userAccount.key}
+                      onChange={e => this.handleChange(e, "key")}
+                    />
+                    <span className="help-block" id="textInput5-modal-user-help">
+                      {formatMessage(messages.sshKeyHelp)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-default" data-dismiss="modal">
+                <FormattedMessage defaultMessage="Cancel" />
+              </button>
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={disabledSubmit}
+                onClick={e => this.handleSubmitUserAccount(e)}
+              >
+                {(userAccount.editUser !== "" && <FormattedMessage defaultMessage="Update" />) || (
+                  <FormattedMessage defaultMessage="Create" />
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    );
+  }
+}
+
+UserAccount.propTypes = {
+  userAccount: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string,
+    password: PropTypes.string,
+    key: PropTypes.string,
+    showDuplicateUser: PropTypes.bool,
+    showInvalidName: PropTypes.bool,
+    dynamicName: PropTypes.bool,
+    disabledSubmit: PropTypes.bool,
+    visible: PropTypes.bool,
+    editUser: PropTypes.string
+  }),
+  users: PropTypes.arrayOf(PropTypes.object),
+  setModalUserAccountData: PropTypes.func,
+  handlePostUser: PropTypes.func,
+  intl: intlShape.isRequired
+};
+
+UserAccount.defaultProps = {
+  userAccount: {},
+  users: [],
+  setModalUserAccountData: function() {},
+  handlePostUser: function() {}
+};
+
+const mapStateToProps = state => ({
+  userAccount: state.modals.userAccount
+});
+
+const mapDispatchToProps = dispatch => ({
+  setModalUserAccountData: data => {
+    dispatch(setModalUserAccountData(data));
+  }
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(injectIntl(UserAccount));

--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -75,6 +75,23 @@ export const setBlueprintComment = (blueprint, comment) => ({
   }
 });
 
+export const SET_BLUEPRINT_USERS = "SET_BLUEPRINT_USERS";
+export const setBlueprintUsers = (blueprintId, users) => ({
+  type: SET_BLUEPRINT_USERS,
+  payload: {
+    blueprintId,
+    users
+  }
+});
+
+export const SET_BLUEPRINT_USERS_SUCCEEDED = "SET_BLUEPRINT_USERS_SUCCEEDED";
+export const setBlueprintUsersSucceeded = blueprint => ({
+  type: SET_BLUEPRINT_USERS_SUCCEEDED,
+  payload: {
+    blueprint
+  }
+});
+
 export const SET_BLUEPRINT_HOSTNAME = "SET_BLUEPRINT_HOSTNAME";
 export const setBlueprintHostname = (blueprint, hostname) => ({
   type: SET_BLUEPRINT_HOSTNAME,

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -207,6 +207,26 @@ export function appendModalPendingChangesComponentUpdates(componentUpdate) {
   };
 }
 
+export const SET_MODAL_CREATE_USER_DATA = "SET_MODAL_CREATE_USER_DATA";
+export function setModalUserAccountData(data) {
+  return {
+    type: SET_MODAL_CREATE_USER_DATA,
+    payload: {
+      data
+    }
+  };
+}
+
+export const SET_MODAL_CREATE_USER_VISIBLE = "SET_MODAL_CREATE_USER_VISIBLE";
+export function setModalUserAccountVisible(visible) {
+  return {
+    type: SET_MODAL_CREATE_USER_VISIBLE,
+    payload: {
+      visible
+    }
+  };
+}
+
 export const SET_MODAL_MANAGE_SOURCES_VISIBLE = "SET_MODAL_MANAGE_SOURCES_VISIBLE";
 export function setModalManageSourcesVisible(visible) {
   return {

--- a/core/reducers/blueprints.js
+++ b/core/reducers/blueprints.js
@@ -8,6 +8,8 @@ import {
   FETCHING_BLUEPRINT_CONTENTS_SUCCEEDED,
   UPDATE_BLUEPRINT_COMPONENTS,
   SET_BLUEPRINT,
+  SET_BLUEPRINT_USERS,
+  SET_BLUEPRINT_USERS_SUCCEEDED,
   SET_BLUEPRINT_HOSTNAME,
   SET_BLUEPRINT_HOSTNAME_SUCCEEDED,
   SET_BLUEPRINT_DESCRIPTION,
@@ -153,6 +155,57 @@ const blueprints = (state = [], action) => {
             if (blueprint.present.id === action.payload.blueprint.id) {
               return Object.assign({}, blueprint, {
                 present: Object.assign({}, blueprint.present, { comment: action.payload.comment })
+              });
+            }
+            return blueprint;
+          })
+        ]
+      });
+    case SET_BLUEPRINT_USERS:
+      return Object.assign({}, state, {
+        blueprintList: [
+          ...state.blueprintList.map(blueprint => {
+            if (blueprint.present.id === action.payload.blueprintId) {
+              return Object.assign({}, blueprint, {
+                present: Object.assign({}, blueprint.present, {
+                  customizations: Object.assign({}, blueprint.present.customizations, {
+                    user: action.payload.users
+                  })
+                })
+              });
+            }
+            return blueprint;
+          })
+        ]
+      });
+    case SET_BLUEPRINT_USERS_SUCCEEDED:
+      return Object.assign({}, state, {
+        blueprintList: [
+          ...state.blueprintList.map(blueprint => {
+            if (blueprint.present.id === action.payload.blueprint.id) {
+              return Object.assign({}, blueprint, {
+                past: blueprint.past.map(pastBlueprint => {
+                  return Object.assign({}, pastBlueprint, {
+                    version: action.payload.blueprint.version,
+                    customizations: Object.assign({}, pastBlueprint.customizations, {
+                      user: action.payload.blueprint.customizations.user
+                    })
+                  });
+                }),
+                present: Object.assign({}, blueprint.present, {
+                  version: action.payload.blueprint.version,
+                  customizations: Object.assign({}, blueprint.present.customizations, {
+                    user: action.payload.blueprint.customizations.user
+                  })
+                }),
+                future: blueprint.future.map(futureBlueprint => {
+                  return Object.assign({}, futureBlueprint, {
+                    version: action.payload.blueprint.version,
+                    customizations: Object.assign({}, futureBlueprint.customizations, {
+                      user: action.payload.blueprint.customizations.user
+                    })
+                  });
+                })
               });
             }
             return blueprint;

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -18,6 +18,8 @@ import {
   SET_MODAL_STOP_BUILD_VISIBLE,
   SET_MODAL_STOP_BUILD_STATE,
   FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS,
+  SET_MODAL_CREATE_USER_VISIBLE,
+  SET_MODAL_CREATE_USER_DATA,
   SET_MODAL_MANAGE_SOURCES_VISIBLE,
   SET_MODAL_MANAGE_SOURCES_CONTENTS,
   MODAL_MANAGE_SOURCES_FAILURE
@@ -158,6 +160,21 @@ const modalExportBlueprint = (state = [], action) => {
   }
 };
 
+const modalUserAccount = (state = [], action) => {
+  switch (action.type) {
+    case SET_MODAL_CREATE_USER_VISIBLE:
+      return Object.assign({}, state, {
+        userAccount: Object.assign({}, state.userAccount, { visible: action.payload.visible })
+      });
+    case SET_MODAL_CREATE_USER_DATA:
+      return Object.assign({}, state, {
+        userAccount: Object.assign({}, state.userAccount, action.payload.data)
+      });
+    default:
+      return state;
+  }
+};
+
 const modalManageSources = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_MANAGE_SOURCES_CONTENTS:
@@ -220,6 +237,10 @@ const modals = (state = [], action) => {
       return modalExportBlueprint(state, action);
     case SET_MODAL_EXPORT_BLUEPRINT_VISIBLE:
       return modalExportBlueprint(state, action);
+    case SET_MODAL_CREATE_USER_VISIBLE:
+      return modalUserAccount(state, action);
+    case SET_MODAL_CREATE_USER_DATA:
+      return modalUserAccount(state, action);
     case SET_MODAL_MANAGE_SOURCES_CONTENTS:
       return modalManageSources(state, action);
     case SET_MODAL_MANAGE_SOURCES_VISIBLE:

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -22,6 +22,8 @@ import {
   CREATING_BLUEPRINT,
   creatingBlueprintSucceeded,
   UPDATE_BLUEPRINT_COMPONENTS,
+  SET_BLUEPRINT_USERS,
+  setBlueprintUsersSucceeded,
   SET_BLUEPRINT_HOSTNAME,
   setBlueprintHostnameSucceeded,
   SET_BLUEPRINT_DESCRIPTION,
@@ -184,6 +186,36 @@ function* getBlueprintHistory(blueprintId) {
   const blueprintHistory = yield select(getBlueprintById, blueprintId);
   const oldestBlueprint = blueprintHistory.past[0] ? blueprintHistory.past[0] : blueprintHistory.present;
   return [oldestBlueprint, blueprintHistory.present];
+}
+
+function* setBlueprintUsers(action) {
+  try {
+    const { blueprintId, users } = action.payload;
+    // commit the oldest blueprint with the updated users
+    const blueprintHistory = yield call(getBlueprintHistory, blueprintId);
+    const blueprintToPost = BlueprintApi.postedBlueprintData(
+      Object.assign({}, blueprintHistory[0], {
+        customizations: Object.assign({}, blueprintHistory[0].customizations, { user: users })
+      })
+    );
+    yield call(BlueprintApi.postBlueprint, blueprintToPost);
+    // get updated blueprint info (i.e. version)
+    const response = yield call(fetchBlueprintInfoApi, blueprintId);
+    yield put(setBlueprintUsersSucceeded(response));
+    // post present blueprint object to workspace
+    if (response.changed === true) {
+      const workspace = Object.assign({}, blueprintHistory[1], {
+        version: response.version,
+        customizations: Object.assign({}, blueprintHistory[1].customizations, {
+          user: users
+        })
+      });
+      yield call(commitToWorkspaceApi, workspace);
+    }
+  } catch (error) {
+    console.log("Error in setBlueprintHostname");
+    yield put(blueprintsFailure(error));
+  }
 }
 
 function* setBlueprintHostname(action) {
@@ -351,6 +383,7 @@ function* fetchCompDeps(action) {
 export default function*() {
   yield takeEvery(CREATING_BLUEPRINT, createBlueprint);
   yield takeEvery(FETCHING_BLUEPRINT_CONTENTS, fetchBlueprintContents);
+  yield takeEvery(SET_BLUEPRINT_USERS, setBlueprintUsers);
   yield takeEvery(SET_BLUEPRINT_HOSTNAME, setBlueprintHostname);
   yield takeEvery(SET_BLUEPRINT_DESCRIPTION, setBlueprintDescription);
   yield takeEvery(DELETING_BLUEPRINT, deleteBlueprint);

--- a/core/store.js
+++ b/core/store.js
@@ -91,6 +91,19 @@ const initialState = {
     manageSources: {
       sources: [],
       visible: false
+    },
+    userAccount: {
+      name: "",
+      description: "",
+      password: "",
+      key: "",
+      groups: [],
+      showDuplicateUser: false,
+      showInvalidName: false,
+      showInvalidPassword: false,
+      dynamicName: true,
+      visible: false,
+      editUser: ""
     }
   },
   sort: {

--- a/public/custom.css
+++ b/public/custom.css
@@ -388,6 +388,30 @@ the "-" that would display instead of the sr-only "to" */
   border-color: #949494;
 }
 
+/* user config - password strength */
+.password-strength-meter {
+  height: 5px;
+  margin-top: 5px;
+  margin-bottom: 0;
+}
+.password-strength-meter div {
+  width: 25%;
+  border-right: 3px solid #fff;
+  background-color: transparent;
+}
+.password-strength-meter.weak div:first-child {
+  background-color: #C00;
+}
+.password-strength-meter.okay div:nth-child(-n+2) {
+  background-color: #EC7A08;
+}
+.password-strength-meter.good div:nth-child(-n+3) {
+  background-color: #3F9C35;
+}
+.password-strength-meter.excellent div:nth-child(-n+4) {
+  background-color: #3F9C35;
+}
+
 /* tab contents */
 .tab-container {
     padding: 20px 0;


### PR DESCRIPTION
- User account creation allows for defining name, description, password, ssh key and also enabling the user to be a server admin (i.e. groups=["wheel"]).
  - When an ssh key is provided, no validation occurs. When the account is listed on the Details page, if the key includes an email address, that is the only part of the key that displays in the table.
  - When a password is provided, an encrypted password is stored in the blueprint. When the account is listed on the Details page, only a checkmark icon displays to indicate that a password is set. When editing a user account, the password can be deleted or a new password can be set.
- User accounts can also be updated or removed.
- User accounts that are created for a blueprint are listed on the Details tab of a blueprint.
- Text strings and functionality match Cockpit as much as possible, but there are some differences given that the workflow is slightly different

![image](https://user-images.githubusercontent.com/21063328/54460688-ad26f000-4740-11e9-9a1e-d3db02a72a95.png)

![image](https://user-images.githubusercontent.com/21063328/54307183-63ec6a00-45a1-11e9-94b6-b1c551a85e92.png)

![image](https://user-images.githubusercontent.com/21063328/54308470-73b97d80-45a4-11e9-8fef-e2657b8959dd.png)


