### PR TITLE
cockpituous: Release to Fedora Rawhide

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -9,7 +9,14 @@ RELEASE_SOURCE="_release/source"
 RELEASE_SPEC="cockpit-composer.spec"
 RELEASE_SRPM="_release/srpm"
 
+# Authenticate for pushing into Fedora dist-git
+cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
+
 job release-source
 job release-srpm
+
+# Do fedora builds for the tag, using tarball
+job release-koji master
+
 job release-github
 job release-copr @weldr/welder-web


### PR DESCRIPTION
cockpit-composer is in rawhide now, so upload new releases automatically
to there.