### PR TITLE
Fix "passwd in rhel 7 does not support sha512" issue

### DIFF
--- a/components/Modal/UserAccount.js
+++ b/components/Modal/UserAccount.js
@@ -182,7 +182,12 @@ class UserAccount extends React.Component {
   }
 
   encryptPassword(password) {
-    return cockpit.spawn(["openssl", "passwd", "-6", "-stdin"], { err: "message" }).input(password);
+    return cockpit
+      .script(
+        "$(which /usr/libexec/platform-python 2>/dev/null || which python3 2>/dev/null || which python) -c 'import sys, crypt; print(crypt.crypt(sys.stdin.readline().strip(), crypt.mksalt(crypt.METHOD_SHA512)))'",
+        { err: "message" }
+      )
+      .input(password);
   }
 
   render() {


### PR DESCRIPTION
Address issue [613](https://github.com/weldr/welder-web/issues/631)
Use python to generate sha512 hashed password in all platforms