### PR TITLE
core: Don't hide errors in sagas

### DIFF
--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -52,7 +52,7 @@ function* fetchBlueprints() {
     yield put(fetchingBlueprintNamesSucceeded());
     yield* blueprintNames.map(blueprintName => fetchBlueprintsFromName(blueprintName));
   } catch (error) {
-    console.log("errorloadBlueprintsSaga");
+    console.log("errorloadBlueprintsSaga", error);
     yield put(blueprintsFailure(error));
   }
 }
@@ -98,7 +98,7 @@ function* fetchBlueprintContents(action) {
       : [];
     yield put(fetchingBlueprintContentsSucceeded(blueprint, pastBlueprint, response.errors[0]));
   } catch (error) {
-    console.log("Error in fetchBlueprintContentsSaga");
+    console.log("Error in fetchBlueprintContentsSaga", error);
     yield put(blueprintContentsFailure(error, action.payload.blueprintId));
   }
 }
@@ -185,7 +185,7 @@ function* reloadBlueprintContents(blueprintId) {
     });
     yield put(reloadingBlueprintContentsSucceeded(blueprint, response.errors[0]));
   } catch (error) {
-    console.log("Error in fetchBlueprintContentsSaga");
+    console.log("Error in fetchBlueprintContentsSaga", error);
     yield put(blueprintContentsFailure(error, blueprintId));
   }
 }
@@ -202,7 +202,7 @@ function* fetchModalBlueprintContents(action) {
     }
     yield put(setModalExportBlueprintContents(components));
   } catch (error) {
-    console.log("Error in loadModalBlueprintSaga");
+    console.log("Error in loadModalBlueprintSaga", error);
   }
 }
 
@@ -238,7 +238,7 @@ function* setBlueprintUsers(action) {
       yield call(commitToWorkspaceApi, workspace);
     }
   } catch (error) {
-    console.log("Error in setBlueprintHostname");
+    console.log("Error in setBlueprintHostname", error);
     yield put(blueprintsFailure(error));
   }
 }
@@ -268,7 +268,7 @@ function* setBlueprintHostname(action) {
       yield call(commitToWorkspaceApi, workspace);
     }
   } catch (error) {
-    console.log("Error in setBlueprintHostname");
+    console.log("Error in setBlueprintHostname", error);
     yield put(blueprintsFailure(error));
   }
 }
@@ -296,7 +296,7 @@ function* setBlueprintDescription(action) {
       yield call(commitToWorkspaceApi, workspace);
     }
   } catch (error) {
-    console.log("Error in setBlueprintDescription");
+    console.log("Error in setBlueprintDescription", error);
     yield put(blueprintsFailure(error));
   }
 }
@@ -307,7 +307,7 @@ function* deleteBlueprint(action) {
     const response = yield call(deleteBlueprintApi, blueprintId);
     yield put(deletingBlueprintSucceeded(response));
   } catch (error) {
-    console.log("errorDeleteBlueprintsSaga");
+    console.log("errorDeleteBlueprintsSaga", error);
     yield put(blueprintsFailure(error));
   }
 }
@@ -318,7 +318,7 @@ function* createBlueprint(action) {
     yield call(createBlueprintApi, blueprint);
     yield put(creatingBlueprintSucceeded(blueprint));
   } catch (error) {
-    console.log("errorCreateBlueprintSaga");
+    console.log("errorCreateBlueprintSaga", error);
     yield put(blueprintsFailure(error));
   }
 }
@@ -344,7 +344,7 @@ function* commitToWorkspace(action) {
       yield call(reloadBlueprintContents, blueprintId);
     }
   } catch (error) {
-    console.log("commitToWorkspaceError");
+    console.log("commitToWorkspaceError", error);
     yield put(blueprintsFailure(error));
   }
 }
@@ -357,7 +357,7 @@ function* deleteWorkspace(action) {
       yield call(reloadBlueprintContents, blueprintId);
     }
   } catch (error) {
-    console.log("deleteWorkspaceError");
+    console.log("deleteWorkspaceError", error);
     yield put(blueprintsFailure("failed delete workspace"));
   }
 }
@@ -401,7 +401,7 @@ function* fetchCompDeps(action) {
     );
     yield put(setCompDeps(updatedComp, blueprintId));
   } catch (error) {
-    console.log("Error in fetchInputDeps");
+    console.log("Error in fetchInputDeps", error);
   }
 }
 

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -36,7 +36,7 @@ function* startCompose(action) {
       yield* pollComposeStatus(statusResponse.uuids[0]);
     }
   } catch (error) {
-    console.log("startComposeError");
+    console.log("startComposeError", error);
     yield put(composesFailure(error));
   }
 }
@@ -56,7 +56,7 @@ function* pollComposeStatus(compose) {
       }
     }
   } catch (error) {
-    console.log("pollComposeStatusError");
+    console.log("pollComposeStatusError", error);
     yield put(composesFailure(error));
   }
 }
@@ -72,7 +72,7 @@ function* fetchComposes() {
       yield all(queue.map(compose => pollComposeStatus(compose)));
     }
   } catch (error) {
-    console.log("fetchComposesError");
+    console.log("fetchComposesError", error);
     yield put(composesFailure(error));
   }
 }
@@ -84,7 +84,7 @@ function* deleteCompose(action) {
     yield put(deletingComposeSucceeded(response, composeId));
     yield* fetchComposes();
   } catch (error) {
-    console.log("errorDeleteComposeSaga");
+    console.log("errorDeleteComposeSaga", error);
     yield put(deletingComposeFailure(error));
   }
 }
@@ -96,7 +96,7 @@ function* cancelCompose(action) {
     yield put(cancellingComposeSucceeded(response, composeId));
     yield* fetchComposes();
   } catch (error) {
-    console.log("errorCancelComposeSaga");
+    console.log("errorCancelComposeSaga", error);
     yield put(cancellingComposeFailure(error));
   }
 }
@@ -106,7 +106,7 @@ function* fetchQueue() {
     const queue = yield call(fetchComposeQueueApi);
     yield put(fetchingQueueSucceeded(queue));
   } catch (error) {
-    console.log("fetchQueueError");
+    console.log("fetchQueueError", error);
     yield put(composesFailure(error));
   }
 }

--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -57,7 +57,7 @@ function* fetchInputs(action) {
     });
     yield put(fetchingInputsSucceeded(filter, selectedInputPage, pageSize, updatedInputs, total));
   } catch (error) {
-    console.log("Error in fetchInputsSaga");
+    console.log("Error in fetchInputsSaga", error);
   }
 }
 
@@ -130,7 +130,7 @@ function* fetchInputDetails(action) {
     });
     yield put(setSelectedInput(componentData));
   } catch (error) {
-    console.log("Error in fetchInputDetails");
+    console.log("Error in fetchInputDetails", error);
   }
 }
 
@@ -162,7 +162,7 @@ function* fetchInputDeps(action) {
     });
     yield put(setSelectedInputDeps(updatedDeps));
   } catch (error) {
-    console.log("Error in fetchInputDeps");
+    console.log("Error in fetchInputDeps", error);
   }
 }
 
@@ -194,7 +194,7 @@ function* fetchDepDetails(action) {
     });
     yield put(setDepDetails(depDetails));
   } catch (error) {
-    console.log("Error in fetchDepDetails");
+    console.log("Error in fetchDepDetails", error);
   }
 }
 


### PR DESCRIPTION
While testing Composer on RHEL 8 Betas I've noticed various
failures in the javascript console, but the actual error content
was hidden. This impedes support, especially of production systems.

I've added full error output to go to the javascript console
in each of these cases.