### PR TITLE
Resolve issues with changes saved to the workspace

### DIFF
--- a/components/Modal/CreateImage.js
+++ b/components/Modal/CreateImage.js
@@ -134,7 +134,8 @@ class CreateImageModal extends React.Component {
     );
 
     const warningEmpty = this.props.blueprint.packages.length === 0 && this.props.blueprint.modules.length === 0;
-    const warningUnsaved = this.props.blueprint.changed === true || this.props.blueprint.localPendingChanges.length > 0;
+    const warningUnsaved =
+      this.props.blueprint.workspacePendingChanges.length > 0 || this.props.blueprint.localPendingChanges.length > 0;
     const warnings = (
       <React.Fragment>
         {warningEmpty && (

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -75,8 +75,8 @@ function* fetchBlueprintContents(action) {
     if (workspaceChanges.diff.length > 0) {
       workspacePendingChanges = workspaceChanges.diff.map(change => {
         return {
-          componentOld: change.old === null ? null : change.old.Package,
-          componentNew: change.new === null ? null : change.new.Package
+          componentOld: change.old === null ? null : change.old.Package ? change.old.Package : change.old.Module,
+          componentNew: change.new === null ? null : change.new.Package ? change.new.Package : change.new.Module
         };
       });
       pastComponents = generatePastComponents(workspaceChanges, blueprintData.blueprint.packages);
@@ -104,7 +104,9 @@ function* fetchBlueprintContents(action) {
 }
 
 function generatePastComponents(workspaceChanges, packages) {
-  const updatedPackages = workspaceChanges.diff.filter(change => change.old !== null).map(change => change.old.Package);
+  const updatedPackages = workspaceChanges.diff
+    .filter(change => change.old !== null)
+    .map(change => (change.old.Package ? change.old.Package : change.old.Module));
   const originalPackages = packages.filter(originalPackage => {
     const addedPackage = workspaceChanges.diff.find(
       change => change.old === null && change.new.Package.name === originalPackage.name


### PR DESCRIPTION
This PR addresses a couple of issues related to how changes that are saved to the workspace are handled. 

- The Create Image modal should display a warning if changes are saved to the workspace. 
  - Make changes to a blueprint, then click Create Image. The modal will display a warning about unsaved changes.
  - Dismiss the modal and reload the page. Then open the Create Image modal again. The warning no longer displays.
  - These updates will now display that warning message for changes from the workspace.
- The example blueprints have some packages defined as "Modules" which results in issues with how these are listed in the Pending Changes modal if they are removed or updated without immediately committing them (i.e. if they are retrieved from the workspace in a later session).
  - Make changes to an example blueprint that has some packages listed as "Module" in the toml file (e.g. remove one of these "modules").
  - Reload the page.
  - Click the Commit button to open the Pending Changes modal.
  - This will result in an error. These updates should fix that issue.