### PR TITLE
WIP: Refactor DeleteBlueprint modal dialog to use Modal from PF react

### DIFF
--- a/components/ListView/BlueprintListView.js
+++ b/components/ListView/BlueprintListView.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import Link from "../Link/Link";
 import CreateImage from "../Modal/CreateImage";
+import DeleteBlueprint from "../Modal/DeleteBlueprint";
 
 class BlueprintListView extends React.PureComponent {
   constructor() {
@@ -46,9 +47,7 @@ class BlueprintListView extends React.PureComponent {
                     </li>
                   )}
                   <li>
-                    <a href="#" onClick={e => this.props.handleShowModalDelete(e, blueprint)}>
-                      <FormattedMessage defaultMessage="Delete" />
-                    </a>
+                    <DeleteBlueprint blueprint={blueprint} />
                   </li>
                 </ul>
               </div>
@@ -72,7 +71,6 @@ class BlueprintListView extends React.PureComponent {
 }
 
 BlueprintListView.propTypes = {
-  handleShowModalDelete: PropTypes.func,
   blueprints: PropTypes.arrayOf(PropTypes.object),
   handleShowModalExport: PropTypes.func,
   imageTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -82,7 +80,6 @@ BlueprintListView.propTypes = {
 };
 
 BlueprintListView.defaultProps = {
-  handleShowModalDelete: function() {},
   blueprints: [],
   handleShowModalExport: function() {},
   layout: {}

--- a/components/Modal/DeleteBlueprint.js
+++ b/components/Modal/DeleteBlueprint.js
@@ -1,83 +1,101 @@
-/* global $ */
-
 import React from "react";
-import { FormattedMessage } from "react-intl";
+import { Modal } from "patternfly-react";
+import { connect } from "react-redux";
+import { FormattedMessage, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
+import { deletingBlueprint } from "../../core/actions/blueprints";
+
 class DeleteBlueprint extends React.Component {
-  componentDidMount() {
-    $(this.modal).modal("show");
-    $(this.modal).on("hidden.bs.modal", this.props.handleHideModal);
+  constructor(props) {
+    super(props);
+    this.state = {
+      showModal: false
+    };
+    this.open = this.open.bind(this);
+    this.close = this.close.bind(this);
+  }
+
+  open() {
+    this.setState({ showModal: true });
+  }
+
+  close() {
+    this.setState({ showModal: false });
+  }
+
+  handleDelete(event, blueprint) {
+    this.props.deletingBlueprint(blueprint);
+    this.close();
   }
 
   render() {
     return (
-      <div
-        className="modal fade"
-        id="cmpsr-modal-delete"
-        ref={c => {
-          this.modal = c;
-        }}
-        tabIndex="-1"
-        role="dialog"
-        aria-labelledby="myModalLabel"
-        aria-hidden="true"
-      >
-        <div className="modal-dialog">
-          <div className="modal-content">
-            <div className="modal-header">
-              <button type="button" className="close" data-dismiss="modal">
-                <span className="pficon pficon-close" />
-              </button>
-              <h4 className="modal-title" id="myModalLabel">
-                <FormattedMessage defaultMessage="Delete Blueprint" />
-              </h4>
-            </div>
-            <div className="modal-body">
-              <p className="lead">
-                <FormattedMessage
-                  defaultMessage="Are you sure you want to delete the blueprint {name}?"
-                  values={{
-                    name: <strong>{this.props.blueprint.name}</strong>
-                  }}
-                />
-              </p>
-              <FormattedMessage defaultMessage="This action cannot be undone." tagName="p" />
-            </div>
-            <div className="modal-footer">
-              <button type="button" className="btn btn-default" data-dismiss="modal">
-                <FormattedMessage defaultMessage="Cancel" />
-              </button>
-              <button
-                type="button"
-                className="btn btn-danger"
-                data-dismiss="modal"
-                onClick={e => this.props.handleDelete(e, this.props.blueprint.id)}
-              >
-                <FormattedMessage defaultMessage="Delete" />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <React.Fragment>
+        <a href="#" onClick={this.open}>
+          <FormattedMessage defaultMessage="Delete" />
+        </a>
+        <Modal show={this.state.showModal} onHide={this.close} id="cmpsr-modal-delete">
+          <Modal.Header>
+            <Modal.CloseButton onClick={this.close} />
+            <Modal.Title>
+              <FormattedMessage defaultMessage="Delete Blueprint" />
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <p className="lead">
+              <FormattedMessage
+                defaultMessage="Are you sure you want to delete the blueprint {name}?"
+                values={{
+                  name: <strong>{this.props.blueprint.name}</strong>
+                }}
+              />
+            </p>
+            <FormattedMessage defaultMessage="This action cannot be undone." tagName="p" />
+          </Modal.Body>
+          <Modal.Footer>
+            <button type="button" className="btn btn-default" onClick={this.close}>
+              <FormattedMessage defaultMessage="Cancel" />
+            </button>
+            <button
+              type="button"
+              className="btn btn-danger"
+              data-dismiss="modal"
+              onClick={e => this.handleDelete(e, this.props.blueprint.id)}
+            >
+              <FormattedMessage defaultMessage="Delete" />
+            </button>
+          </Modal.Footer>
+        </Modal>
+      </React.Fragment>
     );
   }
 }
 
+const makeMapStateToProps = state => {
+  return state;
+};
+
 DeleteBlueprint.propTypes = {
+  deletingBlueprint: PropTypes.func,
   blueprint: PropTypes.shape({
     id: PropTypes.string,
-    name: PropTypes.string,
-    visible: PropTypes.bool
-  }),
-  handleHideModal: PropTypes.func,
-  handleDelete: PropTypes.func
+    name: PropTypes.string
+  })
 };
 
 DeleteBlueprint.defaultProps = {
-  blueprint: {},
-  handleHideModal: function() {},
-  handleDelete: function() {}
+  deletingBlueprint: function() {},
+  blueprint: {}
 };
 
-export default DeleteBlueprint;
+const mapDispatchToProps = dispatch => ({
+  deletingBlueprint: blueprint => {
+    dispatch(deletingBlueprint(blueprint));
+  }
+});
+
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(injectIntl(DeleteBlueprint));

--- a/core/actions/modals.js
+++ b/core/actions/modals.js
@@ -58,36 +58,6 @@ export function fetchingModalExportBlueprintContents(blueprintName) {
   };
 }
 
-export const SET_MODAL_DELETE_BLUEPRINT_NAME = "SET_MODAL_DELETE_BLUEPRINT_NAME";
-export function setModalDeleteBlueprintName(blueprintName) {
-  return {
-    type: SET_MODAL_DELETE_BLUEPRINT_NAME,
-    payload: {
-      blueprintName
-    }
-  };
-}
-
-export const SET_MODAL_DELETE_BLUEPRINT_ID = "SET_MODAL_DELETE_BLUEPRINT_ID";
-export function setModalDeleteBlueprintId(blueprintId) {
-  return {
-    type: SET_MODAL_DELETE_BLUEPRINT_ID,
-    payload: {
-      blueprintId
-    }
-  };
-}
-
-export const SET_MODAL_DELETE_BLUEPRINT_VISIBLE = "SET_MODAL_DELETE_BLUEPRINT_VISIBLE";
-export function setModalDeleteBlueprintVisible(visible) {
-  return {
-    type: SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
-    payload: {
-      visible
-    }
-  };
-}
-
 export const SET_MODAL_STOP_BUILD_STATE = "SET_MODAL_STOP_BUILD_STATE";
 export function setModalStopBuildState(composeId, blueprintName) {
   return {

--- a/core/reducers/modals.js
+++ b/core/reducers/modals.js
@@ -3,9 +3,6 @@ import {
   SET_MODAL_EXPORT_BLUEPRINT_NAME,
   SET_MODAL_EXPORT_BLUEPRINT_CONTENTS,
   SET_MODAL_EXPORT_BLUEPRINT_VISIBLE,
-  SET_MODAL_DELETE_BLUEPRINT_NAME,
-  SET_MODAL_DELETE_BLUEPRINT_ID,
-  SET_MODAL_DELETE_BLUEPRINT_VISIBLE,
   SET_MODAL_DELETE_IMAGE_VISIBLE,
   SET_MODAL_DELETE_IMAGE_STATE,
   SET_MODAL_STOP_BUILD_VISIBLE,
@@ -47,25 +44,6 @@ const modalDeleteImage = (state = [], action) => {
     case SET_MODAL_DELETE_IMAGE_VISIBLE:
       return Object.assign({}, state, {
         deleteImage: Object.assign({}, state.deleteImage, { visible: action.payload.visible })
-      });
-    default:
-      return state;
-  }
-};
-
-const modalDeleteBlueprint = (state = [], action) => {
-  switch (action.type) {
-    case SET_MODAL_DELETE_BLUEPRINT_NAME:
-      return Object.assign({}, state, {
-        deleteBlueprint: Object.assign({}, state.deleteBlueprint, { name: action.payload.blueprintName })
-      });
-    case SET_MODAL_DELETE_BLUEPRINT_ID:
-      return Object.assign({}, state, {
-        deleteBlueprint: Object.assign({}, state.deleteBlueprint, { id: action.payload.blueprintId })
-      });
-    case SET_MODAL_DELETE_BLUEPRINT_VISIBLE:
-      return Object.assign({}, state, {
-        deleteBlueprint: Object.assign({}, state.deleteBlueprint, { visible: action.payload.visible })
       });
     default:
       return state;
@@ -132,12 +110,6 @@ const modals = (state = [], action) => {
   switch (action.type) {
     case SET_MODAL_ACTIVE:
       return Object.assign({}, state, { modalActive: action.payload.modalActive });
-    case SET_MODAL_DELETE_BLUEPRINT_NAME:
-      return modalDeleteBlueprint(state, action);
-    case SET_MODAL_DELETE_BLUEPRINT_ID:
-      return modalDeleteBlueprint(state, action);
-    case SET_MODAL_DELETE_BLUEPRINT_VISIBLE:
-      return modalDeleteBlueprint(state, action);
     case SET_MODAL_STOP_BUILD_STATE:
       return modalStopBuild(state, action);
     case SET_MODAL_STOP_BUILD_VISIBLE:

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -6,20 +6,16 @@ import Layout from "../../components/Layout/Layout";
 import BlueprintListView from "../../components/ListView/BlueprintListView";
 import CreateBlueprint from "../../components/Modal/CreateBlueprint";
 import ExportBlueprint from "../../components/Modal/ExportBlueprint";
-import DeleteBlueprint from "../../components/Modal/DeleteBlueprint";
 import ManageSources from "../../components/Modal/ManageSources";
 import EmptyState from "../../components/EmptyState/EmptyState";
 import Loading from "../../components/Loading/Loading";
 import BlueprintsToolbar from "../../components/Toolbar/BlueprintsToolbar";
-import { deletingBlueprint, fetchingBlueprints } from "../../core/actions/blueprints";
+import { fetchingBlueprints } from "../../core/actions/blueprints";
 import {
   fetchingModalExportBlueprintContents,
   setModalExportBlueprintName,
   setModalExportBlueprintContents,
   setModalExportBlueprintVisible,
-  setModalDeleteBlueprintName,
-  setModalDeleteBlueprintId,
-  setModalDeleteBlueprintVisible,
   setModalManageSourcesVisible,
   fetchingModalManageSourcesContents
 } from "../../core/actions/modals";
@@ -59,9 +55,6 @@ class BlueprintsPage extends React.Component {
   constructor() {
     super();
     this.setNotifications = this.setNotifications.bind(this);
-    this.handleDelete = this.handleDelete.bind(this);
-    this.handleHideModalDelete = this.handleHideModalDelete.bind(this);
-    this.handleShowModalDelete = this.handleShowModalDelete.bind(this);
     this.handleHideModalExport = this.handleHideModalExport.bind(this);
     this.handleShowModalExport = this.handleShowModalExport.bind(this);
     this.handleHideModalManageSources = this.handleHideModalManageSources.bind(this);
@@ -81,12 +74,6 @@ class BlueprintsPage extends React.Component {
 
   setNotifications() {
     this.layout.setNotifications();
-  }
-
-  handleDelete(event, blueprint) {
-    event.preventDefault();
-    event.stopPropagation();
-    this.props.deletingBlueprint(blueprint);
   }
 
   handleStartCompose(blueprintName, composeType) {
@@ -116,20 +103,6 @@ class BlueprintsPage extends React.Component {
     e.stopPropagation();
   }
 
-  handleHideModalDelete() {
-    this.props.setModalDeleteBlueprintVisible(false);
-    this.props.setModalDeleteBlueprintId("");
-    this.props.setModalDeleteBlueprintName("");
-  }
-
-  handleShowModalDelete(e, blueprint) {
-    this.props.setModalDeleteBlueprintId(blueprint.id);
-    this.props.setModalDeleteBlueprintName(blueprint.name);
-    this.props.setModalDeleteBlueprintVisible(true);
-    e.preventDefault();
-    e.stopPropagation();
-  }
-
   handleHideModalManageSources() {
     this.props.setModalManageSourcesVisible(false);
   }
@@ -145,7 +118,6 @@ class BlueprintsPage extends React.Component {
     const {
       blueprints,
       exportBlueprint,
-      deleteBlueprint,
       manageSources,
       blueprintSortKey,
       blueprintSortValue,
@@ -183,7 +155,6 @@ class BlueprintsPage extends React.Component {
                 blueprints={blueprints.map(blueprint => blueprint.present)}
                 setNotifications={this.setNotifications}
                 handleShowModalExport={this.handleShowModalExport}
-                handleShowModalDelete={this.handleShowModalDelete}
                 imageTypes={imageTypes}
                 layout={this.layout}
               />
@@ -209,13 +180,6 @@ class BlueprintsPage extends React.Component {
             handleHideModal={this.handleHideModalExport}
           />
         ) : null}
-        {deleteBlueprint !== undefined && deleteBlueprint.visible ? (
-          <DeleteBlueprint
-            blueprint={deleteBlueprint}
-            handleDelete={this.handleDelete}
-            handleHideModal={this.handleHideModalDelete}
-          />
-        ) : null}
         {manageSources !== undefined && manageSources.visible ? (
           <ManageSources handleHideModal={this.handleHideModalManageSources} sources={manageSources.sources} />
         ) : null}
@@ -225,10 +189,6 @@ class BlueprintsPage extends React.Component {
 }
 
 BlueprintsPage.propTypes = {
-  deletingBlueprint: PropTypes.func,
-  setModalDeleteBlueprintVisible: PropTypes.func,
-  setModalDeleteBlueprintName: PropTypes.func,
-  setModalDeleteBlueprintId: PropTypes.func,
   setModalExportBlueprintVisible: PropTypes.func,
   setModalExportBlueprintName: PropTypes.func,
   setModalExportBlueprintContents: PropTypes.func,
@@ -239,11 +199,6 @@ BlueprintsPage.propTypes = {
   blueprints: PropTypes.arrayOf(PropTypes.object),
   exportBlueprint: PropTypes.shape({
     contents: PropTypes.arrayOf(PropTypes.object),
-    name: PropTypes.string,
-    visible: PropTypes.bool
-  }),
-  deleteBlueprint: PropTypes.shape({
-    id: PropTypes.string,
     name: PropTypes.string,
     visible: PropTypes.bool
   }),
@@ -275,10 +230,6 @@ BlueprintsPage.propTypes = {
 };
 
 BlueprintsPage.defaultProps = {
-  deletingBlueprint: function() {},
-  setModalDeleteBlueprintVisible: function() {},
-  setModalDeleteBlueprintName: function() {},
-  setModalDeleteBlueprintId: function() {},
   setModalExportBlueprintVisible: function() {},
   setModalExportBlueprintName: function() {},
   setModalExportBlueprintContents: function() {},
@@ -288,7 +239,6 @@ BlueprintsPage.defaultProps = {
   fetchingBlueprints: function() {},
   blueprints: [],
   exportBlueprint: {},
-  deleteBlueprint: {},
   manageSources: {},
   blueprintSortKey: "",
   blueprintSortValue: "",
@@ -310,7 +260,6 @@ const makeMapStateToProps = () => {
     if (getSortedBlueprints(state) !== undefined) {
       return {
         exportBlueprint: state.modals.exportBlueprint,
-        deleteBlueprint: state.modals.deleteBlueprint,
         imageTypes: state.composes.composeTypes,
         manageSources: state.modals.manageSources,
         blueprints: getFilteredBlueprints(state, getSortedBlueprints(state)),
@@ -323,7 +272,6 @@ const makeMapStateToProps = () => {
     }
     return {
       exportBlueprint: state.modals.exportBlueprint,
-      deleteBlueprint: state.modals.deleteBlueprint,
       imageTypes: state.composes.composeTypes,
       manageSources: state.modals.manageSources,
       blueprints: state.blueprints.blueprintList,
@@ -354,23 +302,11 @@ const mapDispatchToProps = dispatch => ({
   setModalExportBlueprintVisible: modalVisible => {
     dispatch(setModalExportBlueprintVisible(modalVisible));
   },
-  setModalDeleteBlueprintName: modalBlueprintName => {
-    dispatch(setModalDeleteBlueprintName(modalBlueprintName));
-  },
-  setModalDeleteBlueprintId: modalBlueprintId => {
-    dispatch(setModalDeleteBlueprintId(modalBlueprintId));
-  },
-  setModalDeleteBlueprintVisible: modalVisible => {
-    dispatch(setModalDeleteBlueprintVisible(modalVisible));
-  },
   fetchingModalManageSourcesContents: () => {
     dispatch(fetchingModalManageSourcesContents());
   },
   setModalManageSourcesVisible: modalVisible => {
     dispatch(setModalManageSourcesVisible(modalVisible));
-  },
-  deletingBlueprint: blueprint => {
-    dispatch(deletingBlueprint(blueprint));
   },
   blueprintsSortSetKey: key => {
     dispatch(blueprintsSortSetKey(key));

--- a/test/end-to-end/pages/deleteBlueprint.page.js
+++ b/test/end-to-end/pages/deleteBlueprint.page.js
@@ -1,13 +1,12 @@
 // Delete Blueprint Page
 class DeleteBlueprintPage {
   constructor() {
-    this.containerSelector = '[id="cmpsr-modal-delete"]';
+    this.containerSelector = '[role="dialog"] [id="cmpsr-modal-delete"]';
   }
 
   loading() {
-    // sometimes the style attribute is style="display: block; padding-right: 12px;"
     browser.waitUntil(
-      () => browser.getAttribute(this.containerSelector, "style").includes("display: block;"),
+      () => browser.isExisting(this.containerSelector),
       timeout,
       "Cannot pop up Delete Blueprint dialog"
     );


### PR DESCRIPTION
The following changes where also introduced:
* The link that triggers the dialog was moved to the same component as
the modal
* All delete blueprint modal related fields where removed from the redux
store, and similarly all related saga actions
* Stop using jquery to show/hide the modal; instead use event handlers on
the buttons