### PR TITLE
Two updates for ARM64 testing scenario.

### DIFF
--- a/test/end-to-end/specs/api.test.js
+++ b/test/end-to-end/specs/api.test.js
@@ -1,4 +1,5 @@
 const commands = require("../utils/commands");
+const blueprintsPage = require("../pages/blueprints.page");
 
 // acceptable API response time
 // the 1 second comes from https://www.nngroup.com/articles/response-times-3-important-limits/
@@ -9,6 +10,7 @@ describe("lorax-composer api sanity test", function() {
     commands.login();
     // Edge does not support the following command so have to keep default timeout(3 seconds)
     // browser.timeouts({ script: timeout });
+    blueprintsPage.loading();
   });
 
   function apiFetchTest(endpoint, options = { body: "" }) {

--- a/test/end-to-end/wdio.conf.js
+++ b/test/end-to-end/wdio.conf.js
@@ -5,7 +5,7 @@ const crypto = require("crypto");
 
 // const commands = require('./utils/commands');
 
-const mochaTimeout = process.env.DEBUG_TEST === "true" ? 99999999 : 120000;
+const mochaTimeout = parseInt(process.env.MOCHA_TIMEOUT) || 120000;
 
 exports.config = {
   //
@@ -99,11 +99,11 @@ exports.config = {
   baseUrl: process.env.BASE_URL || "http://localhost:9090",
   //
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 120000,
+  waitforTimeout: parseInt(process.env.WAITFOR_TIMEOUT) || 120000,
   //
   // Default timeout in milliseconds for request
   // if Selenium Grid doesn't send response
-  connectionRetryTimeout: 120000,
+  connectionRetryTimeout: parseInt(process.env.CONNECTION_TIMEOUT) || 120000,
   //
   // Default request retries count
   connectionRetryCount: 3,


### PR DESCRIPTION
1. Make all timeout timers in wdio.conf.js configurable by ENV.
2. Not run API test until the blueprints page is fully loaded. That just waits for cockpit available.