### PR TITLE
Refactor CreateImage && CreateBlueprint modal dialogs

### DIFF
--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -2,6 +2,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import Link from "../Link/Link";
+import CreateImage from "../Modal/CreateImage";
 
 class BlueprintListView extends React.PureComponent {
   constructor() {
@@ -9,7 +10,7 @@ class BlueprintListView extends React.PureComponent {
   }
 
   render() {
-    const { blueprints } = this.props; // eslint-disable-line no-use-before-define
+    const { blueprints, imageTypes, layout } = this.props;
     return (
       <div className="list-group list-view-pf list-view-pf-view">
         {blueprints.map(blueprint => (
@@ -18,13 +19,7 @@ class BlueprintListView extends React.PureComponent {
               <Link to={`/edit/${blueprint.name}`} className="btn btn-default">
                 <FormattedMessage defaultMessage="Edit Blueprint" />
               </Link>
-              <button
-                type="button"
-                className="btn btn-default"
-                onClick={e => this.props.handleShowModalCreateImage(e, blueprint)}
-              >
-                <FormattedMessage defaultMessage="Create Image" />
-              </button>
+              <CreateImage blueprint={blueprint} imageTypes={imageTypes} layout={layout} />
               <div className="dropdown pull-right dropdown-kebab-pf">
                 <button
                   className="btn btn-link dropdown-toggle"
@@ -80,14 +75,17 @@ BlueprintListView.propTypes = {
   handleShowModalDelete: PropTypes.func,
   blueprints: PropTypes.arrayOf(PropTypes.object),
   handleShowModalExport: PropTypes.func,
-  handleShowModalCreateImage: PropTypes.func
+  imageTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  layout: PropTypes.shape({
+    setNotifications: PropTypes.func
+  })
 };
 
 BlueprintListView.defaultProps = {
   handleShowModalDelete: function() {},
   blueprints: [],
   handleShowModalExport: function() {},
-  handleShowModalCreateImage: function() {}
+  layout: {}
 };
 
 export default BlueprintListView;

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -1,6 +1,7 @@
 /* global $ */
 
 import React from "react";
+import { Modal } from "patternfly-react";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -14,6 +15,52 @@ import {
 import { creatingBlueprint } from "../../core/actions/blueprints";
 
 class CreateBlueprint extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { showModal: false };
+    this.open = this.open.bind(this);
+    this.close = this.close.bind(this);
+  }
+
+  open() {
+    this.setState({ showModal: true });
+  }
+
+  close() {
+    this.setState({ showModal: false });
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <button
+          className="btn btn-default"
+          id="cmpsr-btn-crt-blueprint"
+          type="button"
+          onClick={this.open}
+          disabled={this.props.disabled}
+        >
+          <FormattedMessage defaultMessage="Create Blueprint" />
+        </button>
+        {this.state.showModal && (
+          <CreateBlueprintModal
+            blueprintNames={this.props.blueprintNames}
+            setModalCreateBlueprintErrorNameVisible={this.props.setModalCreateBlueprintErrorNameVisible}
+            setModalCreateBlueprintErrorDuplicateVisible={this.props.setModalCreateBlueprintErrorDuplicateVisible}
+            setModalCreateBlueprintErrorInline={this.props.setModalCreateBlueprintErrorInline}
+            setModalCreateBlueprintCheckErrors={this.props.setModalCreateBlueprintCheckErrors}
+            setModalCreateBlueprintBlueprint={this.props.setModalCreateBlueprintBlueprint}
+            createBlueprint={this.props.createBlueprint}
+            creatingBlueprint={this.props.creatingBlueprint}
+            close={this.close}
+          />
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+class CreateBlueprintModal extends React.Component {
   componentDidMount() {
     this.bindAutofocus();
   }
@@ -68,7 +115,7 @@ class CreateBlueprint extends React.Component {
   }
 
   handleCreateBlueprint(blueprint) {
-    $("#cmpsr-modal-crt-blueprint").modal("hide");
+    this.close();
     const updatedBlueprint = blueprint;
     updatedBlueprint.id = updatedBlueprint.name.replace(/\s/g, "-");
     this.props.creatingBlueprint(updatedBlueprint);
@@ -111,148 +158,162 @@ class CreateBlueprint extends React.Component {
   render() {
     const { createBlueprint } = this.props;
     return (
-      <div
-        className="modal fade"
-        id="cmpsr-modal-crt-blueprint"
-        tabIndex="-1"
-        role="dialog"
-        aria-labelledby="myModalLabel"
-        aria-hidden="true"
-      >
-        <div className="modal-dialog">
-          <div className="modal-content">
-            <div className="modal-header">
-              <button
-                type="button"
-                className="close"
-                data-dismiss="modal"
-                aria-hidden="true"
-                onMouseEnter={() => this.errorChecking(false)}
-                onMouseLeave={() => this.errorChecking(true)}
-                onClick={e => this.dismissErrors(e)}
-              >
-                <span className="pficon pficon-close" />
-              </button>
-              <h4 className="modal-title" id="myModalLabel">
-                <FormattedMessage defaultMessage="Create Blueprint" />
-              </h4>
+      <Modal show onHide={this.props.close} id="cmpsr-modal-crt-blueprint">
+        <Modal.Header>
+          <Modal.CloseButton
+            onClick={() => {
+              this.dismissErrors();
+              this.props.close();
+            }}
+          />
+          <Modal.Title>
+            <FormattedMessage defaultMessage="Create Blueprint" />
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {createBlueprint.errorInline && createBlueprint.errorNameVisible && (
+            <div className="alert alert-danger">
+              <span className="pficon pficon-error-circle-o" />
+              <strong>
+                <FormattedMessage defaultMessage="Required information is missing." />
+              </strong>
             </div>
-            <div className="modal-body">
-              {createBlueprint.errorInline && createBlueprint.errorNameVisible && (
-                <div className="alert alert-danger">
-                  <span className="pficon pficon-error-circle-o" />
-                  <strong>
-                    <FormattedMessage defaultMessage="Required information is missing." />
-                  </strong>
-                </div>
-              )}
-              {createBlueprint.errorInline && createBlueprint.errorDuplicateVisible && (
-                <div className="alert alert-danger">
-                  <span className="pficon pficon-error-circle-o" />
-                  <strong>
-                    <FormattedMessage defaultMessage="Specify a new blueprint name." />
-                  </strong>
-                </div>
-              )}
-              <form className="form-horizontal">
-                <p className="fields-status-pf">
-                  <FormattedMessage
-                    defaultMessage="The fields marked with {val} are required."
-                    values={{
-                      val: <span className="required-pf">*</span>
-                    }}
-                  />
-                </p>
-                <div
-                  className={`form-group ${
-                    createBlueprint.errorNameVisible || createBlueprint.errorDuplicateVisible ? "has-error" : ""
-                  }`}
-                >
-                  <label className="col-sm-3 control-label required-pf" htmlFor="textInput-modal-markup">
-                    <FormattedMessage defaultMessage="Name" />
-                  </label>
-                  <div className="col-sm-9">
-                    <input
-                      type="text"
-                      id="textInput-modal-markup"
-                      className="form-control"
-                      value={createBlueprint.blueprint.name}
-                      onFocus={e => {
-                        this.dismissErrors();
-                        this.handleErrorDuplicate(e.target.value);
+          )}
+          {createBlueprint.errorInline && createBlueprint.errorDuplicateVisible && (
+            <div className="alert alert-danger">
+              <span className="pficon pficon-error-circle-o" />
+              <strong>
+                <FormattedMessage defaultMessage="Specify a new blueprint name." />
+              </strong>
+            </div>
+          )}
+          <form className="form-horizontal">
+            <p className="fields-status-pf">
+              <FormattedMessage
+                defaultMessage="The fields marked with {val} are required."
+                values={{
+                  val: <span className="required-pf">*</span>
+                }}
+              />
+            </p>
+            <div
+              className={`form-group ${
+                createBlueprint.errorNameVisible || createBlueprint.errorDuplicateVisible ? "has-error" : ""
+              }`}
+            >
+              <label className="col-sm-3 control-label required-pf" htmlFor="textInput-modal-markup">
+                <FormattedMessage defaultMessage="Name" />
+              </label>
+              <div className="col-sm-9">
+                <input
+                  type="text"
+                  id="textInput-modal-markup"
+                  className="form-control"
+                  value={createBlueprint.blueprint.name}
+                  onFocus={e => {
+                    this.dismissErrors();
+                    this.handleErrorDuplicate(e.target.value);
+                  }}
+                  onChange={e => this.handleChange(e, "name")}
+                  onBlur={e => this.handleErrors(e.target.value)}
+                  onKeyPress={e => this.handleEnterKey(e)}
+                />
+                {createBlueprint.errorNameVisible && (
+                  <span className="help-block">
+                    <FormattedMessage defaultMessage="A blueprint name is required." />
+                  </span>
+                )}
+                {createBlueprint.errorDuplicateVisible && (
+                  <span className="help-block">
+                    <FormattedMessage
+                      defaultMessage="The name {name} already exists."
+                      values={{
+                        name: createBlueprint.blueprint.name
                       }}
-                      onChange={e => this.handleChange(e, "name")}
-                      onBlur={e => this.handleErrors(e.target.value)}
-                      onKeyPress={e => this.handleEnterKey(e)}
                     />
-                    {createBlueprint.errorNameVisible && (
-                      <span className="help-block">
-                        <FormattedMessage defaultMessage="A blueprint name is required." />
-                      </span>
-                    )}
-                    {createBlueprint.errorDuplicateVisible && (
-                      <span className="help-block">
-                        <FormattedMessage
-                          defaultMessage="The name {name} already exists."
-                          values={{
-                            name: createBlueprint.blueprint.name
-                          }}
-                        />
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="form-group">
-                  <label className="col-sm-3 control-label" htmlFor="textInput2-modal-markup">
-                    <FormattedMessage defaultMessage="Description" />
-                  </label>
-                  <div className="col-sm-9">
-                    <input
-                      type="text"
-                      id="textInput2-modal-markup"
-                      className="form-control"
-                      value={createBlueprint.blueprint.description}
-                      onChange={e => this.handleChange(e, "description")}
-                      onKeyPress={e => this.handleEnterKey(e)}
-                    />
-                  </div>
-                </div>
-              </form>
+                  </span>
+                )}
+              </div>
             </div>
-            <div className="modal-footer">
-              <button
-                type="button"
-                className="btn btn-default"
-                data-dismiss="modal"
-                onMouseEnter={() => this.errorChecking(false)}
-                onMouseLeave={() => this.errorChecking(true)}
-                onClick={e => this.dismissErrors(e)}
-              >
-                <FormattedMessage defaultMessage="Cancel" />
-              </button>
-              {((createBlueprint.blueprint.name === "" || createBlueprint.errorDuplicateVisible) && (
-                <button type="button" className="btn btn-primary" onClick={e => this.showInlineError(e)}>
-                  <FormattedMessage defaultMessage="Create" />
-                </button>
-              )) || (
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={() => this.handleCreateBlueprint(createBlueprint.blueprint)}
-                >
-                  <FormattedMessage defaultMessage="Create" />
-                </button>
-              )}
+            <div className="form-group">
+              <label className="col-sm-3 control-label" htmlFor="textInput2-modal-markup">
+                <FormattedMessage defaultMessage="Description" />
+              </label>
+              <div className="col-sm-9">
+                <input
+                  type="text"
+                  id="textInput2-modal-markup"
+                  className="form-control"
+                  value={createBlueprint.blueprint.description}
+                  onChange={e => this.handleChange(e, "description")}
+                  onKeyPress={e => this.handleEnterKey(e)}
+                />
+              </div>
             </div>
-          </div>
-        </div>
-      </div>
+          </form>
+        </Modal.Body>
+        <Modal.Footer>
+          <button
+            type="button"
+            className="btn btn-default"
+            onMouseEnter={() => this.errorChecking(false)}
+            onMouseLeave={() => this.errorChecking(true)}
+            onClick={e => {
+              this.props.close();
+              this.dismissErrors(e);
+            }}
+          >
+            <FormattedMessage defaultMessage="Cancel" />
+          </button>
+          {((createBlueprint.blueprint.name === "" || createBlueprint.errorDuplicateVisible) && (
+            <button
+              id="create-blueprint-modal-create-button"
+              type="button"
+              className="btn btn-primary"
+              onClick={e => this.showInlineError(e)}
+            >
+              <FormattedMessage defaultMessage="Create" />
+            </button>
+          )) || (
+            <button
+              id="create-blueprint-modal-create-button"
+              type="button"
+              className="btn btn-primary"
+              onClick={() => this.handleCreateBlueprint(createBlueprint.blueprint)}
+            >
+              <FormattedMessage defaultMessage="Create" />
+            </button>
+          )}
+        </Modal.Footer>
+      </Modal>
     );
   }
 }
 
+CreateBlueprintModal.propTypes = {
+  close: PropTypes.func.isRequired,
+  blueprintNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setModalCreateBlueprintErrorNameVisible: PropTypes.func.isRequired,
+  setModalCreateBlueprintErrorDuplicateVisible: PropTypes.func.isRequired,
+  setModalCreateBlueprintErrorInline: PropTypes.func.isRequired,
+  setModalCreateBlueprintCheckErrors: PropTypes.func.isRequired,
+  setModalCreateBlueprintBlueprint: PropTypes.func.isRequired,
+  createBlueprint: PropTypes.shape({
+    blueprint: PropTypes.object,
+    checkErrors: PropTypes.bool,
+    errorDuplicateVisible: PropTypes.bool,
+    errorInline: PropTypes.bool,
+    errorNameVisible: PropTypes.bool,
+    inlineError: PropTypes.bool,
+    showErrorDuplicate: PropTypes.bool,
+    showErrorName: PropTypes.bool
+  }).isRequired,
+  creatingBlueprint: PropTypes.func.isRequired
+};
+
 CreateBlueprint.propTypes = {
   blueprintNames: PropTypes.arrayOf(PropTypes.string),
+  disabled: PropTypes.bool,
   setModalCreateBlueprintErrorNameVisible: PropTypes.func,
   setModalCreateBlueprintErrorDuplicateVisible: PropTypes.func,
   setModalCreateBlueprintErrorInline: PropTypes.func,
@@ -273,6 +334,7 @@ CreateBlueprint.propTypes = {
 
 CreateBlueprint.defaultProps = {
   blueprintNames: [],
+  disabled: false,
   setModalCreateBlueprintErrorNameVisible: function() {},
   setModalCreateBlueprintErrorDuplicateVisible: function() {},
   setModalCreateBlueprintErrorInline: function() {},

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -3,7 +3,7 @@ import { Modal } from "patternfly-react";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { setModalCreateBlueprintErrorInline, setModalCreateBlueprintBlueprint } from "../../core/actions/modals";
+import { setModalCreateBlueprintBlueprint } from "../../core/actions/modals";
 import { creatingBlueprint } from "../../core/actions/blueprints";
 
 class CreateBlueprint extends React.Component {
@@ -39,7 +39,6 @@ class CreateBlueprint extends React.Component {
         {this.state.showModal && (
           <CreateBlueprintModal
             blueprintNames={this.props.blueprintNames}
-            setModalCreateBlueprintErrorInline={this.props.setModalCreateBlueprintErrorInline}
             setModalCreateBlueprintBlueprint={this.props.setModalCreateBlueprintBlueprint}
             createBlueprint={this.props.createBlueprint}
             creatingBlueprint={this.props.creatingBlueprint}
@@ -57,7 +56,8 @@ class CreateBlueprintModal extends React.Component {
     this.state = {
       errorNameEmpty: false,
       errorNameDuplicate: false,
-      checkErrors: true
+      checkErrors: true,
+      errorInline: false
     };
   }
 
@@ -86,7 +86,7 @@ class CreateBlueprintModal extends React.Component {
       this.handleErrors(this.props.createBlueprint.blueprint.name);
       setTimeout(() => {
         if (this.state.errorNameEmpty || this.state.errorNameDuplicate) {
-          this.showInlineError();
+          this.setState({ errorInline: true });
         } else {
           this.handleCreateBlueprint(this.props.createBlueprint.blueprint);
         }
@@ -102,8 +102,7 @@ class CreateBlueprintModal extends React.Component {
   }
 
   dismissErrors() {
-    this.setState({ errorNameEmpty: false, errorNameDuplicate: false });
-    this.props.setModalCreateBlueprintErrorInline(false);
+    this.setState({ errorNameEmpty: false, errorNameDuplicate: false, errorInline: false });
   }
 
   handleErrors(blueprintName) {
@@ -126,27 +125,18 @@ class CreateBlueprintModal extends React.Component {
     }
   }
 
-  showInlineError() {
-    this.props.setModalCreateBlueprintErrorInline(true);
-  }
-
   render() {
     const { createBlueprint } = this.props;
     return (
       <Modal show onHide={this.props.close} id="cmpsr-modal-crt-blueprint">
         <Modal.Header>
-          <Modal.CloseButton
-            onClick={() => {
-              this.dismissErrors();
-              this.close();
-            }}
-          />
+          <Modal.CloseButton onClick={this.props.close} />
           <Modal.Title>
             <FormattedMessage defaultMessage="Create Blueprint" />
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {createBlueprint.errorInline && this.state.errorNameEmpty && (
+          {this.state.errorInline && this.state.errorNameEmpty && (
             <div className="alert alert-danger">
               <span className="pficon pficon-error-circle-o" />
               <strong>
@@ -154,7 +144,7 @@ class CreateBlueprintModal extends React.Component {
               </strong>
             </div>
           )}
-          {createBlueprint.errorInline && this.state.errorNameDuplicate && (
+          {this.state.errorInline && this.state.errorNameDuplicate && (
             <div className="alert alert-danger">
               <span className="pficon pficon-error-circle-o" />
               <strong>
@@ -232,10 +222,7 @@ class CreateBlueprintModal extends React.Component {
             className="btn btn-default"
             onMouseEnter={() => this.setState({ checkErrors: false })}
             onMouseLeave={() => this.setState({ checkErrors: true })}
-            onClick={e => {
-              this.props.close();
-              this.dismissErrors(e);
-            }}
+            onClick={this.props.close}
           >
             <FormattedMessage defaultMessage="Cancel" />
           </button>
@@ -244,7 +231,7 @@ class CreateBlueprintModal extends React.Component {
               id="create-blueprint-modal-create-button"
               type="button"
               className="btn btn-primary"
-              onClick={e => this.showInlineError(e)}
+              onClick={() => this.setState({ errorInline: true })}
             >
               <FormattedMessage defaultMessage="Create" />
             </button>
@@ -267,12 +254,9 @@ class CreateBlueprintModal extends React.Component {
 CreateBlueprintModal.propTypes = {
   close: PropTypes.func.isRequired,
   blueprintNames: PropTypes.arrayOf(PropTypes.string).isRequired,
-  setModalCreateBlueprintErrorInline: PropTypes.func.isRequired,
   setModalCreateBlueprintBlueprint: PropTypes.func.isRequired,
   createBlueprint: PropTypes.shape({
-    blueprint: PropTypes.object,
-    errorInline: PropTypes.bool,
-    inlineError: PropTypes.bool
+    blueprint: PropTypes.object
   }).isRequired,
   creatingBlueprint: PropTypes.func.isRequired
 };
@@ -280,12 +264,9 @@ CreateBlueprintModal.propTypes = {
 CreateBlueprint.propTypes = {
   blueprintNames: PropTypes.arrayOf(PropTypes.string),
   disabled: PropTypes.bool,
-  setModalCreateBlueprintErrorInline: PropTypes.func,
   setModalCreateBlueprintBlueprint: PropTypes.func,
   createBlueprint: PropTypes.shape({
-    blueprint: PropTypes.object,
-    errorInline: PropTypes.bool,
-    inlineError: PropTypes.bool
+    blueprint: PropTypes.object
   }),
   creatingBlueprint: PropTypes.func
 };
@@ -293,7 +274,6 @@ CreateBlueprint.propTypes = {
 CreateBlueprint.defaultProps = {
   blueprintNames: [],
   disabled: false,
-  setModalCreateBlueprintErrorInline: function() {},
   setModalCreateBlueprintBlueprint: function() {},
   createBlueprint: {},
   creatingBlueprint: function() {}
@@ -304,9 +284,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  setModalCreateBlueprintErrorInline: inlineError => {
-    dispatch(setModalCreateBlueprintErrorInline(inlineError));
-  },
   setModalCreateBlueprintBlueprint: blueprint => {
     dispatch(setModalCreateBlueprintBlueprint(blueprint));
   },

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -226,25 +226,15 @@ class CreateBlueprintModal extends React.Component {
           >
             <FormattedMessage defaultMessage="Cancel" />
           </button>
-          {((this.state.name === "" || this.state.errorNameDuplicate) && (
-            <button
-              id="create-blueprint-modal-create-button"
-              type="button"
-              className="btn btn-primary"
-              onClick={() => this.setState({ errorInline: true })}
-            >
-              <FormattedMessage defaultMessage="Create" />
-            </button>
-          )) || (
-            <button
-              id="create-blueprint-modal-create-button"
-              type="button"
-              className="btn btn-primary"
-              onClick={() => this.handleCreateBlueprint()}
-            >
-              <FormattedMessage defaultMessage="Create" />
-            </button>
-          )}
+          <button
+            id="create-blueprint-modal-create-button"
+            type="button"
+            className="btn btn-primary"
+            disabled={this.state.name == "" || this.state.errorNameDuplicate}
+            onClick={() => this.handleCreateBlueprint()}
+          >
+            <FormattedMessage defaultMessage="Create" />
+          </button>
         </Modal.Footer>
       </Modal>
     );

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -72,7 +72,6 @@ class CreateBlueprintModal extends React.Component {
   }
 
   componentDidUpdate() {
-    this.unbind();
     this.bindAutofocus();
   }
 
@@ -84,17 +83,12 @@ class CreateBlueprintModal extends React.Component {
       packages: []
     };
     this.props.setModalCreateBlueprintBlueprint(initialBlueprint);
-    this.unbind();
   }
 
   bindAutofocus() {
     $("#cmpsr-modal-crt-blueprint").on("shown.bs.modal", () => {
       $("#textInput-modal-markup").focus();
     });
-  }
-
-  unbind() {
-    $("#cmpsr-modal-crt-image .btn-primary").off("shown.bs.modal");
   }
 
   handleChange(e, prop) {

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -1,5 +1,3 @@
-/* global $ */
-
 import React from "react";
 import { Modal } from "patternfly-react";
 import { FormattedMessage } from "react-intl";
@@ -67,14 +65,6 @@ class CreateBlueprintModal extends React.Component {
     };
   }
 
-  componentDidMount() {
-    this.bindAutofocus();
-  }
-
-  componentDidUpdate() {
-    this.bindAutofocus();
-  }
-
   componentWillUnmount() {
     const initialBlueprint = {
       name: "",
@@ -83,12 +73,6 @@ class CreateBlueprintModal extends React.Component {
       packages: []
     };
     this.props.setModalCreateBlueprintBlueprint(initialBlueprint);
-  }
-
-  bindAutofocus() {
-    $("#cmpsr-modal-crt-blueprint").on("shown.bs.modal", () => {
-      $("#textInput-modal-markup").focus();
-    });
   }
 
   handleChange(e, prop) {
@@ -203,6 +187,7 @@ class CreateBlueprintModal extends React.Component {
               </label>
               <div className="col-sm-9">
                 <input
+                  autoFocus
                   type="text"
                   id="textInput-modal-markup"
                   className="form-control"

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -3,11 +3,7 @@ import { Modal } from "patternfly-react";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import {
-  setModalCreateBlueprintErrorInline,
-  setModalCreateBlueprintCheckErrors,
-  setModalCreateBlueprintBlueprint
-} from "../../core/actions/modals";
+import { setModalCreateBlueprintErrorInline, setModalCreateBlueprintBlueprint } from "../../core/actions/modals";
 import { creatingBlueprint } from "../../core/actions/blueprints";
 
 class CreateBlueprint extends React.Component {
@@ -44,7 +40,6 @@ class CreateBlueprint extends React.Component {
           <CreateBlueprintModal
             blueprintNames={this.props.blueprintNames}
             setModalCreateBlueprintErrorInline={this.props.setModalCreateBlueprintErrorInline}
-            setModalCreateBlueprintCheckErrors={this.props.setModalCreateBlueprintCheckErrors}
             setModalCreateBlueprintBlueprint={this.props.setModalCreateBlueprintBlueprint}
             createBlueprint={this.props.createBlueprint}
             creatingBlueprint={this.props.creatingBlueprint}
@@ -61,7 +56,8 @@ class CreateBlueprintModal extends React.Component {
     super(props);
     this.state = {
       errorNameEmpty: false,
-      errorNameDuplicate: false
+      errorNameDuplicate: false,
+      checkErrors: true
     };
   }
 
@@ -99,14 +95,10 @@ class CreateBlueprintModal extends React.Component {
   }
 
   handleCreateBlueprint(blueprint) {
-    this.close();
+    this.props.close();
     const updatedBlueprint = blueprint;
     updatedBlueprint.id = updatedBlueprint.name.replace(/\s/g, "-");
     this.props.creatingBlueprint(updatedBlueprint);
-  }
-
-  errorChecking(state) {
-    this.props.setModalCreateBlueprintCheckErrors(state);
   }
 
   dismissErrors() {
@@ -127,7 +119,7 @@ class CreateBlueprintModal extends React.Component {
   }
 
   handleErrorName(blueprintName) {
-    if (blueprintName === "" && this.props.createBlueprint.checkErrors) {
+    if (blueprintName === "" && this.state.checkErrors) {
       setTimeout(() => {
         this.setState({ errorNameEmpty: true });
       }, 200);
@@ -146,7 +138,7 @@ class CreateBlueprintModal extends React.Component {
           <Modal.CloseButton
             onClick={() => {
               this.dismissErrors();
-              this.props.close();
+              this.close();
             }}
           />
           <Modal.Title>
@@ -238,8 +230,8 @@ class CreateBlueprintModal extends React.Component {
           <button
             type="button"
             className="btn btn-default"
-            onMouseEnter={() => this.errorChecking(false)}
-            onMouseLeave={() => this.errorChecking(true)}
+            onMouseEnter={() => this.setState({ checkErrors: false })}
+            onMouseLeave={() => this.setState({ checkErrors: true })}
             onClick={e => {
               this.props.close();
               this.dismissErrors(e);
@@ -276,11 +268,9 @@ CreateBlueprintModal.propTypes = {
   close: PropTypes.func.isRequired,
   blueprintNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   setModalCreateBlueprintErrorInline: PropTypes.func.isRequired,
-  setModalCreateBlueprintCheckErrors: PropTypes.func.isRequired,
   setModalCreateBlueprintBlueprint: PropTypes.func.isRequired,
   createBlueprint: PropTypes.shape({
     blueprint: PropTypes.object,
-    checkErrors: PropTypes.bool,
     errorInline: PropTypes.bool,
     inlineError: PropTypes.bool
   }).isRequired,
@@ -291,11 +281,9 @@ CreateBlueprint.propTypes = {
   blueprintNames: PropTypes.arrayOf(PropTypes.string),
   disabled: PropTypes.bool,
   setModalCreateBlueprintErrorInline: PropTypes.func,
-  setModalCreateBlueprintCheckErrors: PropTypes.func,
   setModalCreateBlueprintBlueprint: PropTypes.func,
   createBlueprint: PropTypes.shape({
     blueprint: PropTypes.object,
-    checkErrors: PropTypes.bool,
     errorInline: PropTypes.bool,
     inlineError: PropTypes.bool
   }),
@@ -306,7 +294,6 @@ CreateBlueprint.defaultProps = {
   blueprintNames: [],
   disabled: false,
   setModalCreateBlueprintErrorInline: function() {},
-  setModalCreateBlueprintCheckErrors: function() {},
   setModalCreateBlueprintBlueprint: function() {},
   createBlueprint: {},
   creatingBlueprint: function() {}
@@ -319,9 +306,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   setModalCreateBlueprintErrorInline: inlineError => {
     dispatch(setModalCreateBlueprintErrorInline(inlineError));
-  },
-  setModalCreateBlueprintCheckErrors: checkErrors => {
-    dispatch(setModalCreateBlueprintCheckErrors(checkErrors));
   },
   setModalCreateBlueprintBlueprint: blueprint => {
     dispatch(setModalCreateBlueprintBlueprint(blueprint));

--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -1,14 +1,12 @@
-/* global $ */
-
 import React from "react";
 import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
 import PropTypes from "prop-types";
-import { Button, OverlayTrigger, Popover, Icon, Alert } from "patternfly-react";
+import { Button, OverlayTrigger, Popover, Icon, Alert, Modal } from "patternfly-react";
 import { connect } from "react-redux";
 import NotificationsApi from "../../data/NotificationsApi";
 import BlueprintApi from "../../data/BlueprintApi";
 import { setBlueprint } from "../../core/actions/blueprints";
-import { fetchingQueue, clearQueue } from "../../core/actions/composes";
+import { fetchingQueue, clearQueue, startCompose } from "../../core/actions/composes";
 
 const messages = defineMessages({
   infotip: {
@@ -24,13 +22,15 @@ const messages = defineMessages({
   }
 });
 
-class CreateImage extends React.Component {
+class CreateImageModal extends React.Component {
   constructor() {
     super();
     this.state = { imageType: "" };
     this.handleCreateImage = this.handleCreateImage.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.handleCommit = this.handleCommit.bind(this);
+    this.handleStartCompose = this.handleStartCompose.bind(this);
+    this.setNotifications = this.setNotifications.bind(this);
   }
 
   componentWillMount() {
@@ -39,20 +39,23 @@ class CreateImage extends React.Component {
     }
   }
 
-  componentDidMount() {
-    $(this.modal).modal("show");
-    if (this.props.handleHideModal) $(this.modal).on("hidden.bs.modal", this.props.handleHideModal);
-  }
-
   componentWillUnmount() {
     this.props.clearQueue();
   }
 
+  setNotifications() {
+    this.props.layout.setNotifications();
+  }
+
+  handleStartCompose(blueprintName, composeType) {
+    this.props.startCompose(blueprintName, composeType);
+  }
+
   handleCreateImage() {
     NotificationsApi.displayNotification(this.props.blueprint.name, "imageWaiting");
-    if (this.props.setNotifications) this.props.setNotifications();
-    if (this.props.handleStartCompose) this.props.handleStartCompose(this.props.blueprint.name, this.state.imageType);
-    $("#cmpsr-modal-crt-image").modal("hide");
+    if (this.setNotifications) this.setNotifications();
+    if (this.handleStartCompose) this.handleStartCompose(this.props.blueprint.name, this.state.imageType);
+    this.props.close();
   }
 
   handleChange(event) {
@@ -65,7 +68,7 @@ class CreateImage extends React.Component {
     NotificationsApi.closeNotification(undefined, "committing");
     // display the committing notification
     NotificationsApi.displayNotification(this.props.blueprint.name, "committing");
-    this.props.setNotifications();
+    this.setNotifications();
     // post blueprint (includes 'committed' notification)
     Promise.all([BlueprintApi.handleCommitBlueprint(this.props.blueprint)])
       .then(() => {
@@ -89,130 +92,196 @@ class CreateImage extends React.Component {
     const { formatMessage } = this.props.intl;
     const running = this.props.composeQueue.filter(compose => compose.queue_status === "RUNNING").length;
     const waiting = this.props.composeQueue.filter(compose => compose.queue_status === "WAITING").length;
+    const modalBody = (
+      <React.Fragment>
+        <form className="form-horizontal">
+          <div className="form-group">
+            <label className="col-sm-3 control-label" htmlFor="blueprint-name">
+              <FormattedMessage defaultMessage="Blueprint" />
+            </label>
+            <div className="col-sm-9">
+              <p className="form-control-static" id="blueprint-name">
+                {this.props.blueprint.name}
+              </p>
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="col-sm-3 control-label required-pf" htmlFor="textInput-modal-markup">
+              <FormattedMessage defaultMessage="Image Type" />
+            </label>
+            <div className="col-sm-9">
+              <select
+                id="textInput-modal-markup"
+                className="form-control"
+                required
+                value={this.state.imageType}
+                onChange={this.handleChange}
+              >
+                <option value="" disabled hidden>
+                  {formatMessage(messages.selectOne)}
+                </option>
+                {this.props.imageTypes !== undefined &&
+                  this.props.imageTypes.map(type => (
+                    <option key={type.name} value={type.name} disabled={!type.enabled}>
+                      {type.label}
+                    </option>
+                  ))}
+              </select>
+            </div>
+          </div>
+        </form>
+      </React.Fragment>
+    );
+
+    const warningEmpty = this.props.blueprint.packages.length === 0 && this.props.blueprint.modules.length === 0;
+    const warningUnsaved = this.props.blueprint.changed === true || this.props.blueprint.localPendingChanges.length > 0;
+    const warnings = (
+      <React.Fragment>
+        {warningEmpty && (
+          <Alert type="warning">
+            <FormattedMessage defaultMessage="This blueprint is empty." />
+          </Alert>
+        )}
+        {warningUnsaved && <Alert type="warning">{formatMessage(messages.warningUnsaved)}</Alert>}
+      </React.Fragment>
+    );
+
     // const running = 1;
     // const waiting = 2;
     return (
-      <div
-        className="modal fade"
-        id="cmpsr-modal-crt-image"
-        ref={c => {
-          this.modal = c;
-        }}
-        tabIndex="-1"
-        role="dialog"
-        aria-labelledby="myModalLabel"
-        aria-hidden="true"
-      >
-        <div className="modal-dialog">
-          <div className="modal-content">
-            <div className="modal-header">
-              <button type="button" className="close" data-dismiss="modal" aria-hidden="true">
-                <span className="pficon pficon-close" />
-              </button>
-              <h4 className="modal-title" id="myModalLabel">
-                <FormattedMessage defaultMessage="Create Image" />
-              </h4>
-            </div>
-            <div className="modal-body">
-              {this.props.warningEmpty === true && (
-                <Alert type="warning">
-                  <FormattedMessage defaultMessage="This blueprint is empty." />
-                </Alert>
-              )}
-              {this.props.warningUnsaved === true && (
-                <Alert type="warning">{formatMessage(messages.warningUnsaved)}</Alert>
-              )}
-              <form className="form-horizontal">
-                <div className="form-group">
-                  <label className="col-sm-3 control-label" htmlFor="blueprint-name">
-                    <FormattedMessage defaultMessage="Blueprint" />
-                  </label>
-                  <div className="col-sm-9">
-                    <p className="form-control-static" id="blueprint-name">
-                      {this.props.blueprint.name}
-                    </p>
-                  </div>
-                </div>
-                <div className="form-group">
-                  <label className="col-sm-3 control-label required-pf" htmlFor="textInput-modal-markup">
-                    <FormattedMessage defaultMessage="Image Type" />
-                  </label>
-                  <div className="col-sm-9">
-                    <select
-                      id="textInput-modal-markup"
-                      className="form-control"
-                      required
-                      value={this.state.imageType}
-                      onChange={this.handleChange}
-                    >
-                      <option value="" disabled hidden>
-                        {formatMessage(messages.selectOne)}
-                      </option>
-                      {this.props.imageTypes !== undefined &&
-                        this.props.imageTypes.map(type => (
-                          <option key={type.name} value={type.name} disabled={!type.enabled}>
-                            {type.label}
-                          </option>
-                        ))}
-                    </select>
-                  </div>
-                </div>
-              </form>
-            </div>
-            <div className="modal-footer">
-              <div className="pull-left">
-                <OverlayTrigger
-                  overlay={
-                    <Popover id="CreateImageInfotip">
-                      <p>{formatMessage(messages.infotip)}</p>
-                      {running >= 1 && <FormattedMessage defaultMessage="1 build is in progress" tagName="p" />}
-                      {waiting >= 1 && (
-                        <FormattedMessage
-                          defaultMessage="{builds, plural,
+      <Modal show onHide={this.props.close} id="cmpsr-modal-crt-image">
+        <Modal.Header>
+          <Modal.CloseButton onClick={this.props.close} />
+          <Modal.Title>
+            {" "}
+            <FormattedMessage defaultMessage="Create Image" />{" "}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {warnings}
+          {modalBody}
+        </Modal.Body>
+        <Modal.Footer>
+          <div className="pull-left">
+            <OverlayTrigger
+              overlay={
+                <Popover id="CreateImageInfotip">
+                  <p>{formatMessage(messages.infotip)}</p>
+                  {running >= 1 && <FormattedMessage defaultMessage="1 build is in progress" tagName="p" />}
+                  {waiting >= 1 && (
+                    <FormattedMessage
+                      defaultMessage="{builds, plural,
                             one   {# build is waiting}
                             other {# builds are waiting}
                           }"
-                          tagName="p"
-                          values={{
-                            builds: waiting
-                          }}
-                        />
-                      )}
-                    </Popover>
-                  }
-                  placement="right"
-                  trigger={["click"]}
-                  rootClose
-                >
-                  <Button bsStyle="link">
-                    <Icon type="pf" name="pficon pficon-help" />
-                  </Button>
-                </OverlayTrigger>
-              </div>
-              <button type="button" className="btn btn-default" data-dismiss="modal">
-                <FormattedMessage defaultMessage="Cancel" />
-              </button>
-              {(this.props.warningUnsaved === true && this.state.imageType !== "" && (
-                <button type="button" className="btn btn-primary" onClick={this.handleCommit}>
-                  <FormattedMessage defaultMessage="Commit and Create" />
-                </button>
-              )) ||
-                (this.state.imageType !== "" && (
-                  <button type="button" className="btn btn-primary" onClick={this.handleCreateImage}>
-                    <FormattedMessage defaultMessage="Create" />
-                  </button>
-                ))}
-              {this.state.imageType === "" && (
-                <button type="button" className="btn btn-primary" disabled>
-                  {(this.props.warningUnsaved === true && <FormattedMessage defaultMessage="Commit and Create" />) || (
-                    <FormattedMessage defaultMessage="Create" />
+                      tagName="p"
+                      values={{
+                        builds: waiting
+                      }}
+                    />
                   )}
-                </button>
-              )}
-            </div>
+                </Popover>
+              }
+              placement="right"
+              trigger={["click"]}
+              rootClose
+            >
+              <Button bsStyle="link">
+                <Icon type="pf" name="pficon pficon-help" />
+              </Button>
+            </OverlayTrigger>
           </div>
-        </div>
-      </div>
+          <button type="button" className="btn btn-default" onClick={this.props.close}>
+            <FormattedMessage defaultMessage="Cancel" />
+          </button>
+          {(warningUnsaved && this.state.imageType !== "" && (
+            <button type="button" className="btn btn-primary" onClick={this.handleCommit}>
+              <FormattedMessage defaultMessage="Commit and Create" />
+            </button>
+          )) ||
+            (this.state.imageType !== "" && (
+              <button type="button" className="btn btn-primary" onClick={this.handleCreateImage}>
+                <FormattedMessage defaultMessage="Create" />
+              </button>
+            ))}
+          {this.state.imageType === "" && (
+            <button type="button" className="btn btn-primary" disabled>
+              {(warningUnsaved && <FormattedMessage defaultMessage="Commit and Create" />) || (
+                <FormattedMessage defaultMessage="Create" />
+              )}
+            </button>
+          )}
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+CreateImageModal.propTypes = {
+  blueprint: PropTypes.shape({
+    changed: PropTypes.bool,
+    description: PropTypes.string,
+    groups: PropTypes.array,
+    id: PropTypes.string,
+    localPendingChanges: PropTypes.array,
+    modules: PropTypes.array,
+    name: PropTypes.string,
+    packages: PropTypes.arrayOf(PropTypes.object),
+    version: PropTypes.string,
+    workspacePendingChanges: PropTypes.arrayOf(PropTypes.object)
+  }).isRequired,
+  composeQueue: PropTypes.arrayOf(PropTypes.object).isRequired,
+  composeQueueFetched: PropTypes.bool.isRequired,
+  fetchingQueue: PropTypes.func.isRequired,
+  clearQueue: PropTypes.func.isRequired,
+  imageTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setBlueprint: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
+  startCompose: PropTypes.func.isRequired,
+  layout: PropTypes.shape({
+    setNotifications: PropTypes.func
+  }).isRequired,
+  close: PropTypes.func.isRequired
+};
+
+class CreateImage extends React.Component {
+  constructor() {
+    super();
+    this.state = { showModal: false };
+    this.open = this.open.bind(this);
+    this.close = this.close.bind(this);
+  }
+
+  open() {
+    this.setState({ showModal: true });
+  }
+
+  close() {
+    this.setState({ showModal: false });
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <button className="btn btn-default" id="cmpsr-btn-crt-image" type="button" onClick={this.open}>
+          <FormattedMessage defaultMessage="Create Image" />
+        </button>
+        {this.state.showModal && (
+          <CreateImageModal
+            blueprint={this.props.blueprint}
+            composeQueue={this.props.composeQueue}
+            composeQueueFetched={this.props.composeQueueFetched}
+            fetchingQueue={this.props.fetchingQueue}
+            clearQueue={this.props.clearQueue}
+            imageTypes={this.props.imageTypes}
+            setBlueprint={this.props.setBlueprint}
+            intl={this.props.intl}
+            startCompose={this.props.startCompose}
+            layout={this.props.layout}
+            close={this.close}
+          />
+        )}
+      </React.Fragment>
     );
   }
 }
@@ -232,31 +301,27 @@ CreateImage.propTypes = {
   }),
   composeQueue: PropTypes.arrayOf(PropTypes.object),
   composeQueueFetched: PropTypes.bool,
-  handleStartCompose: PropTypes.func,
   fetchingQueue: PropTypes.func,
   clearQueue: PropTypes.func,
-  handleHideModal: PropTypes.func,
-  setNotifications: PropTypes.func,
   imageTypes: PropTypes.arrayOf(PropTypes.object),
-  warningEmpty: PropTypes.bool,
-  warningUnsaved: PropTypes.bool,
   setBlueprint: PropTypes.func,
-  intl: intlShape.isRequired
+  intl: intlShape.isRequired,
+  startCompose: PropTypes.func,
+  layout: PropTypes.shape({
+    setNotifications: PropTypes.func
+  })
 };
 
 CreateImage.defaultProps = {
   blueprint: {},
   composeQueue: [],
   composeQueueFetched: true,
-  handleStartCompose: function() {},
   fetchingQueue: function() {},
   clearQueue: function() {},
-  handleHideModal: function() {},
-  setNotifications: function() {},
   imageTypes: [],
-  warningEmpty: false,
-  warningUnsaved: false,
-  setBlueprint: function() {}
+  setBlueprint: function() {},
+  startCompose: function() {},
+  layout: {}
 };
 
 const mapStateToProps = state => ({
@@ -273,6 +338,9 @@ const mapDispatchToProps = dispatch => ({
   },
   clearQueue: () => {
     dispatch(clearQueue());
+  },
+  startCompose: (blueprintName, composeType) => {
+    dispatch(startCompose(blueprintName, composeType));
   }
 });
 

--- a/components/Toolbar/BlueprintsToolbar.js
+++ b/components/Toolbar/BlueprintsToolbar.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import FilterInput from "./FilterInput";
 import ToolbarLayout from "./ToolbarLayout";
+import CreateBlueprint from "../Modal/CreateBlueprint";
 
 const BlueprintsToolbar = props => (
   <ToolbarLayout
@@ -35,15 +36,7 @@ const BlueprintsToolbar = props => (
     </div>
     <div className="toolbar-pf-action-right">
       <div className="form-group">
-        <button
-          className="btn btn-default"
-          type="button"
-          data-toggle="modal"
-          data-target="#cmpsr-modal-crt-blueprint"
-          disabled={props.errorState}
-        >
-          <FormattedMessage defaultMessage="Create Blueprint" />
-        </button>
+        <CreateBlueprint blueprintNames={props.blueprintNames} disabled={props.errorState} />
         <div className="dropdown btn-group dropdown-kebab-pf">
           <button
             className="btn btn-link dropdown-toggle"
@@ -72,6 +65,7 @@ const BlueprintsToolbar = props => (
 );
 
 BlueprintsToolbar.propTypes = {
+  blueprintNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   filters: PropTypes.shape({
     defaultFilterType: PropTypes.string,
     filterTypes: PropTypes.arrayOf(PropTypes.object),

--- a/core/actions/composes.js
+++ b/core/actions/composes.js
@@ -42,6 +42,14 @@ export const fetchingComposeStatusSucceeded = compose => ({
   }
 });
 
+export const FETCHING_COMPOSE_TYPES_SUCCEEDED = "FETCHING_COMPOSE_TYPES_SUCCEEDED";
+export const fetchingComposeTypesSucceeded = composeTypes => ({
+  type: FETCHING_COMPOSE_TYPES_SUCCEEDED,
+  payload: {
+    composeTypes
+  }
+});
+
 export const FETCHING_QUEUE_SUCCEEDED = "FETCHING_QUEUE_SUCCEEDED";
 export const fetchingQueueSucceeded = queue => ({
   type: FETCHING_QUEUE_SUCCEEDED,

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -58,16 +58,6 @@ export function setModalCreateBlueprintBlueprint(blueprint) {
   };
 }
 
-export const FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS = "FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS";
-export function fetchingModalCreateImageTypesSuccess(imageTypes) {
-  return {
-    type: FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS,
-    payload: {
-      imageTypes
-    }
-  };
-}
-
 export const SET_MODAL_EXPORT_BLUEPRINT_NAME = "SET_MODAL_EXPORT_BLUEPRINT_NAME";
 export function setModalExportBlueprintName(blueprintName) {
   return {
@@ -135,23 +125,6 @@ export function setModalDeleteBlueprintVisible(visible) {
     payload: {
       visible
     }
-  };
-}
-
-export const SET_MODAL_CREATE_IMAGE_VISIBLE = "SET_MODAL_CREATE_IMAGE_VISIBLE";
-export function setModalCreateImageVisible(blueprint) {
-  return {
-    type: SET_MODAL_CREATE_IMAGE_VISIBLE,
-    payload: {
-      blueprint
-    }
-  };
-}
-
-export const SET_MODAL_CREATE_IMAGE_HIDDEN = "SET_MODAL_CREATE_IMAGE_HIDDEN";
-export function setModalCreateImageHidden() {
-  return {
-    type: SET_MODAL_CREATE_IMAGE_HIDDEN
   };
 }
 

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -18,16 +18,6 @@ export function setModalCreateBlueprintErrorInline(errorInline) {
   };
 }
 
-export const SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS = "SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS";
-export function setModalCreateBlueprintCheckErrors(checkErrors) {
-  return {
-    type: SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS,
-    payload: {
-      checkErrors
-    }
-  };
-}
-
 export const SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT = "SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT";
 export function setModalCreateBlueprintBlueprint(blueprint) {
   return {

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -8,16 +8,6 @@ export function setModalActive(modalActive) {
   };
 }
 
-export const SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE = "SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE";
-export function setModalCreateBlueprintErrorInline(errorInline) {
-  return {
-    type: SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE,
-    payload: {
-      errorInline
-    }
-  };
-}
-
 export const SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT = "SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT";
 export function setModalCreateBlueprintBlueprint(blueprint) {
   return {

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -8,26 +8,6 @@ export function setModalActive(modalActive) {
   };
 }
 
-export const SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE = "SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE";
-export function setModalCreateBlueprintErrorNameVisible(errorNameVisible) {
-  return {
-    type: SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE,
-    payload: {
-      errorNameVisible
-    }
-  };
-}
-
-export const SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE = "SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE";
-export function setModalCreateBlueprintErrorDuplicateVisible(errorDuplicateVisible) {
-  return {
-    type: SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE,
-    payload: {
-      errorDuplicateVisible
-    }
-  };
-}
-
 export const SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE = "SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE";
 export function setModalCreateBlueprintErrorInline(errorInline) {
   return {

--- a/core/apiCalls.js
+++ b/core/apiCalls.js
@@ -69,7 +69,7 @@ export function fetchBlueprintInfoApi(blueprintName) {
   return blueprintFetch;
 }
 
-export function fetchModalCreateImageTypesApi() {
+export function fetchComposeTypesApi() {
   const imageTypeLabels = {
     ami: "Amazon Machine Image Disk (.ami)",
     "ext4-filesystem": "Ext4 File System Image (.img)",

--- a/core/reducers/composes.js
+++ b/core/reducers/composes.js
@@ -19,7 +19,6 @@ function removeCompose(array, composeId) {
 const compose = (state = [], action) => {
   switch (action.type) {
     case FETCHING_COMPOSE_TYPES_SUCCEEDED:
-      console.info("reducers");
       return Object.assign({}, state, {
         composeTypes: action.payload.composeTypes
       });

--- a/core/reducers/composes.js
+++ b/core/reducers/composes.js
@@ -1,4 +1,5 @@
 import {
+  FETCHING_COMPOSE_TYPES_SUCCEEDED,
   FETCHING_COMPOSE_SUCCEEDED,
   FETCHING_COMPOSE_STATUS_SUCCEEDED,
   COMPOSES_FAILURE,
@@ -17,6 +18,11 @@ function removeCompose(array, composeId) {
 
 const compose = (state = [], action) => {
   switch (action.type) {
+    case FETCHING_COMPOSE_TYPES_SUCCEEDED:
+      console.info("reducers");
+      return Object.assign({}, state, {
+        composeTypes: action.payload.composeTypes
+      });
     case FETCHING_COMPOSE_STATUS_SUCCEEDED:
       // Check composes for one that matches the id then replace it with its up-to-date version
       return Object.assign({}, state, {

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -6,7 +6,6 @@ import {
   SET_MODAL_DELETE_BLUEPRINT_NAME,
   SET_MODAL_DELETE_BLUEPRINT_ID,
   SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
-  SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE,
   SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT,
   SET_MODAL_DELETE_IMAGE_VISIBLE,
   SET_MODAL_DELETE_IMAGE_STATE,
@@ -21,10 +20,6 @@ import {
 
 const modalCreateBlueprint = (state = [], action) => {
   switch (action.type) {
-    case SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE:
-      return Object.assign({}, state, {
-        createBlueprint: Object.assign({}, state.createBlueprint, { errorInline: action.payload.errorInline })
-      });
     case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
       return Object.assign({}, state, {
         createBlueprint: Object.assign({}, state.createBlueprint, { blueprint: action.payload.blueprint })
@@ -149,8 +144,6 @@ const modals = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_ACTIVE:
       return Object.assign({}, state, { modalActive: action.payload.modalActive });
-    case SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE:
-      return modalCreateBlueprint(state, action);
     case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
       return modalCreateBlueprint(state, action);
     case SET_MODAL_DELETE_BLUEPRINT_NAME:

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -6,7 +6,6 @@ import {
   SET_MODAL_DELETE_BLUEPRINT_NAME,
   SET_MODAL_DELETE_BLUEPRINT_ID,
   SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
-  SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT,
   SET_MODAL_DELETE_IMAGE_VISIBLE,
   SET_MODAL_DELETE_IMAGE_STATE,
   SET_MODAL_STOP_BUILD_VISIBLE,
@@ -17,17 +16,6 @@ import {
   SET_MODAL_MANAGE_SOURCES_CONTENTS,
   MODAL_MANAGE_SOURCES_FAILURE
 } from "../actions/modals";
-
-const modalCreateBlueprint = (state = [], action) => {
-  switch (action.type) {
-    case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
-      return Object.assign({}, state, {
-        createBlueprint: Object.assign({}, state.createBlueprint, { blueprint: action.payload.blueprint })
-      });
-    default:
-      return state;
-  }
-};
 
 const modalStopBuild = (state = [], action) => {
   switch (action.type) {
@@ -144,8 +132,6 @@ const modals = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_ACTIVE:
       return Object.assign({}, state, { modalActive: action.payload.modalActive });
-    case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
-      return modalCreateBlueprint(state, action);
     case SET_MODAL_DELETE_BLUEPRINT_NAME:
       return modalDeleteBlueprint(state, action);
     case SET_MODAL_DELETE_BLUEPRINT_ID:

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -7,7 +7,6 @@ import {
   SET_MODAL_DELETE_BLUEPRINT_ID,
   SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
   SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE,
-  SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS,
   SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT,
   SET_MODAL_DELETE_IMAGE_VISIBLE,
   SET_MODAL_DELETE_IMAGE_STATE,
@@ -25,10 +24,6 @@ const modalCreateBlueprint = (state = [], action) => {
     case SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE:
       return Object.assign({}, state, {
         createBlueprint: Object.assign({}, state.createBlueprint, { errorInline: action.payload.errorInline })
-      });
-    case SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS:
-      return Object.assign({}, state, {
-        checkErrors: Object.assign({}, state.createBlueprint, { errorInline: action.payload.checkErrors })
       });
     case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
       return Object.assign({}, state, {
@@ -155,8 +150,6 @@ const modals = (state = [], action) => {
     case SET_MODAL_ACTIVE:
       return Object.assign({}, state, { modalActive: action.payload.modalActive });
     case SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE:
-      return modalCreateBlueprint(state, action);
-    case SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS:
       return modalCreateBlueprint(state, action);
     case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
       return modalCreateBlueprint(state, action);

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -11,13 +11,10 @@ import {
   SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE,
   SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS,
   SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT,
-  SET_MODAL_CREATE_IMAGE_VISIBLE,
-  SET_MODAL_CREATE_IMAGE_HIDDEN,
   SET_MODAL_DELETE_IMAGE_VISIBLE,
   SET_MODAL_DELETE_IMAGE_STATE,
   SET_MODAL_STOP_BUILD_VISIBLE,
   SET_MODAL_STOP_BUILD_STATE,
-  FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS,
   SET_MODAL_CREATE_USER_VISIBLE,
   SET_MODAL_CREATE_USER_DATA,
   SET_MODAL_MANAGE_SOURCES_VISIBLE,
@@ -50,36 +47,6 @@ const modalCreateBlueprint = (state = [], action) => {
     case SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT:
       return Object.assign({}, state, {
         createBlueprint: Object.assign({}, state.createBlueprint, { blueprint: action.payload.blueprint })
-      });
-    default:
-      return state;
-  }
-};
-
-const modalCreateImage = (state = [], action) => {
-  switch (action.type) {
-    case FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS:
-      return Object.assign({}, state, {
-        createImage: Object.assign({}, state.createImage, { imageTypes: action.payload.imageTypes })
-      });
-    case SET_MODAL_CREATE_IMAGE_VISIBLE:
-      return Object.assign({}, state, {
-        createImage: Object.assign({}, state.createImage, {
-          visible: true,
-          blueprint: action.payload.blueprint,
-          warningEmpty: action.payload.blueprint.packages.length === 0 && action.payload.blueprint.modules.length === 0,
-          warningUnsaved:
-            action.payload.blueprint.changed === true || action.payload.blueprint.localPendingChanges.length > 0
-        })
-      });
-    case SET_MODAL_CREATE_IMAGE_HIDDEN:
-      return Object.assign({}, state, {
-        createImage: Object.assign({}, state.createImage, {
-          visible: false,
-          name: "",
-          warningEmpty: undefined,
-          warningUnsaved: undefined
-        })
       });
     default:
       return state;
@@ -217,12 +184,6 @@ const modals = (state = [], action) => {
       return modalDeleteBlueprint(state, action);
     case SET_MODAL_DELETE_BLUEPRINT_VISIBLE:
       return modalDeleteBlueprint(state, action);
-    case FETCHING_MODAL_CREATE_COMPOSTION_TYPES_SUCCESS:
-      return modalCreateImage(state, action);
-    case SET_MODAL_CREATE_IMAGE_VISIBLE:
-      return modalCreateImage(state, action);
-    case SET_MODAL_CREATE_IMAGE_HIDDEN:
-      return modalCreateImage(state, action);
     case SET_MODAL_STOP_BUILD_STATE:
       return modalStopBuild(state, action);
     case SET_MODAL_STOP_BUILD_VISIBLE:

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -6,8 +6,6 @@ import {
   SET_MODAL_DELETE_BLUEPRINT_NAME,
   SET_MODAL_DELETE_BLUEPRINT_ID,
   SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
-  SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE,
-  SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE,
   SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE,
   SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS,
   SET_MODAL_CREATE_BLUEPRINT_BLUEPRINT,
@@ -24,18 +22,6 @@ import {
 
 const modalCreateBlueprint = (state = [], action) => {
   switch (action.type) {
-    case SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE:
-      return Object.assign({}, state, {
-        createBlueprint: Object.assign({}, state.createBlueprint, {
-          errorNameVisible: action.payload.errorNameVisible
-        })
-      });
-    case SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE:
-      return Object.assign({}, state, {
-        createBlueprint: Object.assign({}, state.createBlueprint, {
-          errorDuplicateVisible: action.payload.errorDuplicateVisible
-        })
-      });
     case SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE:
       return Object.assign({}, state, {
         createBlueprint: Object.assign({}, state.createBlueprint, { errorInline: action.payload.errorInline })
@@ -168,10 +154,6 @@ const modals = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_ACTIVE:
       return Object.assign({}, state, { modalActive: action.payload.modalActive });
-    case SET_MODAL_CREATE_BLUEPRINT_ERROR_NAME_VISIBLE:
-      return modalCreateBlueprint(state, action);
-    case SET_MODAL_CREATE_BLUEPRINT_ERROR_DUPLICATE_VISIBLE:
-      return modalCreateBlueprint(state, action);
     case SET_MODAL_CREATE_BLUEPRINT_ERROR_INLINE:
       return modalCreateBlueprint(state, action);
     case SET_MODAL_CREATE_BLUEPRINT_CHECK_ERRORS:

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -3,6 +3,7 @@ import { call, all, put, takeEvery } from "redux-saga/effects";
 import {
   startComposeApi,
   fetchImageStatusApi,
+  fetchComposeTypesApi,
   fetchComposeQueueApi,
   fetchComposeFinishedApi,
   fetchComposeFailedApi,
@@ -14,6 +15,7 @@ import {
   START_COMPOSE,
   fetchingComposeStatusSucceeded,
   FETCHING_COMPOSES,
+  fetchingComposeTypesSucceeded,
   fetchingComposeSucceeded,
   composesFailure,
   CANCELLING_COMPOSE,
@@ -111,7 +113,18 @@ function* fetchQueue() {
   }
 }
 
+function* fetchComposeTypes() {
+  try {
+    console.info("fetchComposeTypes");
+    const response = yield call(fetchComposeTypesApi);
+    yield put(fetchingComposeTypesSucceeded(response));
+  } catch (error) {
+    console.log("Error in loadImageTypesSaga");
+  }
+}
+
 export default function*() {
+  yield* fetchComposeTypes();
   yield takeEvery(START_COMPOSE, startCompose);
   yield takeEvery(FETCHING_COMPOSES, fetchComposes);
   yield takeEvery(DELETING_COMPOSE, deleteCompose);

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -115,7 +115,6 @@ function* fetchQueue() {
 
 function* fetchComposeTypes() {
   try {
-    console.info("fetchComposeTypes");
     const response = yield call(fetchComposeTypesApi);
     yield put(fetchingComposeTypesSucceeded(response));
   } catch (error) {

--- a/core/sagas/modals.js
+++ b/core/sagas/modals.js
@@ -1,8 +1,7 @@
 import { call, put, takeEvery } from "redux-saga/effects";
-import { fetchModalCreateImageTypesApi, fetchSourceInfoApi } from "../apiCalls";
+import { fetchSourceInfoApi } from "../apiCalls";
 
 import {
-  fetchingModalCreateImageTypesSuccess,
   FETCHING_MODAL_MANAGE_SOURCES_CONTENTS,
   setModalManageSourcesContents,
   modalManageSourcesFailure
@@ -18,16 +17,6 @@ function* fetchModalManageSourcesContents() {
   }
 }
 
-function* fetchModalCreateImageTypes() {
-  try {
-    const response = yield call(fetchModalCreateImageTypesApi);
-    yield put(fetchingModalCreateImageTypesSuccess(response));
-  } catch (error) {
-    console.log("Error in loadModalBlueprintSaga");
-  }
-}
-
 export default function*() {
   yield takeEvery(FETCHING_MODAL_MANAGE_SOURCES_CONTENTS, fetchModalManageSourcesContents);
-  yield* fetchModalCreateImageTypes();
 }

--- a/core/store.js
+++ b/core/store.js
@@ -37,6 +37,7 @@ const initialState = {
     errorState: null
   },
   composes: {
+    composeTypes: [],
     composeList: [],
     queue: [],
     queueFetched: false,
@@ -44,11 +45,6 @@ const initialState = {
     errorState: null
   },
   modals: {
-    createImage: {
-      blueprint: {},
-      imageTypes: [],
-      visible: false
-    },
     stopBuild: {
       composeId: "",
       blueprintName: "",

--- a/core/store.js
+++ b/core/store.js
@@ -66,8 +66,6 @@ const initialState = {
       visible: false
     },
     createBlueprint: {
-      showErrorName: false,
-      showErrorDuplicate: false,
       inlineError: false,
       checkErrors: true,
       blueprint: {

--- a/core/store.js
+++ b/core/store.js
@@ -66,7 +66,6 @@ const initialState = {
       visible: false
     },
     createBlueprint: {
-      inlineError: false,
       blueprint: {
         name: "",
         description: "",

--- a/core/store.js
+++ b/core/store.js
@@ -65,14 +65,6 @@ const initialState = {
       id: "",
       visible: false
     },
-    createBlueprint: {
-      blueprint: {
-        name: "",
-        description: "",
-        modules: [],
-        packages: []
-      }
-    },
     pendingChanges: {
       componentUpdates: {
         past: [],

--- a/core/store.js
+++ b/core/store.js
@@ -67,7 +67,6 @@ const initialState = {
     },
     createBlueprint: {
       inlineError: false,
-      checkErrors: true,
       blueprint: {
         name: "",
         description: "",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
       "jsx-a11y/no-onchange": "off",
       "jsx-a11y/label-has-for": "off",
       "redux-saga/no-unhandled-errors": 0,
-      "jsx-a11y/anchor-is-valid": "off"
+      "jsx-a11y/anchor-is-valid": "off",
+      "jsx-a11y/no-autofocus": "off"
     },
     "env": {
       "browser": true,

--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
       "jsx-a11y/no-onchange": "off",
       "jsx-a11y/label-has-for": "off",
       "redux-saga/no-unhandled-errors": 0,
-      "jsx-a11y/anchor-is-valid": "off"
+      "jsx-a11y/anchor-is-valid": "off",
+      "react/no-multi-comp": "off"
     },
     "env": {
       "browser": true,

--- a/package.json
+++ b/package.json
@@ -174,11 +174,11 @@
         }
       ],
       "react/destructuring-assignment": "off",
+      "react/no-multi-comp": "off",
       "jsx-a11y/no-onchange": "off",
       "jsx-a11y/label-has-for": "off",
       "redux-saga/no-unhandled-errors": 0,
-      "jsx-a11y/anchor-is-valid": "off",
-      "react/no-multi-comp": "off"
+      "jsx-a11y/anchor-is-valid": "off"
     },
     "env": {
       "browser": true,

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -35,13 +35,11 @@ import {
   setSelectedInputParent,
   fetchingDepDetails
 } from "../../core/actions/inputs";
-import { fetchingComposes, startCompose } from "../../core/actions/composes";
+import { fetchingComposes } from "../../core/actions/composes";
 import {
   setModalUserAccountVisible,
   setModalUserAccountData,
   setModalExportBlueprintVisible,
-  setModalCreateImageVisible,
-  setModalCreateImageHidden,
   setModalStopBuildVisible,
   setModalStopBuildState,
   setModalDeleteImageVisible,
@@ -125,7 +123,6 @@ const messages = defineMessages({
 class BlueprintPage extends React.Component {
   constructor() {
     super();
-    this.setNotifications = this.setNotifications.bind(this);
     this.handleTabChanged = this.handleTabChanged.bind(this);
     this.handleComponentDetails = this.handleComponentDetails.bind(this);
     this.handleComponentListItem = this.handleComponentListItem.bind(this);
@@ -134,8 +131,6 @@ class BlueprintPage extends React.Component {
     this.handleShowModalEditUser = this.handleShowModalEditUser.bind(this);
     this.handleHideModalExport = this.handleHideModalExport.bind(this);
     this.handleShowModalExport = this.handleShowModalExport.bind(this);
-    this.handleHideModalCreateImage = this.handleHideModalCreateImage.bind(this);
-    this.handleShowModalCreateImage = this.handleShowModalCreateImage.bind(this);
     this.handleHideModalStop = this.handleHideModalStop.bind(this);
     this.handleHideModalDeleteImage = this.handleHideModalDeleteImage.bind(this);
     this.handleEditDescription = this.handleEditDescription.bind(this);
@@ -143,7 +138,6 @@ class BlueprintPage extends React.Component {
     this.handleEditHostnameValue = this.handleEditHostnameValue.bind(this);
     this.handlePostUser = this.handlePostUser.bind(this);
     this.handleDeleteUser = this.handleDeleteUser.bind(this);
-    this.handleStartCompose = this.handleStartCompose.bind(this);
     this.downloadUrl = this.downloadUrl.bind(this);
   }
 
@@ -165,10 +159,6 @@ class BlueprintPage extends React.Component {
 
   componentWillUnmount() {
     this.props.clearSelectedInput();
-  }
-
-  setNotifications() {
-    this.layout.setNotifications();
   }
 
   handleTabChanged(key) {
@@ -281,16 +271,6 @@ class BlueprintPage extends React.Component {
     e.stopPropagation();
   }
 
-  handleHideModalCreateImage() {
-    this.props.setModalCreateImageHidden();
-  }
-
-  handleShowModalCreateImage(e, blueprint) {
-    this.props.setModalCreateImageVisible(blueprint);
-    e.preventDefault();
-    e.stopPropagation();
-  }
-
   handleHideModalStop() {
     this.props.setModalStopBuildVisible(false);
     this.props.setModalStopBuildState("", "");
@@ -299,10 +279,6 @@ class BlueprintPage extends React.Component {
   handleHideModalDeleteImage() {
     this.props.setModalDeleteImageVisible(false);
     this.props.setModalDeleteImageState("", "");
-  }
-
-  handleStartCompose(blueprintName, composeType) {
-    this.props.startCompose(blueprintName, composeType);
   }
 
   downloadUrl(compose) {
@@ -329,7 +305,6 @@ class BlueprintPage extends React.Component {
       blueprint,
       exportModalVisible,
       userAccount,
-      createImage,
       stopBuild,
       deleteImage,
       selectedComponents,
@@ -340,7 +315,8 @@ class BlueprintPage extends React.Component {
       selectedInputDeps,
       setSelectedInput,
       setSelectedInputParent,
-      clearSelectedInput
+      clearSelectedInput,
+      imageTypes
     } = this.props;
     const { editDescriptionVisible, editHostnameVisible, editHostnameInvalid } = this.props.blueprintPage;
     const { formatMessage } = this.props.intl;
@@ -374,16 +350,7 @@ class BlueprintPage extends React.Component {
                 </Link>
               </li>
               <li>
-                <button
-                  className="btn btn-default"
-                  id="cmpsr-btn-crt-image"
-                  data-toggle="modal"
-                  data-target="#cmpsr-modal-crt-image"
-                  type="button"
-                  onClick={e => this.handleShowModalCreateImage(e, blueprint)}
-                >
-                  <FormattedMessage defaultMessage="Create Image" />
-                </button>
+                <CreateImage blueprint={blueprint} imageTypes={imageTypes} layout={this.layout} />
               </li>
               <li>
                 <div className="dropdown dropdown-kebab-pf">
@@ -602,16 +569,7 @@ class BlueprintPage extends React.Component {
                   title={formatMessage(messages.noImagesTitle)}
                   message={formatMessage(messages.noImagesMessage)}
                 >
-                  <button
-                    className="btn btn-default"
-                    id="cmpsr-btn-crt-image"
-                    data-toggle="modal"
-                    data-target="#cmpsr-modal-crt-image"
-                    type="button"
-                    onClick={e => this.handleShowModalCreateImage(e, blueprint)}
-                  >
-                    <FormattedMessage defaultMessage="Create Image" />
-                  </button>
+                  <CreateImage blueprint={blueprint} imageTypes={imageTypes} layout={this.layout} />
                 </EmptyState>
               )) || (
                 <ListView className="cmpsr-images" stacked>
@@ -629,17 +587,6 @@ class BlueprintPage extends React.Component {
             </div>
           </Tab>
         </Tabs>
-        {createImage.visible ? (
-          <CreateImage
-            blueprint={blueprint}
-            imageTypes={createImage.imageTypes}
-            setNotifications={this.setNotifications}
-            handleStartCompose={this.handleStartCompose}
-            handleHideModal={this.handleHideModalCreateImage}
-            warningEmpty={createImage.warningEmpty}
-            warningUnsaved={createImage.warningUnsaved}
-          />
-        ) : null}
         {userAccount.visible ? <UserAccount handlePostUser={this.handlePostUser} users={users} /> : null}
         {exportModalVisible ? (
           <ExportBlueprint
@@ -735,7 +682,6 @@ BlueprintPage.propTypes = {
   }),
   createImage: PropTypes.shape({
     blueprint: PropTypes.object,
-    imageTypes: PropTypes.arrayOf(PropTypes.object),
     visible: PropTypes.bool
   }),
   userAccount: PropTypes.shape({
@@ -761,13 +707,10 @@ BlueprintPage.propTypes = {
   dependencies: PropTypes.arrayOf(PropTypes.object),
   componentsSortKey: PropTypes.string,
   componentsSortValue: PropTypes.string,
-  setModalCreateImageVisible: PropTypes.func,
-  setModalCreateImageHidden: PropTypes.func,
   setModalStopBuildVisible: PropTypes.func,
   setModalStopBuildState: PropTypes.func,
   setModalDeleteImageVisible: PropTypes.func,
   setModalDeleteImageState: PropTypes.func,
-  startCompose: PropTypes.func,
   blueprintContentsError: PropTypes.shape({
     message: PropTypes.string,
     options: PropTypes.object,
@@ -775,7 +718,8 @@ BlueprintPage.propTypes = {
     url: PropTypes.string
   }),
   blueprintContentsFetching: PropTypes.bool,
-  intl: intlShape.isRequired
+  intl: intlShape.isRequired,
+  imageTypes: PropTypes.arrayOf(PropTypes.object)
 };
 
 BlueprintPage.defaultProps = {
@@ -818,15 +762,13 @@ BlueprintPage.defaultProps = {
   clearSelectedInput: function() {},
   setSelectedInputParent: function() {},
   fetchingDepDetails: function() {},
-  setModalCreateImageVisible: function() {},
-  setModalCreateImageHidden: function() {},
   setModalStopBuildVisible: function() {},
   setModalStopBuildState: function() {},
   setModalDeleteImageVisible: function() {},
   setModalDeleteImageState: function() {},
-  startCompose: function() {},
   blueprintContentsError: {},
-  blueprintContentsFetching: false
+  blueprintContentsFetching: false,
+  imageTypes: []
 };
 
 const makeMapStateToProps = () => {
@@ -855,6 +797,7 @@ const makeMapStateToProps = () => {
         exportModalVisible: state.modals.exportBlueprint.visible,
         createImage: state.modals.createImage,
         userAccount: state.modals.userAccount,
+        imageTypes: state.composes.composeTypes,
         stopBuild: state.modals.stopBuild,
         deleteImage: state.modals.deleteImage,
         componentsSortKey: state.sort.components.key,
@@ -875,6 +818,7 @@ const makeMapStateToProps = () => {
       exportModalVisible: state.modals.exportBlueprint.visible,
       createImage: state.modals.createImage,
       userAccount: state.modals.userAccount,
+      imageTypes: state.composes.composeTypes,
       stopBuild: state.modals.stopBuild,
       deleteImage: state.modals.deleteImage,
       componentsSortKey: state.sort.components.key,
@@ -935,12 +879,6 @@ const mapDispatchToProps = dispatch => ({
   setModalUserAccountData: data => {
     dispatch(setModalUserAccountData(data));
   },
-  setModalCreateImageVisible: modalVisible => {
-    dispatch(setModalCreateImageVisible(modalVisible));
-  },
-  setModalCreateImageHidden: () => {
-    dispatch(setModalCreateImageHidden());
-  },
   setModalStopBuildState: (composeId, blueprintName) => {
     dispatch(setModalStopBuildState(composeId, blueprintName));
   },
@@ -979,9 +917,6 @@ const mapDispatchToProps = dispatch => ({
   },
   fetchingDepDetails: (component, blueprintId) => {
     dispatch(fetchingDepDetails(component, blueprintId));
-  },
-  startCompose: (blueprintName, composeType) => {
-    dispatch(startCompose(blueprintName, composeType));
   }
 });
 

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -162,6 +162,7 @@ class BlueprintsPage extends React.Component {
     return (
       <Layout className="container-fluid" ref={c => (this.layout = c)}>
         <BlueprintsToolbar
+          blueprintNames={blueprints.map(blueprint => blueprint.present.id)}
           emptyState={blueprints.length === 0 && blueprintFilters.filterValues.length === 0}
           errorState={blueprintsError !== null}
           filters={blueprintFilters}
@@ -189,14 +190,7 @@ class BlueprintsPage extends React.Component {
             )) ||
               ((blueprintFilters.filterValues.length === 0 && (
                 <EmptyState title={formatMessage(messages.emptyTitle)} message={formatMessage(messages.emptyMessage)}>
-                  <button
-                    className="btn btn-primary btn-lg"
-                    type="button"
-                    data-toggle="modal"
-                    data-target="#cmpsr-modal-crt-blueprint"
-                  >
-                    <FormattedMessage defaultMessage="Create Blueprint" />
-                  </button>
+                  <CreateBlueprint blueprintNames={blueprints.map(blueprint => blueprint.present.id)} />
                 </EmptyState>
               )) || (
                 <EmptyState
@@ -208,7 +202,6 @@ class BlueprintsPage extends React.Component {
                   </button>
                 </EmptyState>
               ))))}
-        <CreateBlueprint blueprintNames={blueprints.map(blueprint => blueprint.present.id)} />
         {exportBlueprint !== undefined && exportBlueprint.visible ? (
           <ExportBlueprint
             blueprint={exportBlueprint.name}

--- a/test/end-to-end/pages/createBlueprint.page.js
+++ b/test/end-to-end/pages/createBlueprint.page.js
@@ -1,13 +1,12 @@
 // Create Blueprint Page
 class CreateBlueprintPage {
   constructor() {
-    this.containerSelector = '[id="cmpsr-modal-crt-blueprint"]';
+    this.containerSelector = '[role="dialog"] [id="cmpsr-modal-crt-blueprint"]';
   }
 
   loading() {
-    // sometimes the style attribute is style="display: block; padding-right: 12px;"
     browser.waitUntil(
-      () => browser.getAttribute(this.containerSelector, "style").includes("display: block;"),
+      () => browser.isExisting(this.containerSelector),
       timeout,
       "Cannot pop up Create Blueprint dialog"
     );
@@ -34,7 +33,7 @@ class CreateBlueprintPage {
   }
 
   get createButton() {
-    const selector = "span=Create";
+    const selector = '[id="create-blueprint-modal-create-button"]';
     browser.waitUntil(
       () => browser.isVisible(selector),
       timeout,

--- a/test/end-to-end/specs/createBlueprint.test.js
+++ b/test/end-to-end/specs/createBlueprint.test.js
@@ -18,11 +18,11 @@ describe("Create Blueprints Page", function() {
   });
 
   afterEach(function() {
-    const isOpen = browser.getAttribute(createBlueprintPage.containerSelector, "style").includes("display: block;");
+    const isOpen = browser.isExisting(createBlueprintPage.containerSelector);
     if (isOpen) {
       createBlueprintPage.cancelButton.click();
       browser.waitUntil(
-        () => browser.getAttribute(createBlueprintPage.containerSelector, "style").includes("display: none;"),
+        () => !browser.isExisting(createBlueprintPage.containerSelector),
         timeout,
         "Cannot close Create Blueprint dialog"
       );
@@ -36,11 +36,9 @@ describe("Create Blueprints Page", function() {
     expect(createBlueprintPage.helpBlock.getText()).to.equal("A blueprint name is required.");
   });
 
-  it("Alert message should look good - clicking create button", function() {
-    addContext(this, "create blueprint without name (clicking create button)");
-    createBlueprintPage.nameBox.click();
-    createBlueprintPage.createButton.click();
-    expect(createBlueprintPage.alert.getText()).to.equal("Required information is missing.");
+  it("Create button should be disabled when create blueprint dialog does not have name", function() {
+    addContext(this, "cannot create blueprint without name");
+    expect(createBlueprintPage.createButton.getAttribute("disabled")).to.equal("true");
   });
 
   it("Duplicated blueprint name help message should be in place", function() {
@@ -67,10 +65,10 @@ describe("Create Blueprints Page", function() {
   it("should close by clicking X button", function() {
     createBlueprintPage.clickXButton();
     browser.waitUntil(
-      () => browser.getAttribute(createBlueprintPage.containerSelector, "style").includes("display: none;"),
+      () => !browser.isExisting(createBlueprintPage.containerSelector),
       timeout,
       "Cannot close Create Blueprint dialog"
     );
-    expect(browser.getAttribute(createBlueprintPage.containerSelector, "style").includes("display: none;")).to.be.true;
+    expect(!browser.isExisting(createBlueprintPage.containerSelector));
   });
 });


### PR DESCRIPTION
This commit introduces the following changes:
* The dialog uses now Modal component from patternfly-react
* All properties that can be derived from others were removed from props
* The Button with the Modal for Create image belong now to the same
component. This removes the need for handlers getting passed all
around
* Stop using jquery for handling the modal state
* Remove from global state all properties that are Modal state specific
* The list of images types was moved out from the modals object in the
global state, since it's not really related to the that