### PR TITLE
fixes issue with fetching contents for Export modal

### DIFF
--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -38,6 +38,7 @@ import {
   FETCHING_COMP_DEPS,
   setCompDeps
 } from "../actions/blueprints";
+import { FETCHING_MODAL_EXPORT_BLUEPRINT_CONTENTS, setModalExportBlueprintContents } from "../actions/modals";
 import { makeGetBlueprintById, makeGetSelectedDeps } from "../selectors";
 
 function* fetchBlueprintsFromName(blueprintName) {
@@ -186,6 +187,22 @@ function* reloadBlueprintContents(blueprintId) {
   } catch (error) {
     console.log("Error in fetchBlueprintContentsSaga");
     yield put(blueprintContentsFailure(error, blueprintId));
+  }
+}
+
+function* fetchModalBlueprintContents(action) {
+  // fetches contents for Export modal on Blueprints page
+  try {
+    const { blueprintName } = action.payload;
+    const response = yield call(fetchBlueprintContentsApi, blueprintName);
+    const blueprintData = response.blueprints[0];
+    let components = [];
+    if (blueprintData.dependencies.length > 0) {
+      components = yield call(generateComponents, blueprintData);
+    }
+    yield put(setModalExportBlueprintContents(components));
+  } catch (error) {
+    console.log("Error in loadModalBlueprintSaga");
   }
 }
 
@@ -391,6 +408,7 @@ function* fetchCompDeps(action) {
 export default function*() {
   yield takeEvery(CREATING_BLUEPRINT, createBlueprint);
   yield takeEvery(FETCHING_BLUEPRINT_CONTENTS, fetchBlueprintContents);
+  yield takeEvery(FETCHING_MODAL_EXPORT_BLUEPRINT_CONTENTS, fetchModalBlueprintContents);
   yield takeEvery(SET_BLUEPRINT_USERS, setBlueprintUsers);
   yield takeEvery(SET_BLUEPRINT_HOSTNAME, setBlueprintHostname);
   yield takeEvery(SET_BLUEPRINT_DESCRIPTION, setBlueprintDescription);

--- a/core/sagas/modals.js
+++ b/core/sagas/modals.js
@@ -1,24 +1,12 @@
 import { call, put, takeEvery } from "redux-saga/effects";
-import { fetchBlueprintContentsApi, fetchModalCreateImageTypesApi, fetchSourceInfoApi } from "../apiCalls";
+import { fetchModalCreateImageTypesApi, fetchSourceInfoApi } from "../apiCalls";
 
 import {
-  FETCHING_MODAL_EXPORT_BLUEPRINT_CONTENTS,
-  setModalExportBlueprintContents,
   fetchingModalCreateImageTypesSuccess,
   FETCHING_MODAL_MANAGE_SOURCES_CONTENTS,
   setModalManageSourcesContents,
   modalManageSourcesFailure
 } from "../actions/modals";
-
-function* fetchModalBlueprintContents(action) {
-  try {
-    const { blueprintName } = action.payload;
-    const response = yield call(fetchBlueprintContentsApi, blueprintName);
-    yield put(setModalExportBlueprintContents(response.components));
-  } catch (error) {
-    console.log("Error in loadModalBlueprintSaga");
-  }
-}
 
 function* fetchModalManageSourcesContents() {
   try {
@@ -40,7 +28,6 @@ function* fetchModalCreateImageTypes() {
 }
 
 export default function*() {
-  yield takeEvery(FETCHING_MODAL_EXPORT_BLUEPRINT_CONTENTS, fetchModalBlueprintContents);
   yield takeEvery(FETCHING_MODAL_MANAGE_SOURCES_CONTENTS, fetchModalManageSourcesContents);
   yield* fetchModalCreateImageTypes();
 }


### PR DESCRIPTION
Unlike the other pages, the Export modal on the Blueprints page requires an api call to fetch the contents of the modal. This was broken in #500 when the api calls were refactored. This update
moves the functionality from the modals saga to the blueprints saga to reuse functions that handle flattening the list of components after the api call.