### PR TITLE
Add id to Popover in PendingChanges component in order to fix console warning

### DIFF
--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -200,7 +200,11 @@ class PendingChanges extends React.Component {
                   <div>
                     <FormattedMessage defaultMessage="Changes made in a previous session" tagName="strong" />
                     <OverlayTrigger
-                      overlay={<Popover>{formatMessage(messages.previousSessionInfotip)}</Popover>}
+                      overlay={
+                        <Popover id="previous-session-changes-popover">
+                          {formatMessage(messages.previousSessionInfotip)}
+                        </Popover>
+                      }
                       placement="right"
                       trigger={["click"]}
                       rootClose


### PR DESCRIPTION
Without this fix I get the following warning in console:
'Failed prop type: The prop `id` is required to make `Popover`
accessible for users of assistive technologies such as screen readers.'