### PR TITLE
po: Add cleanup commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,8 @@ bots:
 update-po:
 upload-pot: po-push
 download-po: po-pull
+clean-po:
+	rm po/*.po
 
 .PHONY: tag local-clean vm check devel-install
 


### PR DESCRIPTION
New version of po-refresh bot also needs `clean-po` command.
This command is used for dropping languages that do not have sufficient
translation coverage anymore - currently all languages that have at least
one translated word in welder-web are pulled. So non languages will drop
anyway, but if once introduced minimal translations rule then languages
could be dropped (but seems that zanata-js does not support min-translation)

See also: https://github.com/cockpit-project/cockpit/pull/11638