### PR TITLE
Addresses issue with duplicate keys when multiple arches

### DIFF
--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -133,7 +133,7 @@ function* generateComponents(blueprintData) {
   const moduleNames = blueprintData.blueprint.modules.map(component => component.name);
   const selectedComponentNames = packageNames.concat(moduleNames);
   const componentInfo = yield call(fetchComponentDetailsApi, componentNames);
-  const components = blueprintData.dependencies.map(component => {
+  const components = flattenComponents(blueprintData.dependencies).map(component => {
     const info = componentInfo.find(item => item.name === component.name);
     const componentData = Object.assign(
       {},
@@ -152,6 +152,14 @@ function* generateComponents(blueprintData) {
     return componentData;
   });
   return components;
+}
+
+function flattenComponents(components) {
+  let previousComponents = {};
+  let flattened = components.filter(component => {
+    return previousComponents.hasOwnProperty(component.name) ? false : (previousComponents[component.name] = true);
+  });
+  return flattened;
 }
 
 function* reloadBlueprintContents(blueprintId) {


### PR DESCRIPTION
When the api call constants.get_blueprints_deps returns a list of dependencies, if a package has more than one arch, then each arch is a separate item in the array of dependencies. Since the list item key is based on the name, this results in issues when rendering the list of contents as they are updated due to the key not being unique.

This update removes duplicates in the list of selected components and dependencies.