### PR TITLE
test: Bump API sanity test timeout

### DIFF
--- a/test/end-to-end/specs/api.test.js
+++ b/test/end-to-end/specs/api.test.js
@@ -1,9 +1,10 @@
 const commands = require("../utils/commands");
 const blueprintsPage = require("../pages/blueprints.page");
 
-// acceptable API response time
-// the 1 second comes from https://www.nngroup.com/articles/response-times-3-important-limits/
-const acceptable = 1000;
+// acceptable API response time; we want that to be 1s
+// (https://www.nngroup.com/articles/response-times-3-important-limits/)
+// but on slow/loaded nested-VM OSCI infrastructure this often takes much longer
+const acceptable = 10000;
 
 describe("lorax-composer api sanity test", function() {
   before(function() {


### PR DESCRIPTION
On the loaded OSCI infrastructure, which uses nested VMs, the test often
takes much longer; times up to 6.5 seconds have been observed. Bump the
timeout to 10 seconds so that we don't have to fight numerous failures.