### PR TITLE
Update jquery dependence to fix CVE-2019-11358

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "3.4.1",
     "fastclick": "1.0.6",
     "history": "3.3.0",
-    "jquery": "3.3.1",
+    "jquery": "3.4.0",
     "patternfly": "3.59.1",
     "patternfly-react": "1.19.1",
     "prop-types": "15.7.2",


### PR DESCRIPTION
Fix [CVE-2019-11358](https://github.com/weldr/welder-web/network/alert/package.json/jquery/open).